### PR TITLE
Fortunac/retrowrite bug fixes

### DIFF
--- a/wp/lib/bap_wp/src/constraint.ml
+++ b/wp/lib/bap_wp/src/constraint.ml
@@ -33,12 +33,12 @@ let pp_path (ch : Format.formatter) (p : path) : unit =
       let jmp_str =
         jmp |> Jmp.to_string |> String.substr_replace_first ~pattern:"\n" ~with_:"" in
       let taken_str = if taken then "(taken)" else "(not taken)" in
-      match Term.get_attr jmp address with
-      | None ->
-        Format.fprintf ch "\t%s %s\n%!" jmp_str taken_str;
-      | Some addr ->
-        Format.fprintf ch "\t%s %s (Address: %s)\n%!"
-          jmp_str taken_str (Addr.to_string addr)
+      let addr_str =
+        match Term.get_attr jmp address with
+        | None -> "not found"
+        | Some addr -> Addr.to_string addr
+      in
+      Format.fprintf ch "\t%s\t%s\t(Address: %s)\n%!" jmp_str taken_str addr_str;
     )
 
 let path_to_string (p : path) : string =

--- a/wp/lib/bap_wp/src/constraint.mli
+++ b/wp/lib/bap_wp/src/constraint.mli
@@ -114,3 +114,8 @@ val get_refuted_goals :
     evaluation fails in the case that the argument contains quantifiers, is
     partial, or is not well-sorted. *)
 val eval_model_exn : Z3.Model.model -> z3_expr -> z3_expr
+
+(** Gets the model of the last check to the Z3 solver. An error will be raised
+    if retrieving the model fails in the case that [check] was not yet called
+    to the solver or the result of the last [check] did not result in SAT. *)
+val get_model_exn : Z3.Solver.solver -> Z3.Model.model

--- a/wp/lib/bap_wp/src/output.ml
+++ b/wp/lib/bap_wp/src/output.ml
@@ -33,7 +33,6 @@ module VarMap = Var.Map
 open Core_kernel
 open Bap.Std
 
-
 let format_model (model : Model.model) (env1 : Env.t) (_env2 : Env.t) : string =
   let var_map = Env.get_var_map env1 in
   let key_val = Env.EnvMap.fold var_map ~init:[]
@@ -68,8 +67,7 @@ let print_result (solver : Solver.solver) (status : Solver.status)
   | Solver.UNKNOWN -> Format.printf "\nUNKNOWN!\n%!"
   | Solver.SATISFIABLE ->
     Format.printf "\nSAT!\n%!";
-    let model = Solver.get_model solver
-                |> Option.value_exn ?here:None ?error:None ?message:None in
+    let model = Constr.get_model_exn solver in
     Format.printf "\nModel:\n%s\n%!" (format_model model env1 env2);
     let refuted_goals = Constr.get_refuted_goals_and_paths goals solver ctx in
     Format.printf "\nRefuted goals:\n%!";
@@ -84,8 +82,7 @@ let output_gdb (solver : Solver.solver) (status : Solver.status)
     (env : Env.t) ~func:(func : string) ~filename:(gdb_filename : string) : unit =
   match status with
   | Solver.SATISFIABLE ->
-    let model = Solver.get_model solver
-                |> Option.value_exn ?here:None ?error:None ?message:None in
+    let model = Constr.get_model_exn solver in
     let varmap = Env.get_var_map env in
     let module Target = (val target_of_arch (Env.get_arch env)) in
     let regmap = VarMap.filter_keys ~f:(Target.CPU.is_reg) varmap in

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -249,7 +249,7 @@ let set_fun_called (post : Constr.t) (env : Env.t) (tid : Tid.t) : Constr.t =
 
 let is_x86 (a : Arch.t) : bool =
   match a with
-  | `x86 | `x86_64 -> true
+  | #Arch.x86 -> true
   | _ -> false
 
 let increment_stack_ptr (post : Constr.t) (env : Env.t) : Constr.t * Env.t =

