### PR TITLE
Fortunac/print paths

### DIFF
--- a/wp/lib/bap_wp/src/constraint.mli
+++ b/wp/lib/bap_wp/src/constraint.mli
@@ -43,9 +43,9 @@ type t
 (** A goal is simply a Z3 (boolean) expression tagged with a name. *)
 type goal
 
-(** A path tracks an execution path by mapping [tid]s of branches to a
+(** A path tracks an execution path by mapping [jmp]s of branches to a
     boolean, which marks whether the path was taken or not. *)
-type path = bool Bap.Std.Tid.Map.t
+type path = bool Bap.Std.Jmp.Map.t
 
 (** [mk_goal name e] creates a goal using a Z3 boolean expression and
     a name. *)
@@ -73,10 +73,10 @@ val pp_constr : Format.formatter -> t -> unit
 (** Creates a constraint made of a single goal. *)
 val mk_constr : goal -> t
 
-(** [mk_ite tid e lc rc] creates an if-then-else constraint
-    representing a branch at [tid] with constraint [e], which has
+(** [mk_ite jmp e lc rc] creates an if-then-else constraint
+    representing a branch at [jmp] with constraint [e], which has
     the constraints [lc] if [e] is true and [rc] otherwise. *)
-val mk_ite : Bap.Std.Tid.t -> z3_expr -> t -> t -> t
+val mk_ite : Bap.Std.Jmp.t -> z3_expr -> t -> t -> t
 
 (** [mk_clause [a1;...,an] [v1;...;vm]] creates the constraint
     [a1 /\ ... /\ an ==> v1 /\ ... /\ vm]. *)

--- a/wp/lib/bap_wp/src/constraint.mli
+++ b/wp/lib/bap_wp/src/constraint.mli
@@ -54,6 +54,12 @@ val mk_goal : string -> z3_expr -> goal
 (** Creates a string representation of a goal. *)
 val goal_to_string : goal -> string
 
+(** Creates a string representation of a path. *)
+val path_to_string : path -> string
+
+(** Pretty prints a path. *)
+val pp_path : Format.formatter -> path -> unit
+
 (** Creates a string representation of a goal that has been refuted given the model.
     This string shows the lhs and rhs of a goal that compares two values. *)
 val refuted_goal_to_string : goal -> Z3.Model.model -> string

--- a/wp/lib/bap_wp/tests/performance/test_precondition.ml
+++ b/wp/lib/bap_wp/tests/performance/test_precondition.ml
@@ -115,9 +115,9 @@ let test_nested_ifs (threshold : float) (test_ctx : test_ctxt) : unit =
             if t = tid then begin
               (* The first branch in the seq is the innermost in the nest. *)
               if i = 0 then
-                Some (Constr.mk_ite tid (cond_to_z3 cond env) false_constr true_constr, env)
+                Some (Constr.mk_ite jmp (cond_to_z3 cond env) false_constr true_constr, env)
               else
-                Some (Constr.mk_ite tid (cond_to_z3 cond env) branch_pre true_constr, env)
+                Some (Constr.mk_ite jmp (cond_to_z3 cond env) branch_pre true_constr, env)
             end
             else
               None)

--- a/wp/lib/bap_wp/tests/unit/test_precondition.ml
+++ b/wp/lib/bap_wp/tests/unit/test_precondition.ml
@@ -1080,19 +1080,19 @@ let test_branches_1 (test_ctx : test_ctxt) : unit =
       ]
     ) |> bil_to_sub
   in
-  let jmp_spec = fun env post tid jmp ->
+  let jmp_spec = fun env post _ jmp ->
     let jump_cond cond = Pre.bv_to_bool (mk_z3_expr env cond) ctx 1 in
     let jump_pre =
       match Jmp.kind jmp with
       | Goto (Direct tid) -> Option.value (Env.get_precondition env tid) ~default:post
       | _ -> assert false
     in
-    if Tid.equal tid (jump_tid sub cond_x) then
-      Some (Constr.mk_ite tid (jump_cond cond_x) jump_pre (true_constr ctx), env)
-    else if Tid.equal tid (jump_tid sub cond_y) then
-      Some (Constr.mk_ite tid (jump_cond cond_y) jump_pre (true_constr ctx), env)
-    else if Tid.equal tid (jump_tid sub cond_z) then
-      Some (Constr.mk_ite tid (jump_cond cond_z) (false_constr ctx) (true_constr ctx), env)
+    if Jmp.equal jmp (find_jump sub cond_x) then
+      Some (Constr.mk_ite jmp (jump_cond cond_x) jump_pre (true_constr ctx), env)
+    else if Jmp.equal jmp (find_jump sub cond_y) then
+      Some (Constr.mk_ite jmp (jump_cond cond_y) jump_pre (true_constr ctx), env)
+    else if Jmp.equal jmp (find_jump sub cond_z) then
+      Some (Constr.mk_ite jmp (jump_cond cond_z) (false_constr ctx) (true_constr ctx), env)
     else
       None
   in
@@ -1125,10 +1125,10 @@ let test_jmp_spec_reach_1 (test_ctx : test_ctxt) : unit =
     ) |> bil_to_sub
   in
   let jmp_spec =
