### PR TITLE
Fortunac/output register comparison

### DIFF
--- a/wp/lib/bap_wp/src/environment.ml
+++ b/wp/lib/bap_wp/src/environment.ml
@@ -166,7 +166,9 @@ let loop_exit_pre (env : t) (node : Graphs.Ir.Node.t) (graph : Graphs.Ir.t)
         ) in
       match exit_node with
       | None -> None
-      | Some e -> get_precondition env e
+      | Some e ->
+        debug "Using precondition from node %s%!" (Tid.to_string e);
+        get_precondition env e
 
 let init_loop_unfold (num_unroll : int) : loop_handler =
   {

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -64,8 +64,9 @@ val lookup_sub : Bap.Std.Label.t -> Constr.t -> Env.t -> Constr.t * Env.t
 (** Get {e every} variable from a subroutine. *)
 val get_vars : Bap.Std.Sub.t -> Bap.Std.Var.Set.t
 
-(** For a subroutine, find the set of output variables. *)
-val get_output_vars : Bap.Std.Sub.t -> Bap.Std.Var.Set.t
+(** Find the set of BAP variables in a subroutine for equivalence checking
+    given the name of each variable. *)
+val get_output_vars : Bap.Std.Sub.t -> string list -> Bap.Std.Var.Set.t
 
 (** Create a Z3 expression that denotes a load in memory [mem] at address [addr]. *)
 val load_z3_mem

--- a/wp/lib/bap_wp/tests/unit/test_compare.ml
+++ b/wp/lib/bap_wp/tests/unit/test_compare.ml
@@ -425,32 +425,6 @@ let test_sub_pair_fun_4 (test_ctx : test_ctxt) : unit =
     compare_prop Z3.Solver.SATISFIABLE
 
 
-let test_sub_pair_mem_1 (test_ctx : test_ctxt) : unit =
-  let ctx = Env.mk_ctx () in
-  let var_gen = Env.mk_var_gen () in
-  let blk1 = Blk.create () in
-  let blk2 = Blk.create () in
-  let mem = Var.create "mem" (mem32_t `r32) in
-  let loc1 = Var.create "loc" reg32_t in
-  let bv1 = Word.of_int ~width:32 0xDEADBEEF in
-  let bv2 = Word.of_int ~width:32 0x0FA1AFE1 in
-  let store1 = Bil.(store ~mem:(var mem) ~addr:(var loc1) (int bv1) LittleEndian `r32) in
-  let store2 = Bil.(store ~mem:(var mem) ~addr:(var loc1) (int bv2) LittleEndian `r32) in
-  let blk1 = blk1 |> mk_def mem store1 in
-  let blk2 = blk2 |> mk_def mem store2 in
-  let sub1 = mk_sub ~name:"main_sub" [blk1] in
-  let sub2 = mk_sub ~name:"main_sub" [blk2] in
-  let env1 = Pre.mk_default_env ctx var_gen ~subs:(Seq.of_list [sub1]) in
-  let env2 = Pre.mk_default_env ctx var_gen ~subs:(Seq.of_list [sub2]) in
-  let input_vars = Var.Set.of_list [mem; loc1] in
-  let output_vars = Var.Set.singleton mem in
-  let compare_prop, _ = Comp.compare_subs_eq
-      ~input:input_vars ~output:output_vars
-      ~original:(sub1,env1) ~modified:(sub2,env2) in
-  assert_z3_compare test_ctx ctx (Sub.to_string sub1) (Sub.to_string sub2)
-    compare_prop Z3.Solver.SATISFIABLE
-
-
 let suite = [
   "z = x+y; and x = x+1; y = y-1; z = x+y;"  >:: test_block_pair_1;
   "z = x; and y = x; z = y;"                 >:: test_block_pair_2;
@@ -467,6 +441,4 @@ let suite = [
   "Fun called in modified sub"               >:: test_sub_pair_fun_2;
   "Branches with fun calls"                  >:: test_sub_pair_fun_3;
   "Fun called in branch"                     >:: test_sub_pair_fun_4;
-
-  "Different memory in two subroutines"      >:: test_sub_pair_mem_1;
 ]

--- a/wp/lib/bap_wp/tests/unit/test_precondition.ml
+++ b/wp/lib/bap_wp/tests/unit/test_precondition.ml
@@ -37,7 +37,7 @@ let assert_z3_result (test_ctx : test_ctxt) (z3_ctx : Z3.context) (body : string
     ~pp_diff:(fun ff (exp, real) ->
         Format.fprintf ff "\n\nPost:\n%a\n\nAnalyzing:\n%sPre:\n%a\n\n%!"
           Constr.pp_constr post body Constr.pp_constr pre;
-        print_z3_model ff solver exp real)
+        print_z3_model ff solver exp real z3_ctx pre)
     expected result
 
 

--- a/wp/lib/bap_wp/tests/unit/test_precondition.ml
+++ b/wp/lib/bap_wp/tests/unit/test_precondition.ml
@@ -1163,6 +1163,40 @@ let test_exclude_1 (test_ctx : test_ctxt) : unit =
         (not (Expr.equal v value)))
 
 
+let test_output_vars_1 (test_ctx : test_ctxt) : unit =
+  let x = Var.create "x" reg32_t in
+  let y = Var.create "y" reg32_t in
+  let z = Var.create "z" reg32_t in
+  let sub = Bil.(
+      [
+        x := i32 1;
+        y := i32 2;
+        z := i32 3;
+      ]
+    ) |> bil_to_sub
+  in
+  let vars = Pre.get_output_vars sub ["x"; "y"; "z"] in
+  assert_equal ~ctxt:test_ctx ~cmp:Var.Set.equal
+    ~printer:(fun v -> v |> Var.Set.to_list |> List.to_string ~f:Var.to_string)
+    (Var.Set.of_list [x; y; z]) vars
+
+
+let test_output_vars_2 (test_ctx : test_ctxt) : unit =
+  let x = Var.create "x" reg32_t in
+  let y = Var.create "y" reg32_t in
+  let sub = Bil.(
+      [
+        x := i32 1;
+        y := i32 2;
+      ]
+    ) |> bil_to_sub
+  in
+  let vars = Pre.get_output_vars sub ["x"; "y"; "z"] in
+  assert_equal ~ctxt:test_ctx ~cmp:Var.Set.equal
+    ~printer:(fun v -> v |> Var.Set.to_list |> List.to_string ~f:Var.to_string)
+    (Var.Set.of_list [x; y]) vars
+
+
 let suite = [
   "Empty Block" >:: test_empty_block;
   "Assign SSA block: y = x+1; Post: y == x+1" >:: test_assign_1;
@@ -1263,4 +1297,7 @@ let suite = [
   "Test jmp_spec_reach UNSAT" >:: test_jmp_spec_reach_2;
 
   "Test exclude" >:: test_exclude_1;
+
+  "Test get output variables by name" >:: test_output_vars_1;
+  "z not in subroutine" >:: test_output_vars_2;
 ]

--- a/wp/plugin/README.md
+++ b/wp/plugin/README.md
@@ -326,6 +326,9 @@ The various options are:
   this to be an experimental feature.
 - `--wp-num-unroll=num`. If present, replaces the default number of
   times to unroll each loop. The number of loop unrollings is 5 by default.
+- `--wp-output-vars=var_list`. List of output variables for equivalence checking
+  by `,` given the same input variables in the case of a comparative analysis.
+  Defaults to `RAX,EAX` which are the 64- and 32-bit output registers for x86.
 
 ## C checking API
 

--- a/wp/plugin/tests/test_wp.ml
+++ b/wp/plugin/tests/test_wp.ml
@@ -43,6 +43,7 @@ let test_compare_elf (elf_dir : string) (expected : string)
     ?func:(func = "main")
     ?check_calls:(check_calls = false)
     ?inline:(inline = false)
+    ?output_vars:(output_vars = "RAX,EAX")
     (test_ctx : test_ctxt)
   : unit =
   let target = Format.sprintf "%s/%s" bin_dir elf_dir in
@@ -55,6 +56,7 @@ let test_compare_elf (elf_dir : string) (expected : string)
       Format.sprintf "--wp-function=%s" func;
       Format.sprintf "--wp-check-calls=%b" check_calls;
       Format.sprintf "--wp-inline=%b" inline;
+      Format.sprintf "--wp-output-vars=%s" output_vars;
     ] in
   assert_command ~backtrace:true ~ctxt:test_ctx "make" ["-C"; target];
   assert_command ~foutput:(fun res -> check_result res expected test_ctx)
@@ -100,7 +102,7 @@ let suite = [
   "Diff Pointer Val"           >:: test_compare_elf "diff_pointer_val" "SAT!";
   "Switch Case Assignments"    >:: test_compare_elf "switch_case_assignments" "SAT!" ~func:"process_status";
   "Switch Cases"               >:: test_compare_elf "switch_cases" "SAT!" ~func:"process_message" ~check_calls:true;
-  "Remove Stack Protector"     >:: test_compare_elf "no_stack_protection" "SAT!";
+  "Remove Stack Protector"     >:: test_compare_elf "no_stack_protection" "SAT!" ~output_vars:"RSI,RAX";
   "Caller-saved registers"     >:: test_compare_elf "retrowrite_stub" "UNSAT!" ~inline:true;
   "Pop RSP in Summary"         >:: test_compare_elf "retrowrite_stub" "UNSAT!";
   "Simple WP"                  >:: test_single_elf "simple_wp" "main" "SAT!";


### PR DESCRIPTION
Allows the user to specify what registers to check for equivalence with:
`--wp-output-vars=RDI,RSI,RCX,...`