### PR TITLE
few minor build issues

### DIFF
--- a/explicit_edge/_oasis
+++ b/explicit_edge/_oasis
@@ -1,5 +1,5 @@
 OASISFormat: 0.4
-OcamlVersion: >= 4.04.1
+OcamlVersion: >= 4.03.0
 Name:        cbat-explicit-edge
 Version:     0.0.1
 Synopsis:    A library and plugin for BAP to perform value-set analysis on

--- a/value_set/Makefile
+++ b/value_set/Makefile
@@ -7,7 +7,7 @@ build: setup.ml setup.data
 doc: setup.ml setup.data build
 	$(SETUP) -doc $(DOCFLAGS)
 
-test: setup.ml setup.data build
+test: setup-tests build
 	$(SETUP) -test $(TESTFLAGS)
 
 
@@ -31,6 +31,9 @@ clean: setup.ml
 distclean: setup.ml
 	$(SETUP) -distclean $(DISTCLEANFLAGS)
 
+setup-tests: setup.ml
+	$(SETUP) -configure --enable-tests $(CONFIGUREFLAGS)
+
 setup.data: setup.ml
 	$(SETUP) -configure $(CONFIGUREFLAGS)
 
@@ -40,7 +43,7 @@ configure: setup.ml
 setup.ml:
 	oasis setup
 
-.PHONY: build doc test all install uninstall reinstall clean distclean configure plugin
+.PHONY: build doc test all install uninstall reinstall clean distclean configure plugin setup-tests
 
 OCI=ocp-indent
 

--- a/value_set/_oasis
+++ b/value_set/_oasis
@@ -1,5 +1,5 @@
 OASISFormat: 0.4
-OcamlVersion: >= 4.04.1
+OcamlVersion: >= 4.03.0
 Name:        cbat-value-set
 Version:     0.0.1
 Synopsis:    A library and plugin for BAP to perform value-set analysis on
@@ -44,6 +44,7 @@ Library "cbat-plugin-value-set"
 
 Library test-suite
   Path:           unit-tests/
+  Build$:         flag(tests)
   BuildTools:     ocamlbuild
   BuildDepends:   bap (>= 1.5.0), core_kernel, cbat-value-set, oUnit (>= 2.0.0)
   Install:        false
@@ -55,6 +56,7 @@ Library test-suite
 
 Executable test
   Path:           unit-tests/
+  Build$:         flag(tests)
   BuildTools:     ocamlbuild
   MainIs:         test.ml
   BuildDepends:   bap (>= 1.5.0), core_kernel, cbat-value-set, test-suite
@@ -63,4 +65,5 @@ Executable test
 
 Test unit_tests
      TestTools: test
+     Run$: flag(tests)
      Command: $test -display true


### PR DESCRIPTION
Hey, what do you think about the next changes?
This PR:
1) makes a conditional building of the tests.
   The most visible advantage is that your library and plugin don't depend on `ounit` 
   anymore, only tests do. Building and running tests still possible by `make test`.
2) downgrades a compiler version - we would love to include
   your plugins directly to the installation of the main `bap` package, and we still support
   `4.03.0`.  Do you really need `4.04.1`?
   I can build and run tests with `4.03.0`