-    Tid.Map.empty
-    |> Tid.Map.set ~key:(jump_tid sub cond_x) ~data:true
-    |> Tid.Map.set ~key:(jump_tid sub cond_y) ~data:true
-    |> Tid.Map.set ~key:(jump_tid sub cond_z) ~data:false
+    Jmp.Map.empty
+    |> Jmp.Map.set ~key:(find_jump sub cond_x) ~data:true
+    |> Jmp.Map.set ~key:(find_jump sub cond_y) ~data:true
+    |> Jmp.Map.set ~key:(find_jump sub cond_z) ~data:false
     |> Pre.jmp_spec_reach
   in
   let env = Pre.mk_default_env ctx var_gen ~jmp_spec ~subs:(Seq.singleton sub) in
@@ -1170,10 +1170,10 @@ let test_jmp_spec_reach_2 (test_ctx : test_ctxt) : unit =
     ) |> bil_to_sub
   in
   let jmp_spec =
-    Tid.Map.empty
-    |> Tid.Map.set ~key:(jump_tid sub cond_x) ~data:true
-    |> Tid.Map.set ~key:(jump_tid sub cond_y) ~data:true
-    |> Tid.Map.set ~key:(jump_tid sub cond_unsat) ~data:true
+    Jmp.Map.empty
+    |> Jmp.Map.set ~key:(find_jump sub cond_x) ~data:true
+    |> Jmp.Map.set ~key:(find_jump sub cond_y) ~data:true
+    |> Jmp.Map.set ~key:(find_jump sub cond_unsat) ~data:true
     |> Pre.jmp_spec_reach
   in
   let env = Pre.mk_default_env ctx var_gen ~jmp_spec ~subs:(Seq.singleton sub) in

--- a/wp/lib/bap_wp/tests/unit/test_utils.ml
+++ b/wp/lib/bap_wp/tests/unit/test_utils.ml
@@ -80,14 +80,14 @@ let print_z3_model (ff : Format.formatter) (solver : Z3.Solver.solver)
       Seq.iter refuted_goals ~f:(fun g ->
           Format.fprintf ff "%s\n%!" (Constr.refuted_goal_to_string g model))
 
-(* Obtains the tid of a jump in a sub given its jump condition. *)
-let jump_tid (sub : Sub.t) (cond : Exp.t) : Tid.t =
+(* Finds a jump in a subroutine given its jump condition. *)
+let find_jump (sub : Sub.t) (cond : Exp.t) : Jmp.t =
   let jumps =
     Term.enum blk_t sub
-    |> Seq.map ~f:(fun b -> Term.enum jmp_t b)
+    |> Seq.map ~f:(Term.enum jmp_t)
     |> Seq.concat
   in
-  Term.tid (Seq.find_exn jumps ~f:(fun j -> Exp.equal (Jmp.cond j) cond))
+  Seq.find_exn jumps ~f:(fun j -> Exp.equal (Jmp.cond j) cond)
 
 (* z3_expr representing a jump being taken. *)
 let jump_taken (ctx : Z3.context) : Constr.z3_expr =

--- a/wp/plugin/save_project/save_project.ml
+++ b/wp/plugin/save_project/save_project.ml
@@ -26,7 +26,7 @@ let main nm proj : unit =
     | ("", Some bnm) -> String.concat [bnm; ".bpj"]
     | (user_dest, _) -> user_dest
   in
-  Program.Io.write dest prog
+  Program.Io.write ~fmt:"bin" dest prog
 
 module Cmdline = struct
   open Config

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -116,8 +116,8 @@ let compare_projs (proj : project) (file1: string) (file2 : string)
     ~to_inline:(to_inline : string list)
     ~output_vars:(output_vars : string list)
   : Constr.t * Env.t * Env.t =
-  let prog1 = In_channel.with_file file1 ~f:Program.Io.load in
-  let prog2 = In_channel.with_file file2 ~f:Program.Io.load in
+  let prog1 = Program.Io.read file1 in
+  let prog2 = Program.Io.read file2 in
   (* Currently using the dummy binary's project to determine the architecture
      until we discover a better way of determining the architecture from a program. *)
   let arch = Project.arch proj in
@@ -180,10 +180,10 @@ let main (file1 : string) (file2 : string)
   in
   let result = Pre.check solver ctx pre in
   let () = match gdb_filename with
-          | None -> ()
-          | Some f ->
-                Printf.printf "Dumping gdb script to file: %s\n" f;
-                Output.output_gdb solver result env2 ~func:func ~filename:f in
+    | None -> ()
+    | Some f ->
+      Printf.printf "Dumping gdb script to file: %s\n" f;
+      Output.output_gdb solver result env2 ~func:func ~filename:f in
   Output.print_result solver result pre ~orig:env1 ~modif:env2
 
 


### PR DESCRIPTION
Prints out the path of refuted goal like this:
```
Refuted goals:
assert_fail:
    Z3 Expression: false
    Path:
    00000303: when ZF goto %000002fb (taken) (Address: 0x400433:64u)
```

In the case where BAP cannot find the address of a jump:
```
Refuted goals:
RAX0 = RAX067:
    Concrete values: = #x0000000000000000 #x0000000000000001
    Z3 Expression: = #x0000000000000000 #x0000000000000001
    Path:
    00000878: when ZF goto %00000870 (taken)
    00000881: when ZF goto %00000879 (not taken)
    00000f82: when CF goto %00000f7a (taken)
    00000fa2: goto %00000894 (taken)
    00001170: goto %00000f4b (taken)
```

This has some breaking changes with Primus. `jmp`s should be used instead of `tid`s when creating a jump spec and creating an `ITE` constraint.