### PR TITLE
Print out lhs and rhs of an equality constraint

### DIFF
--- a/wp/lib/bap_wp/src/constraint.mli
+++ b/wp/lib/bap_wp/src/constraint.mli
@@ -54,6 +54,10 @@ val mk_goal : string -> z3_expr -> goal
 (** Creates a string representation of a goal. *)
 val goal_to_string : goal -> string
 
+(** Creates a string representation of a goal that has been refuted given the model.
+    This string shows the lhs and rhs of a goal that compares two values. *)
+val refuted_goal_to_string : goal -> Z3.Model.model -> string
+
 (** Obtains a goal's tagged name. *)
 val get_goal_name : goal -> string
 

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -787,6 +787,7 @@ let mk_smtlib2_post (env : Env.t) (smt_post : string) : Constr.t =
 
 let check (solver : Z3.Solver.solver) (ctx : Z3.context) (pre : Constr.t)
   : Z3.Solver.status =
+  info "Checking precondition with Z3.\n%!";
   let pre' = Constr.eval pre ctx in
   let is_correct = Bool.mk_implies ctx pre' (Bool.mk_false ctx) in
   Z3.Solver.check solver [is_correct]
@@ -804,7 +805,7 @@ let print_result (solver : Z3.Solver.solver) (status : Z3.Solver.status)
     Format.printf "\nModel:\n%s\n%!" (Z3.Model.to_string model);
     Format.printf "\nRefuted goals:\n%!";
     Seq.iter refuted_goals ~f:(fun g ->
-        Format.printf "%s\n%!" (Constr.goal_to_string g))
+        Format.printf "%s\n%!" (Constr.refuted_goal_to_string g model))
 
 let exclude (solver : Z3.Solver.solver) (ctx : Z3.context) ~var:(var : Constr.z3_expr)
     ~pre:(pre : Constr.t) : Z3.Solver.status =


### PR DESCRIPTION
Refuted goals are built as a string in the form:

```
Refuted goals:
EAX0 = EAX09:
        Concrete values: #x80000004 = #x7ffffffd
        Z3 Expression: (let ((a!1 (bvadd #xfffffffd
                  (concat ((_ extract 31 8) (bvadd #xfffffffc EAX09))
                          (bvadd #xfc ((_ extract 7 0) EAX09))))))
                (= EAX0 a!1))
```