--- a/wp/lib/bap_wp/tests/unit/test_precondition.ml
+++ b/wp/lib/bap_wp/tests/unit/test_precondition.ml
@@ -1138,8 +1138,7 @@ let test_jmp_spec_reach_1 (test_ctx : test_ctxt) : unit =
   let result = Pre.check ~refute:false solver ctx pre in
   assert_equal ~ctxt:test_ctx ~printer:Z3.Solver.string_of_status
     Z3.Solver.SATISFIABLE result;
-  let model = Z3.Solver.get_model solver
-              |> Option.value_exn ?here:None ?error:None ?message:None in
+  let model = Constr.get_model_exn solver in
   assert_equal ~ctxt:test_ctx ~printer:Expr.to_string
     (jump_taken ctx) (cond_x |> mk_z3_expr env |> Constr.eval_model_exn model);
   assert_equal ~ctxt:test_ctx ~printer:Expr.to_string
@@ -1198,8 +1197,7 @@ let test_exclude_1 (test_ctx : test_ctxt) : unit =
     Z3.Solver.SATISFIABLE (Pre.check solver ctx pre);
   assert_equal ~ctxt:test_ctx ~printer:Z3.Solver.string_of_status
     Z3.Solver.SATISFIABLE (Pre.exclude solver ctx ~var:var ~pre:pre);
-  let model = Z3.Solver.get_model solver
-              |> Option.value_exn ?here:None ?error:None ?message:None in
+  let model = Constr.get_model_exn solver in
   let regs = model
              |> Z3.Model.get_decls
              |> List.map ~f:(fun v -> Z3.FuncDecl.apply v [])

