### PR TITLE
Fortunac/bap 2.0 upgrade

### DIFF
--- a/explicit_edge/README.md
+++ b/explicit_edge/README.md
@@ -10,7 +10,7 @@ Build
 
 Before installing `explicit_edge`, the following requirements must be met:
 
-* BAP 1.6+ must be available. Confirm with `bap --version`.
+* BAP 2.0.0-alpha+ must be available. Confirm with `bap --version`.
 * core 0.11+ must be available. Confirm with `ocamlfind query core`.
 * ppx\_deriving must be available. Confirm with `ocamlfind query ppx_deriving`
 * cbat\_value\_set must be available. Confirm with `ocamlfind query cbat_value_set`

--- a/value_set/README.md
+++ b/value_set/README.md
@@ -9,7 +9,7 @@ Build
 
 Before installing `value_set`, the following requirements must be met:
 
-* BAP 1.6+ must be available. Confirm with `bap --version`.
+* BAP 2.0.0-alpha+ must be available. Confirm with `bap --version`.
 * core 0.11+ must be available. Confirm with `ocamlfind query core`.
 * ppx\_deriving must be available. Confirm with `ocamlfind query ppx_deriving`
 * oUnit must be available to `findlib` under the name `oUnit`

--- a/value_set/lib/cbat_value_set.opam
+++ b/value_set/lib/cbat_value_set.opam
@@ -14,7 +14,7 @@ homepage: "https://github.com/draperlaboratory/cbat_tools"
 bug-reports: "https://github.com/draperlaboratory/cbat_tools"
 dev-repo: "git+https://github.com/draperlaboratory/cbat_tools"
 depends: [
-  "bap" {>= "1.6"}
+  "bap" {>= "master"}
   "core" {>= "0.11"}
   "ppx_deriving"
   "ppx_bin_prot"

--- a/value_set/lib/src/cbat_vsa.ml
+++ b/value_set/lib/src/cbat_vsa.ml
@@ -211,6 +211,7 @@ let val_top : typ -> val_t = function
     let k = {Mem.addr_width = addr_width;
              Mem.addressable_width = addressable_width} in
     `Mem (Mem.top k)
+  | Type.Unk -> failwith "Error in val_top: typ is not representable by Type.t"
 
 let val_bottom : typ -> val_t = function
   | Type.Imm i -> `Word (WordSet.bottom i)
@@ -221,6 +222,7 @@ let val_bottom : typ -> val_t = function
     let k = {Mem.addr_width = addr_width;
              Mem.addressable_width = addressable_width} in
     `Mem (Mem.bottom k)
+  | Type.Unk -> failwith "Error in val_bottom: typ is not representable by Type.t"
 
 (* Helper functions; define a denotation for expressions.
    Assumes that e has BIR type [Imm bitwidth]
@@ -240,6 +242,7 @@ let rec denote_exp (e : exp) (env : AI.t) : val_t or_type_error =
       let k = {Mem.addr_width = addr_width;
                Mem.addressable_width = addressable_width} in
       return_mem @@ AI.find_memory k env v
+    | Type.Unk -> failwith "Error in denote_exp: var type is not representable by Type.t"
     end
   | Bil.Int bv -> return_imm @@ WordSet.singleton bv
   | Bil.BinOp (op, e1, e2) ->

--- a/value_set/lib/src/cbat_word_ops.ml
+++ b/value_set/lib/src/cbat_word_ops.ml
@@ -55,19 +55,6 @@ let bounded_gcd (w1 : word) (w2 : word) : word =
   else if W.is_zero w2 then w1
   else W.gcd_exn w1 w2
 
-(* Calculates the least common multiple of two words
-   such that the result is not less than the inputs.
-   TODO: the above statement is not true if the result wraps around.
-       check whether this works (it should, but needs a reason) and update docs
-   Returns None if either input is 0.
-*)
-let bounded_lcm (w1 : word) (w2 : word) : word option =
-  let width = W.bitwidth w1 in
-  assert (width = W.bitwidth w2);
-  match W.lcm w1 w2 with
-  | Result.Ok w -> Some w
-  | Result.Error _ -> None
-
 (* Performs an unsigned division that rounds updwards instead of downwards. *)
 let cdiv a b : word = if W.is_zero (W.modulo a b)
     then W.div a b else W.succ (W.div a b)

--- a/value_set/lib/src/cbat_word_ops.mli
+++ b/value_set/lib/src/cbat_word_ops.mli
@@ -30,8 +30,6 @@ val is_one : word -> bool
 
 val bounded_gcd : word -> word -> word
 
-val bounded_lcm : word -> word -> word option
-
 val bounded_diophantine : word -> word -> word -> (word * word) option
 
 val factor_2s : word -> word * int
@@ -61,7 +59,7 @@ val max : word -> word -> word
 
     So one should always invoke this [dom_size] function with [w > i],
     in order to guarantee that the result can be represented by the
-    returned word. *)    
+    returned word. *)
 val dom_size : ?width : int -> int -> word
 
 val cap_at_width : width:int -> word -> word

--- a/value_set/lib/src/cbat_wordset_intf.ml
+++ b/value_set/lib/src/cbat_wordset_intf.ml
@@ -35,7 +35,7 @@ module type S = sig
 
   val min_elem_signed : t -> word option
   val max_elem_signed : t -> word option
-  
+
   val nearest_pred : word -> t ->  word option
   val nearest_succ : word -> t ->  word option
 

--- a/value_set/unit_tests/Makefile
+++ b/value_set/unit_tests/Makefile
@@ -3,9 +3,9 @@
 all: test
 
 test:
-	ocamlbuild -r -use-ocamlfind -pkgs 'bap, cbat_value_set,oUnit' -tag 'warn(A-48-44),debug,thread' test.byte
-	ocamlrun test.byte
+	ocamlbuild -r -use-ocamlfind -pkgs 'bap, cbat_value_set,oUnit' -tag 'warn(A-48-44),debug,thread' test.native
+	./test.native
 
 clean:
 	rm -rf _build
-	rm -f test.byte
+	rm -f test.native

--- a/value_set/unit_tests/clp_test.ml
+++ b/value_set/unit_tests/clp_test.ml
@@ -71,7 +71,7 @@ struct
       end
     end test_clps_64
 
-  let test_min_max_elem_signed ctxt =
+  let test_min_max_elem_signed _ =
 
     let make_clp w b s c =
       let b' = W.of_int b ~width:(w + 1) in
@@ -112,17 +112,17 @@ struct
               let max_e_int = W.to_int_exn max_e in
               let max_e_int_s = W.to_int_exn (W.signed max_e) in
 
-              let msg = 
-                Printf.sprintf 
-                "%s: Elem %d (%d) is less than the signed min elem %d (%d)" 
-                clp_str wd_int wd_int_s min_e_int min_e_int_s 
+              let msg =
+                Printf.sprintf
+                "%s: Elem %d (%d) is less than the signed min elem %d (%d)"
+                clp_str wd_int wd_int_s min_e_int min_e_int_s
                 in
               assert_bool msg (W.(<=) (W.signed min_e) (W.signed wd));
 
-              let msg = 
-                Printf.sprintf 
-                "%s: Elem %d (%d) is greater than the signed max elem %d (%d)" 
-                clp_str wd_int wd_int_s max_e_int max_e_int_s 
+              let msg =
+                Printf.sprintf
+                "%s: Elem %d (%d) is greater than the signed max elem %d (%d)"
+                clp_str wd_int wd_int_s max_e_int max_e_int_s
                 in
               assert_bool msg (W.(>=) (W.signed max_e) (W.signed wd))
 
@@ -707,7 +707,6 @@ struct
       let width = WordSet.bitwidth p1 in
       let p2 = create ~width w in
       let res = WordSet.concat p1 p2 in
-      (*assert (W.extract_exn ~hi:(width - 1)(WordSet.cardinality res) = (WordSet.cardinality p1)); *)
       let res_hi = WordSet.extract ~hi:(2*width - 1) ~lo:width res in
       assert_bool "extract hi of concat approximates the first argument"
         (WordSet.precedes p1 res_hi) in
@@ -819,12 +818,12 @@ struct
       ]
       in
 
-    let bottom_tests = 
+    let bottom_tests =
       List.map
-        (fun (t1, t2) -> "Test rshift bottom">::(test_bottoms t1 t2)) 
+        (fun (t1, t2) -> "Test rshift bottom">::(test_bottoms t1 t2))
         bottoms
       in
-      
+
     (* If both CLPs are singletons, [rshift] should return
        a singleton whose base is clp1.base >> clp2.base. *)
     let test_singletons clp1 clp2 _ =
@@ -832,7 +831,7 @@ struct
       let b2 = Option.value_exn (Clp.min_elem clp2) in
       let shifted_val = W.rshift b1 b2 in
       let width = Clp.bitwidth clp1 in
-      let expected_clp = 
+      let expected_clp =
         Clp.create ~width ~step:(W.zero width) ~cardn:(W.one width) shifted_val in
       let exp = Conv.of_clp expected_clp in
       let p1 = Conv.of_clp clp1 in
@@ -856,7 +855,7 @@ struct
 
     (* A right shift m >> n is equivalent to m / 2^n.
        So CLP1 >> CLP2 should be roughly equivalent to
-       CLP1 / {2^i : i in CLP2}. 
+       CLP1 / {2^i : i in CLP2}.
        But we can't divide by zero, so we need to
        replace 2^i with 1 if 2^i is a 0, since:
        if m = 0, n >> m is equivalent to n, and
@@ -871,14 +870,14 @@ struct
       let clp = make_clp width b s n in
       let p = Conv.of_clp clp in
 
-      let divby = 
+      let divby =
         Seq.map sq ~f:(fun i -> W.of_int ~width (1 lsl i))
         |> Seq.map ~f:(fun i -> if W.is_zero i then (W.one width) else i)
         |> Seq.to_list
 	|> WordSet.of_list ~width in
       let div_res = WordSet.div p divby in
 
-      let shiftby = 
+      let shiftby =
         Seq.map sq ~f:(W.of_int ~width)
         |> Seq.to_list
 	|> WordSet.of_list ~width in
@@ -934,9 +933,9 @@ struct
       ]
       in
 
-    let bottom_tests = 
+    let bottom_tests =
       List.map
-        (fun (t1, t2) -> "Test arshift bottom">::(test_bottoms t1 t2)) 
+        (fun (t1, t2) -> "Test arshift bottom">::(test_bottoms t1 t2))
         bottoms
       in
 
@@ -947,7 +946,7 @@ struct
       let b2 = Option.value_exn (Clp.min_elem clp2) in
       let shifted_val = W.arshift b1 b2 in
       let width = Clp.bitwidth clp1 in
-      let expected_clp = 
+      let expected_clp =
         Clp.create ~width ~step:(W.zero width) ~cardn:(W.one width) shifted_val in
       let exp = Conv.of_clp expected_clp in
       let p1 = Conv.of_clp clp1 in
@@ -973,11 +972,11 @@ struct
 
   (** The following function checks that [WordSet.arshift] handles
        other cases (i.e., non-bottom/non-singleton cases) correctly.
-      
+
       The strategy is to construct actual concrete CLPs (composed
       of integers) along with the abstract CLPs (composed of bitvectors).
       Then check that the two match up in the relevant ways:
-      
+
       - The bases should be the same.
       - The concrete cardinality should be >= the abstract cardinality.
       - The concrete CLP should be a subset of the abstract CLP.
@@ -1011,7 +1010,7 @@ struct
 	range
 	in
       List.rev bits
-      in	
+      in
 
     let word_to_string ?signed:(s=false) w =
       let bits_list = list_of_bits w in
@@ -1070,14 +1069,14 @@ struct
     let product l1 l2 =
       List.concat (List.map (fun e -> List.map (fun e' -> (e,e')) l2) l1)
       in
-  
+
     let arshift_ints clp1 clp2 =
       let prod = product clp1 clp2 in
-      let result = 
-        List.map 
-        (fun (a, b) -> 
-          let a' = W.of_int a ~width:64 in
-          let b' = W.of_int b ~width:64 in
+      let result =
+        List.map
+        (fun (a, b) ->
+          let a' = W.of_int a ~width:Sys.int_size in
+          let b' = W.of_int b ~width:Sys.int_size in
           let c' = W.arshift (W.signed a') b' in
           W.to_int_exn (W.signed c'))
         prod
@@ -1090,12 +1089,12 @@ struct
     let cardn_of_ints l = List.length l in
 
     let test_base_ints b1 b2 b_res end2 msg =
-      let zero = W.of_int 0 ~width:64 in
-      let b1' = W.of_int b1 ~width:64 in
-      let b2' = W.of_int b2 ~width:64 in
-      let end2' = W.of_int end2 ~width:64 in
-      let b' = 
-        if W.(>=) (W.signed b1') zero 
+      let zero = W.of_int 0 ~width:Sys.int_size in
+      let b1' = W.of_int b1 ~width:Sys.int_size in
+      let b2' = W.of_int b2 ~width:Sys.int_size in
+      let end2' = W.of_int end2 ~width:Sys.int_size in
+      let b' =
+        if W.(>=) (W.signed b1') zero
         then W.arshift (W.signed b1') end2'
         else W.arshift (W.signed b1') b2'
         in
@@ -1269,7 +1268,7 @@ struct
         (fun (clp1, clp2) -> "Test arshift">::(test_shift clp1 clp2))
         clps
       in
-	
+
     List.flatten [tests]
 
   (** The SWEET paper's algorithm for arithmetic shift is incorrect.
@@ -1278,8 +1277,8 @@ struct
       We have changed it to this:
       - [if 0 >= c1[n1 - 1]]
       The following function checks that this revised algorithm
-      does what we expect. 
-      To keep things simple, this function constructs small, concrete 
+      does what we expect.
+      To keep things simple, this function constructs small, concrete
       integer CLPs (no bitvectors), and then it confirms that the
       algorithm computes the correct base and cardinality. *)
   let test_arshift_math =
@@ -1291,7 +1290,7 @@ struct
         let new_acc = Printf.sprintf "%d %s" hd acc in
         ints_to_string ~acc:new_acc tl
       in
-	
+
     let clp_of_ints b s n =
       let l = Seq.range 0 n |> Seq.to_list in
       let result = List.map (fun i -> b + (s * i)) l in
@@ -1301,7 +1300,7 @@ struct
     let product l1 l2 =
       List.concat (List.map (fun e -> List.map (fun e' -> (e,e')) l2) l1)
       in
-  
+ 
     let arshift_ints clp1 clp2 =
       let prod = product clp1 clp2 in
       let result = List.map (fun (a, b) -> a asr b) prod in
@@ -1313,7 +1312,7 @@ struct
     let cardn_of_ints l = List.length l in
 
     let test_base b1 b2 b_res end2 msg =
-      let b = 
+      let b =
         if b1 >= 0 then b1 asr end2
         else b1 asr b2
         in
@@ -1335,7 +1334,7 @@ struct
       assert_bool msg' (n_res <= n)
       in
 
-    let test_shift (w1, b1, s1, n1) (w2, b2, s2, n2) _ =
+    let test_shift (_, b1, s1, n1) (_, b2, s2, n2) _ =
 
       let clp1 = clp_of_ints b1 s1 n1 in
       let clp2 = clp_of_ints b2 s2 n2 in
@@ -1354,16 +1353,16 @@ struct
 
       let s = 1 in
 
-      let msg = 
-        Printf.sprintf 
-          "CLP1: %s\nCLP2: %s\nResult: %s\nEnd 1: %d\nEnd 2: %d\nEnd Res: %d\nBase res: %d" 
+      let msg =
+        Printf.sprintf
+          "CLP1: %s\nCLP2: %s\nResult: %s\nEnd 1: %d\nEnd 2: %d\nEnd Res: %d\nBase res: %d"
           clp1_str clp2_str res_str end1 end2 end_res b_res
         in
 
       test_base b1 b2 b_res end2 msg;
       test_cardn s b2 b_res end1 end2 n_res msg
       in
-  
+
     let clps = [
       ((3, (-4), 2, 4), (3, 0, 1, 2));
       ((8, 5, 5, 20), (5, 2, 1, 7));
@@ -1376,7 +1375,7 @@ struct
         (fun (clp1, clp2) -> "Test arshift">::(test_shift clp1 clp2))
         clps
       in
-	
+
     List.flatten [tests]
 
   let all_tests = "WordSet tests">:::[

--- a/value_set/unit_tests/word_ops_test.ml
+++ b/value_set/unit_tests/word_ops_test.ml
@@ -69,12 +69,12 @@ let test_bounded_lcm_gcd _ =
   let two_exp_16_32 = W.lshift (W.one 32) (W.of_int 16 ~width:32) in
   let test_words w1 w2 =
     let gcd = bounded_gcd w1 w2 in
-    match bounded_lcm w1 w2 with
-    | None ->
+    let lcm = W.lcm_exn w1 w2 in
+    if W.is_zero lcm then begin
       if W.is_zero w1 then assert_equal gcd  w2
       else if W.is_zero w2 then assert_equal gcd w1
       else OUnit2.assert_failure "lcm returned None when a solution exists";
-    | Some lcm ->
+    end else begin
       let prod = W.mul w1 w2 in
       let rem = W.modulo prod lcm in
       let cp1 = W.div w1 gcd in
@@ -87,6 +87,7 @@ let test_bounded_lcm_gcd _ =
       let lcm_from_gcd2 = W.mul w2 cp1 in
       assert_equal lcm_from_gcd1 lcm;
       assert_equal lcm_from_gcd2 lcm;
+    end
   in
   List.iter (fun w -> List.iter (test_words w) testlist_64) testlist_64;
   List.iter (fun w -> List.iter (test_words w) testlist_32) testlist_32;
@@ -177,7 +178,7 @@ let test_cap_at_width =
 let test_dom_size =
 
   (* If [w > i], then [dom_size] should be 2^i, represented as
-     a [w]-bit word. For instance [dom_size 3 ~width:4] should 
+     a [w]-bit word. For instance [dom_size 3 ~width:4] should
      return a word that is 4-bits long, which represents the int 8,
      since you can have 8 elements with 3-bit words (2^3 = 8). *)
 
@@ -193,7 +194,7 @@ let test_dom_size =
 
   let dom_tests =
      List.map
-     begin fun (i, w) -> 
+     begin fun (i, w) ->
        (Printf.sprintf "dom_size %d ~width:%d = %d as %d-bit word" i w i w)>::(check_dom (i, w))
      end
      [(1, 2); (2, 3); (2, 32); (3, 4); (3, 8); (4, 5); (8, 32); (60, 61);]
@@ -213,7 +214,7 @@ let test_dom_size =
 
   let zero_tests =
     List.map
-    begin fun i -> 
+    begin fun i ->
       (Printf.sprintf "dom_size %d %d = 0" i i)>::(check_zero i)
     end
     [1; 2; 3; 4; 7; 8; 32; 64; 100; 12350; 16383;]

--- a/wp/lib/bap_wp/README.md
+++ b/wp/lib/bap_wp/README.md
@@ -9,7 +9,7 @@ A weakest-precondition analysis library, for BAP plugins/tools.
 
 Before installing `bap_wp`, the following requirements must be met:
 
-* BAP 1.6+ must be available. Confirm with `bap --version`.
+* BAP 2.0.0-alpha+ must be available. Confirm with `bap --version`.
 * z3 4.8.4+ must be available to `findlib` under the name `z3`
   (note the lowercase `z`). Confirm with `ocamlfind query z3`.
 * core 0.11+ must be available. Confirm with `ocamlfind query core`.

--- a/wp/lib/bap_wp/bap_wp.opam
+++ b/wp/lib/bap_wp/bap_wp.opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/draperlaboratory/CBAT-internal"
 bug-reports: "https://github.com/draperlaboratory/CBAT-internal"
 dev-repo: "git+https://github.com/draperlaboratory/CBAT-internal"
 depends: [
-  "bap" {>= "1.6"}
+  "bap" {>= "master"}
   "core" {>= "0.11"}
   "z3" {>= "4.8.4"}
   "ounit"

--- a/wp/lib/bap_wp/src/bil_to_bir.ml
+++ b/wp/lib/bap_wp/src/bil_to_bir.ml
@@ -87,7 +87,7 @@ let rec stmt_to_blks (stmt : Bil.Types.stmt)
          and [tid]s
       *)
       | Bil.Unknown (tid_s, _) ->
-        let call_tid = Tid.from_string_exn ("%" ^ tid_s) in
+        let call_tid = Tid.from_string_exn tid_s in
         Tid.set_name call_tid "__assert_fail";
         Blk.Builder.add_jmp tail_blk
           (Jmp.create (Call (Call.create ~target:(Label.direct call_tid) ())));

--- a/wp/lib/bap_wp/src/environment.ml
+++ b/wp/lib/bap_wp/src/environment.ml
@@ -79,6 +79,9 @@ let mk_z3_expr (ctx : Z3.context) ~name:(name : string) ~typ:(typ : Type.t) : Co
     let i_sort = Z3.BitVector.mk_sort ctx (Size.in_bits i_size) in
     let w_sort = Z3.BitVector.mk_sort ctx (Size.in_bits w_size) in
     Z3.Z3Array.mk_const_s ctx name i_sort w_sort
+  | Type.Unk ->
+    error "Unk type: Unable to make z3_expr %s.%!" name;
+    failwith "mk_z3_expr: type is not representable by Type.t"
 
 let add_precond (env : t) (tid : Tid.t) (p : Constr.t) : t =
   { env with precond_map = TidMap.set env.precond_map ~key:tid ~data:p }

--- a/wp/plugin/README.md
+++ b/wp/plugin/README.md
@@ -6,7 +6,7 @@ Depends on:
 
     - ocaml 4.05.0
     - core_kernel 0.11
-    - bap 1.6
+    - bap 2.0.0-alpha
     - ounit 2.0.8
     - z3 4.8.4
 

--- a/wp/plugin/save_project/save_project.ml
+++ b/wp/plugin/save_project/save_project.ml
@@ -17,24 +17,26 @@ include Self()
 
 
 let main nm proj : unit =
+  let prog = Project.program proj in
   let dest =
     match (nm, Project.get proj filename) with
-    | ("",None) -> printf "Please specify a destination filename with --save-project-filename.\n";
-                   exit 1;
-    | ("",Some bnm) -> String.concat [bnm;".bpj"]
-    | (user_dest,_) -> user_dest
+    | ("", None) ->
+      Format.printf "Please specify a destination filename with --save-project-filename.\n";
+      exit 1;
+    | ("", Some bnm) -> String.concat [bnm; ".bpj"]
+    | (user_dest, _) -> user_dest
   in
-  Project.Io.write dest proj
+  Program.Io.write dest prog
 
 module Cmdline = struct
   open Config
-  let filename = param string "filename" ~doc:"Optional name of output file"
+  let filename = param string "filename" ~doc:"Name of output file"
 
   let () = when_ready (fun {get=(!!)} ->
-               Project.register_pass' (main !!filename))
+      Project.register_pass' (main !!filename))
 
   let () = manpage [
-     `S "DESCRIPTION";
-     `P "Saves a binary's project data structure to disk."
-  ]
+      `S "DESCRIPTION";
+      `P "Saves a binary's program data structure to disk."
+    ]
 end

--- a/wp/resources/sample_binaries/Makefile
+++ b/wp/resources/sample_binaries/Makefile
@@ -1,0 +1,15 @@
+SAMPLE_DIRS = $(wildcard */)
+BUILD_DIRS = $(SAMPLE_DIRS:%=build-%)
+CLEAN_DIRS = $(SAMPLE_DIRS:%=clean-%)
+
+.PHONY: all clean
+.PHONY: subdirs $(BUILD_DIRS)
+.PHONY: subdirs $(CLEAN_DIRS)
+
+all: $(BUILD_DIRS)
+$(BUILD_DIRS):
+	$(MAKE) -C $(@:build-%=%)
+
+clean: $(CLEAN_DIRS)
+$(CLEAN_DIRS):
+	$(MAKE) -C $(@:clean-%=%) clean

--- a/wp/resources/sample_binaries/diff_pointer_val/Makefile
+++ b/wp/resources/sample_binaries/diff_pointer_val/Makefile
@@ -17,7 +17,7 @@ $(PROG1).s: $(PROG1)
 	objdump -Sd $(PROG1) > $(PROG1).s
 
 $(PROG1).bpj: $(PROG1)
-	bap --pass=save-project $(PROG1)
+	bap --pass=save-project --save-project-filename=$(PROG1).bpj $(PROG1)
 
 prog2: $(PROG2) $(PROG2).s $(PROG2).bpj
 
@@ -28,7 +28,7 @@ $(PROG2).s: $(PROG2)
 	objdump -Sd $(PROG2) > $(PROG2).s
 
 $(PROG2).bpj: $(PROG2)
-	bap --pass=save-project $(PROG2)
+	bap --pass=save-project --save-project-filename=$(PROG2).bpj $(PROG2)
 
 clean:
 	rm -f $(PROG1) $(PROG1).s $(PROG1).bpj  $(PROG2) $(PROG2).s $(PROG2).bpj

--- a/wp/resources/sample_binaries/diff_ret_val/Makefile
+++ b/wp/resources/sample_binaries/diff_ret_val/Makefile
@@ -17,7 +17,7 @@ $(PROG1).s: $(PROG1)
 	objdump -Sd $(PROG1) > $(PROG1).s
 
 $(PROG1).bpj: $(PROG1)
-	bap --pass=save-project $(PROG1)
+	bap --pass=save-project --save-project-filename=$(PROG1).bpj $(PROG1)
 
 prog2: $(PROG2) $(PROG2).s $(PROG2).bpj
 
@@ -28,7 +28,7 @@ $(PROG2).s: $(PROG2)
 	objdump -Sd $(PROG2) > $(PROG2).s
 
 $(PROG2).bpj: $(PROG2)
-	bap --pass=save-project $(PROG2)
+	bap --pass=save-project --save-project-filename=$(PROG2).bpj $(PROG2)
 
 clean:
 	rm -f $(PROG1) $(PROG1).s $(PROG1).bpj  $(PROG2) $(PROG2).s $(PROG2).bpj

--- a/wp/resources/sample_binaries/equiv_argc/Makefile
+++ b/wp/resources/sample_binaries/equiv_argc/Makefile
@@ -17,7 +17,7 @@ $(PROG1).s: $(PROG1)
 	objdump -Sd $(PROG1) > $(PROG1).s
 
 $(PROG1).bpj: $(PROG1)
-	bap --pass=save-project $(PROG1)
+	bap --pass=save-project --save-project-filename=$(PROG1).bpj $(PROG1)
 
 prog2: $(PROG2) $(PROG2).s $(PROG2).bpj
 
@@ -28,7 +28,7 @@ $(PROG2).s: $(PROG2)
 	objdump -Sd $(PROG2) > $(PROG2).s
 
 $(PROG2).bpj: $(PROG2)
-	bap --pass=save-project $(PROG2)
+	bap --pass=save-project --save-project-filename=$(PROG2).bpj $(PROG2)
 
 clean:
 	rm -f $(PROG1) $(PROG1).s $(PROG1).bpj  $(PROG2) $(PROG2).s $(PROG2).bpj

--- a/wp/resources/sample_binaries/equiv_null_check/Makefile
+++ b/wp/resources/sample_binaries/equiv_null_check/Makefile
@@ -17,7 +17,7 @@ $(PROG1).s: $(PROG1)
 	objdump -Sd $(PROG1) > $(PROG1).s
 
 $(PROG1).bpj: $(PROG1)
-	bap --pass=save-project $(PROG1)
+	bap --pass=save-project --save-project-filename=$(PROG1).bpj $(PROG1)
 
 prog2: $(PROG2) $(PROG2).s $(PROG2).bpj
 
@@ -28,7 +28,7 @@ $(PROG2).s: $(PROG2)
 	objdump -Sd $(PROG2) > $(PROG2).s
 
 $(PROG2).bpj: $(PROG2)
-	bap --pass=save-project $(PROG2)
+	bap --pass=save-project --save-project-filename=$(PROG2).bpj $(PROG2)
 
 clean:
 	rm -f $(PROG1) $(PROG1).s $(PROG1).bpj  $(PROG2) $(PROG2).s $(PROG2).bpj

--- a/wp/resources/sample_binaries/no_stack_protection/Makefile
+++ b/wp/resources/sample_binaries/no_stack_protection/Makefile
@@ -15,7 +15,7 @@ $(PROG1).s: $(PROG1)
 	objdump -Sd $(PROG1) > $(PROG1).s
 
 $(PROG1).bpj: $(PROG1)
-	bap --pass=save-project $(PROG1)
+	bap --pass=save-project --save-project-filename=$(PROG1).bpj $(PROG1)
 
 prog2: $(PROG2) $(PROG2).s $(PROG2).bpj
 
@@ -26,7 +26,7 @@ $(PROG2).s: $(PROG2)
 	objdump -Sd $(PROG2) > $(PROG2).s
 
 $(PROG2).bpj: $(PROG2)
-	bap --pass=save-project $(PROG2)
+	bap --pass=save-project --save-project-filename=$(PROG2).bpj $(PROG2)
 
 clean:
 	rm -f $(PROG1) $(PROG1).s $(PROG1).bpj  $(PROG2) $(PROG2).s $(PROG2).bpj

--- a/wp/resources/sample_binaries/retrowrite_stub/Makefile
+++ b/wp/resources/sample_binaries/retrowrite_stub/Makefile
@@ -12,7 +12,7 @@ $(PROG1): $(PROG1).S
 	$(CC) $(FLAGS) -o $(PROG1) $(PROG1).S
 
 $(PROG1).bpj: $(PROG1)
-	bap --pass=save-project $(PROG1)
+	bap --pass=save-project --save-project-filename=$(PROG1).bpj $(PROG1)
 
 prog2: $(PROG2) $(PROG2).bpj
 
@@ -20,7 +20,7 @@ $(PROG2): $(PROG2).S
 	gcc -Wall $(FLAGS) -o $(PROG2) $(PROG2).S
 
 $(PROG2).bpj: $(PROG2)
-	bap --pass=save-project $(PROG2)
+	bap --pass=save-project --save-project-filename=$(PROG2).bpj $(PROG2)
 
 clean:
 	rm -f $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj

--- a/wp/resources/sample_binaries/switch_case_assignments/Makefile
+++ b/wp/resources/sample_binaries/switch_case_assignments/Makefile
@@ -15,7 +15,7 @@ $(PROG1).s: $(PROG1)
 	objdump -Sd $(PROG1) > $(PROG1).s
 
 $(PROG1).bpj: $(PROG1)
-	bap --pass=save-project $(PROG1)
+	bap --pass=save-project --save-project-filename=$(PROG1).bpj $(PROG1)
 
 prog2: $(PROG2) $(PROG2).s $(PROG2).bpj
 
@@ -26,7 +26,7 @@ $(PROG2).s: $(PROG2)
 	objdump -Sd $(PROG2) > $(PROG2).s
 
 $(PROG2).bpj: $(PROG2)
-	bap --pass=save-project $(PROG2)
+	bap --pass=save-project --save-project-filename=$(PROG2).bpj $(PROG2)
 
 clean:
 	rm -f $(PROG1) $(PROG1).s $(PROG1).bpj  $(PROG2) $(PROG2).s $(PROG2).bpj

--- a/wp/resources/sample_binaries/switch_cases/Makefile
+++ b/wp/resources/sample_binaries/switch_cases/Makefile
@@ -17,7 +17,7 @@ $(PROG1).s: $(PROG1)
 	objdump -Sd $(PROG1) > $(PROG1).s
 
 $(PROG1).bpj: $(PROG1)
-	bap --pass=save-project $(PROG1)
+	bap --pass=save-project --save-project-filename=$(PROG1).bpj $(PROG1)
 
 prog2: $(PROG2) $(PROG2).s $(PROG2).bpj
 
@@ -28,7 +28,7 @@ $(PROG2).s: $(PROG2)
 	objdump -Sd $(PROG2) > $(PROG2).s
 
 $(PROG2).bpj: $(PROG2)
-	bap --pass=save-project $(PROG2)
+	bap --pass=save-project --save-project-filename=$(PROG2).bpj $(PROG2)
 
 clean:
 	rm -f $(PROG1) $(PROG1).s $(PROG1).bpj  $(PROG2) $(PROG2).s $(PROG2).bpj


### PR DESCRIPTION
Ports `VSA` and `wp` to BAP 2.0. Major changes include:

WP:
- no longer saving a BAP project in favor of a BAP program for binary diffing
- using the dummy binary as a way to determine the architecture
- using the last block of a sub to determine how much to increment SP rather than looking for a block with `Ret` since `Ret` has been removed

VSA:
- removing `bounded_lcm` in favor of `Word.lcm_exn`