### PR TITLE
Create function call predicates

### DIFF
--- a/wp/lib/bap_wp/src/bil_to_bir.ml
+++ b/wp/lib/bap_wp/src/bil_to_bir.ml
@@ -88,7 +88,6 @@ let rec stmt_to_blks (stmt : Bil.Types.stmt)
       *)
       | Bil.Unknown (tid_s, _) ->
         let call_tid = Tid.from_string_exn tid_s in
-        Tid.set_name call_tid "__assert_fail";
         Blk.Builder.add_jmp tail_blk
           (Jmp.create (Call (Call.create ~target:(Label.direct call_tid) ())));
         sub, tail_blk

--- a/wp/lib/bap_wp/src/compare.ml
+++ b/wp/lib/bap_wp/src/compare.ml
@@ -62,12 +62,12 @@ let fun_call_eqs (env1 : Env.t) (env2 : Env.t) : Constr.t list =
           assert (FuncDecl.equal func_decl1 func_decl2);
           let args1 = Expr.get_args pred1 in
           let args2 = Expr.get_args pred2 in
-          let out_vars = List.append args1 args2 in
-          let sorts = List.map out_vars ~f:Expr.get_sort in
-          let symbols = List.map out_vars
+          let args = List.append args1 args2 in
+          let sorts = List.map args ~f:Expr.get_sort in
+          let symbols = List.map args
               ~f:(fun v -> v |> Expr.to_string |> Z3.Symbol.mk_string ctx) in
-          (* FIXME: Currently assuming that both function calls have the same about
-             of output variables. *)
+          (* FIXME: Currently assuming that both function calls have the same number
+             of input and output variables. *)
           let out_eqs = List.fold2_exn args1 args2 ~init:[]
               ~f:(fun eq var1 var2 -> Bool.mk_eq ctx var1 var2 :: eq) in
           let body = Bool.mk_implies ctx
@@ -78,7 +78,7 @@ let fun_call_eqs (env1 : Env.t) (env2 : Env.t) : Constr.t list =
             |> Constr.mk_goal (Format.sprintf "%s called with equal outputs" f)
             |> Constr.mk_constr
           in
-          f_modified_same_output::hyp
+          f_modified_same_output :: hyp
       )
 
 let compare_blocks

--- a/wp/lib/bap_wp/src/compare.ml
+++ b/wp/lib/bap_wp/src/compare.ml
@@ -44,8 +44,12 @@ let set_to_eqs (env1 : Env.t) (env2 : Env.t) (vars : Var.Set.t) : Constr.t list 
         in (eq::eqs, env1, env2)
       )
 
-(* This hypothesis needs to be generated after visiting both of the subs because
-   function predicates are generated at call time. *)
+(* This hypothesis states that if a function is called in both the original and
+   modified binaries, then the values of its input and output variables are consistent
+   across both binaries.
+
+   It needs to be generated after visiting both of the subs because
+   function predicates are generated at call time.  *)
 let fun_call_eqs (env1 : Env.t) (env2 : Env.t) : Constr.t list =
   let ctx = Env.get_context env1 in
   let get_fun_pred env f =

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -114,9 +114,10 @@ val wp_rec_call :
     typically a constant. *)
 val add_var : t -> Bap.Std.Var.t -> Constr.z3_expr -> t
 
-(** Add a function predicate to the environment representing a function call to
-    a target with a given tid. The function predicate is a z3_expr with the form
-    [foo_pred(in, ..., out, ...)] where in and out are the input and output variables. *)
+(** Add a function predicate representing a function call to the environment with
+    the tid of the call's target. The function predicate is a z3_expr with the
+    form [foo_pred(in, ..., out, ...)] where in and out are the input and output
+    variables. *)
 val add_fun_pred : t -> Bap.Std.Tid.t -> Constr.z3_expr -> t
 
 (** Add a precondition to be associated to a block b to the environment. *)

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -114,7 +114,9 @@ val wp_rec_call :
     typically a constant. *)
 val add_var : t -> Bap.Std.Var.t -> Constr.z3_expr -> t
 