--- a/wp/plugin/tests/test_wp.ml
+++ b/wp/plugin/tests/test_wp.ml
@@ -100,38 +100,39 @@ let test_update_num_unroll (new_unroll : int option) (test_ctx : test_ctxt) : un
     assert_equal ~ctxt:test_ctx ~cmp:Int.equal ~msg:fail_msg updated original
 
 let suite = [
-  "Equiv Null Check"              >:: test_compare_elf "equiv_null_check" "SAT!";
-  "Equiv Argc"                    >:: test_compare_elf "equiv_argc" "SAT!";
-  "Diff Ret Val"                  >:: test_compare_elf "diff_ret_val" "SAT!";
-  "Diff Pointer Val"              >:: test_compare_elf "diff_pointer_val" "SAT!";
-  "Switch Case Assignments"       >:: test_compare_elf "switch_case_assignments" "SAT!" ~func:"process_status";
-  "Switch Cases"                  >:: test_compare_elf "switch_cases" "SAT!" ~func:"process_message" ~check_calls:true;
-  "No Stack Protection"           >:: test_compare_elf "no_stack_protection" "SAT!" ~output_vars:"RSI,RAX";
-  "Retrowrite Stub"               >:: test_compare_elf "retrowrite_stub" "UNSAT!"
+  "Equiv Null Check"               >:: test_compare_elf "equiv_null_check" "SAT!";
+  "Equiv Argc"                     >:: test_compare_elf "equiv_argc" "SAT!";
+  "Diff Ret Val"                   >:: test_compare_elf "diff_ret_val" "SAT!";
+  "Diff Pointer Val"               >:: test_compare_elf "diff_pointer_val" "SAT!";
+  "Switch Case Assignments"        >:: test_compare_elf "switch_case_assignments" "SAT!" ~func:"process_status";
+  "Switch Cases"                   >:: test_compare_elf "switch_cases" "SAT!" ~func:"process_message" ~check_calls:true;
+  "No Stack Protection"            >:: test_compare_elf "no_stack_protection" "SAT!" ~output_vars:"RSI,RAX";
+  "Retrowrite Stub"                >:: test_compare_elf "retrowrite_stub" "UNSAT!"
     ~inline:true ~to_inline:"__afl_maybe_log";
-  "Retrowrite Stub: imply inline" >:: test_compare_elf "retrowrite_stub" "UNSAT!" ~to_inline:"__afl_maybe_log";
-  "Retrowrite Stub: inline all"   >:: test_compare_elf "retrowrite_stub" "UNSAT!" ~inline:true;
-  "Retrowrite Stub: Pop RSP"      >:: test_compare_elf "retrowrite_stub" "UNSAT!";
+  "Retrowrite Stub: imply inline"  >:: test_compare_elf "retrowrite_stub" "UNSAT!" ~to_inline:"__afl_maybe_log";
+  "Retrowrite Stub: inline all"    >:: test_compare_elf "retrowrite_stub" "UNSAT!" ~inline:true;
+  "Retrowrite Stub: Pop RSP"       >:: test_compare_elf "retrowrite_stub" "UNSAT!";
+  "Retrowrite Stub No Ret in Call" >:: test_compare_elf "retrowrite_stub_no_ret" "UNSAT!";
 
-  "Simple WP"                     >:: test_single_elf "simple_wp" "main" "SAT!";
-  "Verifier Assume SAT"           >:: test_single_elf "verifier_calls" "verifier_assume_sat" "SAT!";
-  "Verifier Assume UNSAT"         >:: test_single_elf "verifier_calls" "verifier_assume_unsat" "UNSAT!";
-  "Verifier Nondet"               >:: test_single_elf "verifier_calls" "verifier_nondet" "SAT!";
-  "Function Call"                 >:: test_single_elf "function_call" "main" "SAT!"
+  "Simple WP"                      >:: test_single_elf "simple_wp" "main" "SAT!";
+  "Verifier Assume SAT"            >:: test_single_elf "verifier_calls" "verifier_assume_sat" "SAT!";
+  "Verifier Assume UNSAT"          >:: test_single_elf "verifier_calls" "verifier_assume_unsat" "UNSAT!";
+  "Verifier Nondet"                >:: test_single_elf "verifier_calls" "verifier_nondet" "SAT!";
+  "Function Call"                  >:: test_single_elf "function_call" "main" "SAT!"
     ~inline:true ~to_inline:"foo";
-  "Function Call: imply inline"   >:: test_single_elf "function_call" "main" "SAT!" ~to_inline:"foo";
-  "Function Call: inline all"     >:: test_single_elf "function_call" "main" "SAT!" ~inline:true;
-  "Function Spec"                 >:: test_single_elf "function_spec" "main" "UNSAT!"
+  "Function Call: imply inline"    >:: test_single_elf "function_call" "main" "SAT!" ~to_inline:"foo";
+  "Function Call: inline all"      >:: test_single_elf "function_call" "main" "SAT!" ~inline:true;
+  "Function Spec"                  >:: test_single_elf "function_spec" "main" "UNSAT!"
     ~inline:true ~to_inline:"foo";
-  "Function Spec: imply inline"   >:: test_single_elf "function_spec" "main" "UNSAT!" ~to_inline:"foo";
-  "Function Spec: inline all "    >:: test_single_elf "function_spec" "main" "UNSAT!" ~inline:true;
-  "Function Spec: no inlining"    >:: test_single_elf "function_spec" "main" "SAT!" ~inline:false;
-  "Nested Function Calls"         >:: test_single_elf "nested_function_calls" "main" "SAT!"
+  "Function Spec: imply inline"    >:: test_single_elf "function_spec" "main" "UNSAT!" ~to_inline:"foo";
+  "Function Spec: inline all "     >:: test_single_elf "function_spec" "main" "UNSAT!" ~inline:true;
+  "Function Spec: no inlining"     >:: test_single_elf "function_spec" "main" "SAT!" ~inline:false;
+  "Nested Function Calls"          >:: test_single_elf "nested_function_calls" "main" "SAT!"
     ~inline:true ~to_inline:"foo,bar";
-  "Nested Calls: imply inline"    >:: test_single_elf "nested_function_calls" "main" "SAT!" ~to_inline:"foo,bar";
-  "Nested Calls: inline all"      >:: test_single_elf "nested_function_calls" "main" "SAT!" ~inline:true;
-  "User Defined Postcondition"    >:: test_single_elf "return_argc" "main" "SAT!" ~post:"(assert (= RAX0 #x0000000000000000))";
+  "Nested Calls: imply inline"     >:: test_single_elf "nested_function_calls" "main" "SAT!" ~to_inline:"foo,bar";
+  "Nested Calls: inline all"       >:: test_single_elf "nested_function_calls" "main" "SAT!" ~inline:true;
+  "User Defined Postcondition"     >:: test_single_elf "return_argc" "main" "SAT!" ~post:"(assert (= RAX0 #x0000000000000000))";
 
-  "Update Number of Unrolls"      >:: test_update_num_unroll (Some 3);
-  "Original Number of Unrolls"    >:: test_update_num_unroll None;
+  "Update Number of Unrolls"       >:: test_update_num_unroll (Some 3);
+  "Original Number of Unrolls"     >:: test_update_num_unroll None;
 ]

