### PR TITLE
Improved model printing

### DIFF
--- a/wp/lib/bap_wp/src/compare.mli
+++ b/wp/lib/bap_wp/src/compare.mli
@@ -39,7 +39,7 @@ val compare_blocks
   -> output:Bap.Std.Var.Set.t
   -> original:(Bap.Std.Blk.t * Env.t)
   -> modified:(Bap.Std.Blk.t * Env.t)
-  -> Constr.t * Env.t
+  -> Constr.t * Env.t * Env.t
 
 (** Compare two subroutines by composition for equality of return
     values:
@@ -53,7 +53,7 @@ val compare_subs_eq
   -> output:Bap.Std.Var.Set.t
   -> original:(Bap.Std.Sub.t * Env.t)
   -> modified:(Bap.Std.Sub.t * Env.t)
-  -> Constr.t * Env.t
+  -> Constr.t * Env.t * Env.t
 
 (** Compare two subroutines by composition for an empty postcondition:
 
@@ -63,7 +63,7 @@ val compare_subs_eq
 val compare_subs_empty
   :  original:(Bap.Std.Sub.t * Env.t)
   -> modified:(Bap.Std.Sub.t * Env.t)
-  -> Constr.t * Env.t
+  -> Constr.t * Env.t * Env.t
 
 (** Compare two subroutines by composition for an empty
     postcondition:
@@ -76,7 +76,7 @@ val compare_subs_empty_post
   :  input:Bap.Std.Var.Set.t
   -> original:(Bap.Std.Sub.t * Env.t)
   -> modified:(Bap.Std.Sub.t * Env.t)
-  -> Constr.t * Env.t
+  -> Constr.t * Env.t * Env.t
 
 (** Compare two subroutines by composition for conservation of function calls:
 
@@ -87,4 +87,4 @@ val compare_subs_empty_post
 val compare_subs_fun
   :  original:(Bap.Std.Sub.t * Env.t)
   -> modified:(Bap.Std.Sub.t * Env.t)
-  -> Constr.t * Env.t
+  -> Constr.t * Env.t * Env.t

--- a/wp/lib/bap_wp/src/output.mli
+++ b/wp/lib/bap_wp/src/output.mli
@@ -33,7 +33,8 @@ module Constr = Constraint
 
 (** Prints out the result from check, and if the result is [SAT], generate a model that
     represents the registers and memory values that lead to a specific program state. *)
-val print_result : Z3.Solver.solver -> Z3.Solver.status -> Constr.t -> Z3.context -> unit
+val print_result : Z3.Solver.solver -> Z3.Solver.status -> Constr.t
+  -> orig:Env.t -> modif:Env.t -> unit
 
 
 (** Prints to file a gdb script that will fill the appropriate registers with the countermodel *)

--- a/wp/lib/bap_wp/tests/unit/test_compare.ml
+++ b/wp/lib/bap_wp/tests/unit/test_compare.ml
@@ -55,7 +55,7 @@ let test_block_pair_1 (test_ctx : test_ctxt) : unit =
   in
   let input_vars = Var.Set.union (Var.Set.singleton x) (Var.Set.singleton y) in
   let output_vars = Var.Set.singleton z in
-  let compare_prop, _ = Comp.compare_blocks
+  let compare_prop, _, _ = Comp.compare_blocks
       ~input:input_vars ~output:output_vars
       ~original:(blk1,env1) ~modified:(blk2,env2) in
   assert_z3_compare test_ctx ctx (Blk.to_string blk1) (Blk.to_string blk2)
@@ -77,7 +77,7 @@ let test_block_pair_2 (test_ctx : test_ctxt) : unit =
   in
   let input_vars = Var.Set.singleton x in
   let output_vars = Var.Set.singleton z in
-  let compare_prop, _ = Comp.compare_blocks
+  let compare_prop, _, _ = Comp.compare_blocks
       ~input:input_vars ~output:output_vars
       ~original:(blk1,env1) ~modified:(blk2,env2) in
   assert_z3_compare test_ctx ctx (Blk.to_string blk1) (Blk.to_string blk2)
@@ -117,7 +117,7 @@ let test_sub_pair_1 (test_ctx : test_ctxt) : unit =
   let sub2 = mk_sub [blk1; blk2'; blk3'; blk4] in
   let input_vars = Var.Set.union (Var.Set.singleton x) (Var.Set.singleton y) in
   let output_vars = Var.Set.singleton z in
-  let compare_prop, _ = Comp.compare_subs_eq
+  let compare_prop, _, _ = Comp.compare_subs_eq
       ~input:input_vars ~output:output_vars
       ~original:(sub1,env1) ~modified:(sub2,env2) in
   assert_z3_compare test_ctx ctx (Sub.to_string sub1) (Sub.to_string sub2)
@@ -156,7 +156,7 @@ let test_sub_pair_2 (test_ctx : test_ctxt) : unit =
   let sub2 = mk_sub [blk1; blk2; blk3; blk4'] in
   let input_vars = Var.Set.union (Var.Set.singleton x) (Var.Set.singleton y) in
   let output_vars = Var.Set.singleton z in
-  let compare_prop, _ = Comp.compare_subs_eq
+  let compare_prop, _, _ = Comp.compare_subs_eq
       ~input:input_vars ~output:output_vars
       ~original:(sub1,env1) ~modified:(sub2,env2) in
   assert_z3_compare test_ctx ctx (Sub.to_string sub1) (Sub.to_string sub2)
@@ -189,7 +189,7 @@ let test_sub_pair_3 (test_ctx : test_ctxt) : unit =
   let sub2 = mk_sub [blk1'; blk2'] in
   let input_vars = Var.Set.union (Var.Set.singleton x) (Var.Set.singleton y) in
   let output_vars = Var.Set.singleton z in
-  let compare_prop, _ = Comp.compare_subs_eq
+  let compare_prop, _, _ = Comp.compare_subs_eq
       ~input:input_vars ~output:output_vars
       ~original:(sub1,env1) ~modified:(sub2,env2) in
   assert_z3_compare test_ctx ctx (Sub.to_string sub1) (Sub.to_string sub2)
@@ -225,7 +225,7 @@ let test_sub_pair_4 (test_ctx : test_ctxt) : unit =
   in
   let input_vars = Var.Set.singleton x in
   let output_vars = Var.Set.singleton y in
-  let compare_prop, _ = Comp.compare_subs_eq
+  let compare_prop, _, _ = Comp.compare_subs_eq
       ~input:input_vars ~output:output_vars
       ~original:(sub1,env1) ~modified:(sub2,env2) in
   assert_z3_compare test_ctx ctx (Sub.to_string sub1) (Sub.to_string sub2)
@@ -261,7 +261,7 @@ let test_sub_pair_5 (test_ctx : test_ctxt) : unit =
   let sub2 = mk_sub [blk1'] in
   let input_vars = Var.Set.singleton x in
   let output_vars = Var.Set.singleton y in
-  let compare_prop, _ = Comp.compare_subs_eq
+  let compare_prop, _, _ = Comp.compare_subs_eq
       ~input:input_vars ~output:output_vars
       ~original:(sub1,env1) ~modified:(sub2,env2) in
   assert_z3_compare test_ctx ctx (Sub.to_string sub1) (Sub.to_string sub2)
@@ -279,7 +279,7 @@ let test_sub_pair_6 (test_ctx : test_ctxt) : unit =
   let sub1 = Bil.([if_ (read = i32 12)[][]]) |> bil_to_sub in
   let sub2 = Bil.([if_ (read = i32 3) [if_ (read = i32 4) [][]] []]) |> bil_to_sub in
   let vars = Var.Set.of_list [mem; loc] in
-  let compare_prop, _ = Comp.compare_subs_empty_post ~input:vars
+  let compare_prop, _, _ = Comp.compare_subs_empty_post ~input:vars
       ~original:(sub1, env1) ~modified:(sub2, env2) in
   assert_z3_compare test_ctx ctx (Sub.to_string sub1) (Sub.to_string sub2)
     compare_prop Z3.Solver.UNSATISFIABLE
@@ -297,7 +297,7 @@ let test_sub_pair_7 (test_ctx : test_ctxt) : unit =
   let sub1 = Bil.([if_ (read = i32 3)[][]]) |> bil_to_sub in
   let sub2 = Bil.([if_ (read = i32 3) [if_ (read' = i32 4) [][]] []]) |> bil_to_sub in
   let vars = Var.Set.of_list [mem; loc] in
-  let compare_prop, _ = Comp.compare_subs_empty_post ~input:vars
+  let compare_prop, _, _ = Comp.compare_subs_empty_post ~input:vars
       ~original:(sub1, env1) ~modified:(sub2, env2) in
   assert_z3_compare test_ctx ctx (Sub.to_string sub1) (Sub.to_string sub2)
     compare_prop Z3.Solver.SATISFIABLE
@@ -322,7 +322,7 @@ let test_sub_pair_fun_1 (test_ctx : test_ctxt) : unit =
   let main_sub2 = mk_sub ~tid:sub2_tid ~name:"main_sub" [blk3; blk4] in
   let env1 = Pre.mk_default_env ctx var_gen ~subs:(Seq.of_list [main_sub1; call_sub]) in
   let env2 = Pre.mk_default_env ctx var_gen ~subs:(Seq.of_list [main_sub2; call_sub]) in
-  let compare_prop, _ = Comp.compare_subs_fun
+  let compare_prop, _, _ = Comp.compare_subs_fun
       ~original:(main_sub1, env1) ~modified:(main_sub2, env2) in
   assert_z3_compare test_ctx ctx (Sub.to_string main_sub1) (Sub.to_string main_sub2)
     compare_prop Z3.Solver.UNSATISFIABLE
@@ -346,7 +346,7 @@ let test_sub_pair_fun_2 (test_ctx : test_ctxt) : unit =
   let main_sub2 = mk_sub ~tid:sub2_tid ~name:"main_sub" [blk3; blk4] in
   let env1 = Pre.mk_default_env ctx var_gen ~subs:(Seq.of_list [main_sub1; call_sub]) in
   let env2 = Pre.mk_default_env ctx var_gen ~subs:(Seq.of_list [main_sub2; call_sub]) in
-  let compare_prop, _ = Comp.compare_subs_fun
+  let compare_prop, _, _ = Comp.compare_subs_fun
       ~original:(main_sub1, env1) ~modified:(main_sub2, env2) in
   assert_z3_compare test_ctx ctx (Sub.to_string main_sub1) (Sub.to_string main_sub2)
     compare_prop Z3.Solver.SATISFIABLE
@@ -382,7 +382,7 @@ let test_sub_pair_fun_3 (test_ctx : test_ctxt) : unit =
       ~subs:(Seq.of_list [main_sub1; call1_sub; call2_sub]) in
   let env2 = Pre.mk_default_env ctx var_gen
       ~subs:(Seq.of_list [main_sub2; call1_sub; call2_sub]) in
-  let compare_prop, _ = Comp.compare_subs_fun
+  let compare_prop, _, _ = Comp.compare_subs_fun
       ~original:(main_sub1, env1) ~modified:(main_sub2, env2) in
   assert_z3_compare test_ctx ctx (Sub.to_string main_sub1) (Sub.to_string main_sub2)
     compare_prop Z3.Solver.SATISFIABLE
@@ -419,7 +419,7 @@ let test_sub_pair_fun_4 (test_ctx : test_ctxt) : unit =
       ~subs:(Seq.of_list [main_sub1; call1_sub; call2_sub]) in
   let env2 = Pre.mk_default_env ctx var_gen
       ~subs:(Seq.of_list [main_sub2; call1_sub; call2_sub]) in
-  let compare_prop, _ = Comp.compare_subs_fun
+  let compare_prop, _, _ = Comp.compare_subs_fun
       ~original:(main_sub1, env1) ~modified:(main_sub2, env2) in
   assert_z3_compare test_ctx ctx (Sub.to_string main_sub1) (Sub.to_string main_sub2)
     compare_prop Z3.Solver.SATISFIABLE
@@ -445,7 +445,7 @@ let test_fun_outputs_1 (test_ctx : test_ctxt) : unit =
   let env2 = Pre.mk_default_env ctx var_gen ~subs:(Seq.of_list [main_sub2; call_sub2]) in
   let input_vars = Var.Set.of_list [x; y; ret_var] in
   let output_vars = Var.Set.singleton ret_var in
-  let compare_prop, _ = Comp.compare_subs_eq
+  let compare_prop, _, _ = Comp.compare_subs_eq
       ~input:input_vars ~output:output_vars
       ~original:(main_sub1, env1) ~modified:(main_sub2, env2) in
   assert_z3_compare test_ctx ctx (Sub.to_string main_sub1)
@@ -477,7 +477,7 @@ let test_fun_outputs_2 (test_ctx : test_ctxt) : unit =
   let env2 = Pre.mk_default_env ctx var_gen ~subs:(Seq.of_list [main_sub2; call_sub2]) in
   let input_vars = Var.Set.of_list [x; y; ret_var] in
   let output_vars = Var.Set.singleton ret_var in
-  let compare_prop, _ = Comp.compare_subs_eq
+  let compare_prop, _, _ = Comp.compare_subs_eq
       ~input:input_vars ~output:output_vars
       ~original:(main_sub1, env1) ~modified:(main_sub2, env2) in
   assert_z3_compare test_ctx ctx (Sub.to_string main_sub1)
@@ -504,7 +504,7 @@ let test_sub_pair_mem_1 (test_ctx : test_ctxt) : unit =
   let env2 = Pre.mk_default_env ctx var_gen ~subs:(Seq.of_list [sub2]) in
   let input_vars = Var.Set.of_list [mem; loc1] in
   let output_vars = Var.Set.singleton mem in
-  let compare_prop, _ = Comp.compare_subs_eq
+  let compare_prop, _, _ = Comp.compare_subs_eq
       ~input:input_vars ~output:output_vars
       ~original:(sub1,env1) ~modified:(sub2,env2) in
   assert_z3_compare test_ctx ctx (Sub.to_string sub1) (Sub.to_string sub2)


### PR DESCRIPTION
Function comparisons now return pairs of updated environments, in the order that they were passed in.

Printing of counter-models is now significantly nicer, but we only print variables which appear in the `var_map` of the first environment.