-val add_fun_pred : t -> Bap.Std.Tid.t -> Z3.FuncDecl.func_decl -> t
+(** Add a function predicate to the environment representing a function call to
+    a target with a given tid and given outputs. *)
+val add_fun_pred : t -> Bap.Std.Tid.t -> Constr.z3_expr -> t
 
 (** Add a precondition to be associated to a block b to the environment. *)
 val add_precond : t -> Bap.Std.Tid.t -> Constr.t -> t
@@ -142,8 +144,9 @@ val get_var : t -> Bap.Std.Var.t -> Constr.z3_expr * t
     True if the block is not yet visited. *)
 val get_precondition : t -> Bap.Std.Tid.t -> Constr.t option
 
-(** Looks up the subroutine given its tid. *)
-val get_sub : t -> Bap.Std.Tid.t -> Bap.Std.Sub.t option
+(** Looks up the subroutine's name given its tid. This is needed because a label to
+    a subroutine loses its name when saving a BAP project as a .bpj file. *)
+val get_sub_name : t -> Bap.Std.Tid.t -> string option
 
 (** Finds the tid of a function in the environment. *)
 val get_fun_name_tid : t -> string -> Bap.Std.Tid.t option
@@ -170,6 +173,10 @@ val get_loop_handler :
 
 (** Obtains the architecture of the program. *)
 val get_arch : t -> Bap.Std.Arch.t
+
+(** Looks up the function predicate of a subroutine with a given Tid that contains
+    information about its output variables. *)
+val get_fun_pred : t -> Bap.Std.Tid.t -> Constr.z3_expr option
 
 (** Performs a fold on the map of of function names to tids to generate a
     {!Constr.z3_expr}. *)

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -115,7 +115,8 @@ val wp_rec_call :
 val add_var : t -> Bap.Std.Var.t -> Constr.z3_expr -> t
 
 (** Add a function predicate to the environment representing a function call to
-    a target with a given tid. *)
+    a target with a given tid. The function predicate is a z3_expr with the form
+    [foo_pred(in, ..., out, ...)] where in and out are the input and output variables. *)
 val add_fun_pred : t -> Bap.Std.Tid.t -> Constr.z3_expr -> t
 
 (** Add a precondition to be associated to a block b to the environment. *)
@@ -174,8 +175,10 @@ val get_loop_handler :
 (** Obtains the architecture of the program. *)
 val get_arch : t -> Bap.Std.Arch.t
 
-(** Looks up the function predicate of a subroutine in the form of [func_pred(in, out)]
-    with a given Tid that contains information about its input and output variables. *)
+(** Looks up the function predicate of a subroutine in the form of
+    [func_pred(in, ..., out, ...)] based off the tid of the target function at a
+    call site. This contains information about the target function's input and
+    output variables. *)
 val get_fun_pred : t -> Bap.Std.Tid.t -> Constr.z3_expr option
 
 (** Performs a fold on the map of of function names to tids to generate a

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -115,7 +115,7 @@ val wp_rec_call :
 val add_var : t -> Bap.Std.Var.t -> Constr.z3_expr -> t
 
 (** Add a function predicate to the environment representing a function call to
-    a target with a given tid and given outputs. *)
+    a target with a given tid. *)
 val add_fun_pred : t -> Bap.Std.Tid.t -> Constr.z3_expr -> t
 
 (** Add a precondition to be associated to a block b to the environment. *)
@@ -174,8 +174,8 @@ val get_loop_handler :
 (** Obtains the architecture of the program. *)
 val get_arch : t -> Bap.Std.Arch.t
 
-(** Looks up the function predicate of a subroutine with a given Tid that contains
-    information about its output variables. *)
+(** Looks up the function predicate of a subroutine in the form of [func_pred(in, out)]
+    with a given Tid that contains information about its input and output variables. *)
 val get_fun_pred : t -> Bap.Std.Tid.t -> Constr.z3_expr option
 
 (** Performs a fold on the map of of function names to tids to generate a

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -114,6 +114,8 @@ val wp_rec_call :
     typically a constant. *)
 val add_var : t -> Bap.Std.Var.t -> Constr.z3_expr -> t
 