--- a/wp/resources/sample_binaries/retrowrite_stub_no_ret/.gitignore
+++ b/wp/resources/sample_binaries/retrowrite_stub_no_ret/.gitignore
@@ -1,0 +1,4 @@
+main_1
+main_1.bpj
+main_2
+main_2.bpj

--- a/wp/resources/sample_binaries/retrowrite_stub_no_ret/Makefile
+++ b/wp/resources/sample_binaries/retrowrite_stub_no_ret/Makefile
@@ -1,0 +1,26 @@
+BASE=main
+PROG1=$(BASE)_1
+PROG2=$(BASE)_2
+
+FLAGS=-nostdlib
+
+all: prog1 prog2
+
+prog1: $(PROG1) $(PROG1).bpj
+
+$(PROG1): $(PROG1).S
+	$(CC) $(FLAGS) -o $(PROG1) $(PROG1).S
+
+$(PROG1).bpj: $(PROG1)
+	bap --pass=save-project --save-project-filename=$(PROG1).bpj $(PROG1)
+
+prog2: $(PROG2) $(PROG2).bpj
+
+$(PROG2): $(PROG2).S
+	gcc -Wall $(FLAGS) -o $(PROG2) $(PROG2).S
+
+$(PROG2).bpj: $(PROG2)
+	bap --pass=save-project --save-project-filename=$(PROG2).bpj $(PROG2)
+
+clean:
+	rm -f $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj

--- a/wp/resources/sample_binaries/retrowrite_stub_no_ret/main_1.S
+++ b/wp/resources/sample_binaries/retrowrite_stub_no_ret/main_1.S
@@ -1,0 +1,13 @@
+.global _start
+
+.text
+
+main:
+    nop
+    ret
+
+_start:
+    call   main
+    mov    $0x0, %rbx
+    mov    $0x1, %rax
+    int    $0x80

--- a/wp/resources/sample_binaries/retrowrite_stub_no_ret/main_2.S
+++ b/wp/resources/sample_binaries/retrowrite_stub_no_ret/main_2.S
@@ -1,0 +1,32 @@
+.global _start
+
+.text
+
+__afl_maybe_log:
+    nop
+    jmp __afl_maybe_log_body
+
+__afl_maybe_log_body:
+    nop
+    ret
+
+main:
+    nop
+    lea    -0x98(%rsp), %rsp
+    mov    %rdx, (%rsp)
+    mov    %rcx, 0x8(%rsp)
+    mov    %rax, 0x10(%rsp)
+    mov    $0x8c8a, %rcx
+    call   __afl_maybe_log
+    mov    0x10(%rsp), %rax
+    mov    0x8(%rsp), %rcx
+    mov    (%rsp), %rdx
+    lea    0x98(%rsp), %rsp
+    nop
+    ret
+
+_start:
+    call   main
+    mov    $0x0, %rbx
+    mov    $0x1, %rax
+    int    $0x80

--- a/wp/resources/sample_binaries/retrowrite_stub_no_ret/run_wp.sh
+++ b/wp/resources/sample_binaries/retrowrite_stub_no_ret/run_wp.sh
@@ -1,0 +1,18 @@
+set -x
+
+dummy_dir=../dummy
+
+compile () {
+  make
+}
+
+run () {
+  bap $dummy_dir/hello_world.out --pass=wp \
+    --wp-compare=true \
+    --wp-file1=main_1.bpj \
+    --wp-file2=main_2.bpj \
+    --wp-function=main \
+    --wp-inline=false
+}
+
+compile && run


### PR DESCRIPTION
Fixes a bug in `wp`, where we were looking at the target of a function call to determine how much to increment the stack pointer when visiting a call site. The correct behavior is to increment the stack pointer by 8 for the return address. We will have to update this in the future when we start supporting other architectures.