+val add_fun_pred : t -> Bap.Std.Tid.t -> Z3.FuncDecl.func_decl -> t
+
 (** Add a precondition to be associated to a block b to the environment. *)
 val add_precond : t -> Bap.Std.Tid.t -> Constr.t -> t
 
@@ -140,9 +142,8 @@ val get_var : t -> Bap.Std.Var.t -> Constr.z3_expr * t
     True if the block is not yet visited. *)
 val get_precondition : t -> Bap.Std.Tid.t -> Constr.t option
 
-(** Looks up the subroutine's name given its tid. This is needed because a label to
-    a subroutine loses its name when saving a BAP project as a .bpj file. *)
-val get_sub_name : t -> Bap.Std.Tid.t -> string option
+(** Looks up the subroutine given its tid. *)
+val get_sub : t -> Bap.Std.Tid.t -> Bap.Std.Sub.t option
 
 (** Finds the tid of a function in the environment. *)
 val get_fun_name_tid : t -> string -> Bap.Std.Tid.t option

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -127,8 +127,6 @@ val non_null_assert : Env.exp_cond
     We use the default value [!num_unroll = 5]. *)
 val num_unroll : int ref
 
-val mk_fun_pred : Env.t -> Bap.Std.Sub.t -> Constr.z3_expr list -> Constr.t * Env.t
-
 (** Creates a default environment with the default lists of function
     specs, jump specs, and interrupt specs, and an empty list of
     {!Environment.exp_conds}. Optionally takes in a sequence of subs to initialize

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -127,6 +127,8 @@ val non_null_assert : Env.exp_cond
     We use the default value [!num_unroll = 5]. *)
 val num_unroll : int ref
 
+val mk_fun_pred : Env.t -> Bap.Std.Sub.t -> Constr.z3_expr list -> Constr.t * Env.t
+
 (** Creates a default environment with the default lists of function
     specs, jump specs, and interrupt specs, and an empty list of
     {!Environment.exp_conds}. Optionally takes in a sequence of subs to initialize

--- a/wp/lib/bap_wp/tests/unit/test_compare.ml
+++ b/wp/lib/bap_wp/tests/unit/test_compare.ml
@@ -425,6 +425,34 @@ let test_sub_pair_fun_4 (test_ctx : test_ctxt) : unit =
     compare_prop Z3.Solver.SATISFIABLE
 
 
+let test_sub_pair_fun_5 (test_ctx : test_ctxt) : unit =
+  let ctx = Env.mk_ctx () in
+  let var_gen = Env.mk_var_gen () in
+  let call_tid = Tid.create () in
+  Tid.set_name call_tid "call_tid";
+  let sub1_tid = Tid.create () in
+  let sub2_tid = Tid.create () in
+  let ret_var = Var.create "EAX" reg32_t in
+  let blk1 = Blk.create () in
+  let blk2 = Blk.create () in
+  let blk3 = Blk.create () in
+  let blk4 = Blk.create () in
+  let call_blk1 = Blk.create () |> mk_def ret_var (i32 1) in
+  let call_blk2 = Blk.create () |> mk_def ret_var (i32 2) in
+  let call_sub1 = mk_sub ~tid:call_tid ~name:"test_call" [call_blk1] in
+  let call_sub2 = mk_sub ~tid:call_tid ~name:"test_call" [call_blk2] in
+  let blk1 = blk1 |> mk_call (Label.direct (Term.tid blk2)) (Label.direct (Term.tid call_sub1)) in
+  let blk3 = blk3 |> mk_call (Label.direct (Term.tid blk4)) (Label.direct (Term.tid call_sub2)) in
+  let main_sub1 = mk_sub ~tid:sub1_tid ~name:"main_sub" [blk1; blk2] in
+  let main_sub2 = mk_sub ~tid:sub2_tid ~name:"main_sub" [blk3; blk4] in
+  let env1 = Pre.mk_default_env ctx var_gen ~subs:(Seq.of_list [main_sub1; call_sub1]) in
+  let env2 = Pre.mk_default_env ctx var_gen ~subs:(Seq.of_list [main_sub2; call_sub2]) in
+  let compare_prop, _ = Comp.compare_subs_fun
+      ~original:(main_sub1, env1) ~modified:(main_sub2, env2) in
+  assert_z3_compare test_ctx ctx (Sub.to_string main_sub1) (Sub.to_string main_sub2)
+    compare_prop Z3.Solver.SATISFIABLE
+
+
 let test_sub_pair_mem_1 (test_ctx : test_ctxt) : unit =
   let ctx = Env.mk_ctx () in
   let var_gen = Env.mk_var_gen () in
@@ -467,6 +495,7 @@ let suite = [
   "Fun called in modified sub"               >:: test_sub_pair_fun_2;
   "Branches with fun calls"                  >:: test_sub_pair_fun_3;
   "Fun called in branch"                     >:: test_sub_pair_fun_4;
+  (* "Function predicates"                      >:: test_sub_pair_fun_5; *)
 
   "Compare memory layout"                    >:: test_sub_pair_mem_1;
 ]

--- a/wp/lib/bap_wp/tests/unit/test_compare.ml
+++ b/wp/lib/bap_wp/tests/unit/test_compare.ml
@@ -425,34 +425,6 @@ let test_sub_pair_fun_4 (test_ctx : test_ctxt) : unit =
     compare_prop Z3.Solver.SATISFIABLE
 
 
-let test_sub_pair_fun_5 (test_ctx : test_ctxt) : unit =
-  let ctx = Env.mk_ctx () in
-  let var_gen = Env.mk_var_gen () in
-  let call_tid = Tid.create () in
-  Tid.set_name call_tid "call_tid";
-  let sub1_tid = Tid.create () in
-  let sub2_tid = Tid.create () in
-  let ret_var = Var.create "EAX" reg32_t in
-  let blk1 = Blk.create () in
-  let blk2 = Blk.create () in
-  let blk3 = Blk.create () in
-  let blk4 = Blk.create () in
-  let call_blk1 = Blk.create () |> mk_def ret_var (i32 1) in
-  let call_blk2 = Blk.create () |> mk_def ret_var (i32 2) in
-  let call_sub1 = mk_sub ~tid:call_tid ~name:"test_call" [call_blk1] in
-  let call_sub2 = mk_sub ~tid:call_tid ~name:"test_call" [call_blk2] in
-  let blk1 = blk1 |> mk_call (Label.direct (Term.tid blk2)) (Label.direct (Term.tid call_sub1)) in
-  let blk3 = blk3 |> mk_call (Label.direct (Term.tid blk4)) (Label.direct (Term.tid call_sub2)) in
-  let main_sub1 = mk_sub ~tid:sub1_tid ~name:"main_sub" [blk1; blk2] in
-  let main_sub2 = mk_sub ~tid:sub2_tid ~name:"main_sub" [blk3; blk4] in
-  let env1 = Pre.mk_default_env ctx var_gen ~subs:(Seq.of_list [main_sub1; call_sub1]) in
-  let env2 = Pre.mk_default_env ctx var_gen ~subs:(Seq.of_list [main_sub2; call_sub2]) in
-  let compare_prop, _ = Comp.compare_subs_fun
-      ~original:(main_sub1, env1) ~modified:(main_sub2, env2) in
-  assert_z3_compare test_ctx ctx (Sub.to_string main_sub1) (Sub.to_string main_sub2)
-    compare_prop Z3.Solver.SATISFIABLE
-
-
 let test_sub_pair_mem_1 (test_ctx : test_ctxt) : unit =
   let ctx = Env.mk_ctx () in
   let var_gen = Env.mk_var_gen () in
@@ -495,7 +467,6 @@ let suite = [
   "Fun called in modified sub"               >:: test_sub_pair_fun_2;
   "Branches with fun calls"                  >:: test_sub_pair_fun_3;
   "Fun called in branch"                     >:: test_sub_pair_fun_4;
-  (* "Function predicates"                      >:: test_sub_pair_fun_5; *)
 
   "Compare memory layout"                    >:: test_sub_pair_mem_1;
 ]

--- a/wp/lib/bap_wp/tests/unit/test_compare.ml
+++ b/wp/lib/bap_wp/tests/unit/test_compare.ml
@@ -428,31 +428,29 @@ let test_sub_pair_fun_4 (test_ctx : test_ctxt) : unit =
 let test_sub_pair_fun_5 (test_ctx : test_ctxt) : unit =
   let ctx = Env.mk_ctx () in
   let var_gen = Env.mk_var_gen () in
-  let call_tid = Tid.create () in
-  Tid.set_name call_tid "call_tid";
-  let sub1_tid = Tid.create () in
-  let sub2_tid = Tid.create () in
   let ret_var = Var.create "EAX" reg32_t in
   let x = Var.create "x" reg32_t in
   let y = Var.create "y" reg32_t in
-  let blk1 = Blk.create () in
-  let blk2 = Blk.create () in
-  let blk3 = Blk.create () in
-  let blk4 = Blk.create () in
-  let call_blk1 = Blk.create ()
-                  |> mk_def x (i32 1)
-                  |> mk_def y (i32 2)
-                  |> mk_def ret_var Bil.(var x + var y) in
-  let call_blk2 = Blk.create ()
-                  |> mk_def y (i32 2)
-                  |> mk_def x (i32 1)
-                  |> mk_def ret_var Bil.(var x + var y) in
-  let call_sub1 = mk_sub ~tid:call_tid ~name:"test_call" [call_blk1] in
-  let call_sub2 = mk_sub ~tid:call_tid ~name:"test_call" [call_blk2] in
-  let blk1 = blk1 |> mk_call (Label.direct (Term.tid blk2)) (Label.direct (Term.tid call_sub1)) in
-  let blk3 = blk3 |> mk_call (Label.direct (Term.tid blk4)) (Label.direct (Term.tid call_sub2)) in
-  let main_sub1 = mk_sub ~tid:sub1_tid ~name:"main_sub" [blk1; blk2] in
-  let main_sub2 = mk_sub ~tid:sub2_tid ~name:"main_sub" [blk3; blk4] in
+  let call_sub1 = Bil.(
+      [ x := i32 1;
+        y := i32 2;
+        ret_var := var x + var y;
+      ]
+    ) |> bil_to_sub in
+  let call_sub2 = Bil.(
+      [ y := i32 2;
+        x := i32 1;
+        ret_var := var x + var y;
+      ]
+    ) |> bil_to_sub in
+  let call_sub1 = Sub.with_name call_sub1 "test_call" in
+  let call_sub2 = Sub.with_name call_sub2 "test_call" in
+  let main_sub1 = Bil.(
+      [ jmp (unknown (call_sub1 |> Term.tid |> Tid.to_string) reg64_t) ]
+    ) |> bil_to_sub in
+  let main_sub2 = Bil.(
+      [ jmp (unknown (call_sub2 |> Term.tid |> Tid.to_string) reg64_t) ]
+    ) |> bil_to_sub in
   let env1 = Pre.mk_default_env ctx var_gen ~subs:(Seq.of_list [main_sub1; call_sub1]) in
   let env2 = Pre.mk_default_env ctx var_gen ~subs:(Seq.of_list [main_sub2; call_sub2]) in
   let compare_prop, _ = Comp.compare_subs_fun


### PR DESCRIPTION
At function call time, the precondition is computed with `Func_pred(in, out) => post[fresh_out/out]`.
After both subroutines have been visited,

`forall in_old, in_new, out_old, out_new. Func_pred(in_old, out_old) ^ Func_pred(in_new, out_new) => in_old = in_new ^ out_old = out_new`

is added to the hypotheses.

Assumptions made:
- both function calls have the same number of input and output variables
- the order of the arguments remains consistent between the two binaries

Lastly, I filtered out `mem` from the variable comparison because it caused Z3 to choke.