### PR TITLE
Pzucker/gdb mem

### DIFF
--- a/wp/lib/bap_wp/src/output.ml
+++ b/wp/lib/bap_wp/src/output.ml
@@ -133,12 +133,11 @@ let output_gdb (solver : Solver.solver) (status : Solver.status)
     Printf.printf "Z3 Version: %s\n" (Z3.Version.to_string);
     let model = Solver.get_model solver
                 |> Option.value_exn ?here:None ?error:None ?message:None in
-    Printf.printf "%s \n" (Z3.Model.to_string model);
     let option_mem_model = get_mem model in
     let varmap = Env.get_var_map env in 
 >>>>>>> 874382e... Tests and simple mem-model extractor for gdb
     let module Target = (val target_of_arch (Env.get_arch env)) in
-    let regmap = varmap in (* VarMap.filter_keys ~f:(Target.CPU.is_reg) varmap in *)
+    let regmap = VarMap.filter_keys ~f:(Target.CPU.is_reg) varmap in 
     let reg_val_map = VarMap.map ~f:(fun z3_reg -> Constr.eval_model_exn model z3_reg) regmap in
     Out_channel.with_file gdb_filename  ~f:(fun t ->
         Printf.fprintf t "break *%s\n" func; (* The "*" is necessary to break before some slight setup *)

--- a/wp/lib/bap_wp/src/output.ml
+++ b/wp/lib/bap_wp/src/output.ml
@@ -59,119 +59,43 @@ let format_model (model : Model.model) (env1 : Env.t) (_env2 : Env.t) : string =
   Format.flush_str_formatter ()
 
 
+type mem_model = {default : Z3.Expr.expr ; model : (Z3.Expr.expr * Z3.Expr.expr) list}
 
+(** [extract_array] takes a z3 expression that is a seqeunce of store and converts it into
+    a mem_model, which consists of a key/value association list and a default value *)
 
-let rec extract_array (e : Z3.Expr.expr) : (Z3.Expr.expr * Z3.Expr.expr) list  = 
-      let numargs = Z3.Expr.get_num_args e in
-      let args = Z3.Expr.get_args e in
-      let f_decl = Z3.Expr.get_func_decl e in
-      let f_name = Z3.FuncDecl.get_name f_decl |> Z3.Symbol.to_string in
-      Printf.printf "numargs : %d \n" numargs;
-      Printf.printf "symbol name %s \n" f_name;
-      if ((numargs = 3) && (f_name = "store"))
-      then begin 
-            let next_arr = List.nth_exn args 0 in
-            let key = List.nth_exn args 1 in
-            let value = List.nth_exn args 2 in
-            (( key , value ) :: (extract_array next_arr))
-            end
-      else if ((numargs = 1) && (f_name = "const")) then
-            let key = List.nth_exn args 0 in
-            [( key , key )]
-      else (Printf.printf "Unpexpected case destructing Z3 array: %s" f_name;
-           [])
+let extract_array (e : Z3.Expr.expr) : mem_model  = 
+      let rec extract_array' (partial_map : (Z3.Expr.expr * Z3.Expr.expr) list) (e : Z3.Expr.expr) : mem_model =
+          let numargs = Z3.Expr.get_num_args e in
+          let args = Z3.Expr.get_args e in
+          let f_decl = Z3.Expr.get_func_decl e in
+          let f_name = Z3.FuncDecl.get_name f_decl |> Z3.Symbol.to_string in
+          if ((numargs = 3) && (f_name = "store"))
+          then begin 
+                let next_arr = List.nth_exn args 0 in
+                let key = List.nth_exn args 1 in
+                let value = List.nth_exn args 2 in
+                extract_array' (( key , value ) :: partial_map) next_arr
+                end
+          else if ((numargs = 1) && (f_name = "const")) then begin
+                let key = List.nth_exn args 0 in
+                { default = key; model = List.rev partial_map}
+                end
+          else begin
+                Printf.printf "Unpexpected case destructing Z3 array: %s" f_name;
+                {default = e ; model = partial_map}
+                end
+      in
+      extract_array' [] e
 
 
 module F = Z3.Model.FuncInterp
 
-let get_mem (m : Z3.Model.model) =
+let get_mem (m : Z3.Model.model) : mem_model =
    let decls = Z3.Model.get_decls m |> List.filter ~f:(fun decl -> (Z3.Symbol.to_string (Z3.FuncDecl.get_name decl)) = "mem0") in
    let f_decl = Option.value_exn (List.hd decls) in
    let f_interp = Option.value_exn (Z3.Model.get_const_interp m f_decl) in
    extract_array f_interp
-
-(*
-let get_mem (m : Z3.Model.model) =
-   Printf.printf "Printing func interps\n";
-   let decls = Z3.Model.get_decls m |> List.filter ~f:(fun decl -> (Z3.Symbol.to_string (Z3.FuncDecl.get_name decl)) = "mem0") in
-   List.iter decls ~f:(fun c ->  Printf.printf "func : %s\n " (Z3.FuncDecl.to_string c) ) ;
-   List.iter (Z3.Model.get_decls m) ~f:(fun c ->  Printf.printf "func : %s\n " (Z3.FuncDecl.to_string c) ) ;
-   Printf.printf "Here\n";
-   let f_decl = Option.value_exn (List.hd decls) in
-   Printf.printf "Here\n";
-   let f_interp = Option.value_exn ?message:(Some "getting interp") (Z3.Model.get_const_interp  m f_decl) in
-   let chewed = extract_array f_interp in
-   List.iter chewed ~f:(fun (key , value) -> Printf.printf "( %s, %s ) :: \n" (Z3.Expr.to_string key) (Z3.Expr.to_string value));            
-   Printf.printf "Printing const interps\n";
-   List.iter (Z3.Model.get_const_decls m) ~f:(fun c ->  Printf.printf  "const : %s\n " (Z3.FuncDecl.to_string c) ) ;
-   Printf.printf "Printing func decls\n";
-   List.iter (Z3.Model.get_func_decls m) ~f:(fun c ->  Printf.printf "func : %s\n " (Z3.FuncDecl.to_string c) ) ;
-   chewed
-  *)
-
-   (* 
-   List.iter decls ~f:(fun func -> 
-      Printf.printf "%s\n " (Z3.FuncDecl.to_string func);
-      let arr = Option.value_exn (Z3.Model.get_const_interp m func) ?message:(Some "getting lam") in
-      Printf.printf "%s \n" (Z3.Expr.to_string arr);
-
-      
-      (* let ctx = Z3.mk_context [] in  *)
-              (** goal is basically the entire problem *)
-              (* let g = Z3.Goal.mk_goal ctx true false false in *) (** what the hell are these parameters? *)
-      let solver = Z3.Solver.mk_solver ctx None in
-      let q = Z3.BitVector.mk_const_s ctx "q" 64 in
-      let bvsort64 = Z3.BitVector.mk_sort ctx 64 in 
-      let bvsort8 = Z3.BitVector.mk_sort ctx 8 in 
-      let f2 = Z3.FuncDecl.mk_func_decl_s ctx "f2" [bvsort64] bvsort8 in 
-      let for_e = Z3.Boolean.mk_eq ctx (Z3.FuncDecl.apply f2 [q]) (Z3.Z3Array.mk_select ctx arr q) in
-      let forall = Z3.Quantifier.mk_forall_const ctx [q] for_e None [] [] None None |> Z3.Quantifier.expr_of_quantifier in
-      let () = Z3.Solver.add solver [forall] in
-      match Z3.Solver.check solver [] with
-                     | Z3.Solver.UNKNOWN -> ()
-                     | Z3.Solver.UNSATISFIABLE -> ()
-                     | Z3.Solver.SATISFIABLE -> match Z3.Solver.get_model solver with
-                                                | Some(model) -> Printf.printf "sat\n";
-                                                                 let decls = Z3.Model.get_decls model in
-                                                                 List.iter decls ~f:(fun c ->  Printf.printf  "solution : %s\n " (Z3.FuncDecl.to_string c) );
-                                                                 let f_decl = Option.value_exn (List.hd decls) in 
-                                                                 let lam = Option.value_exn (Z3.Model.get_func_interp model f_decl) ?message:(Some "getting lam") in
-                                                                 Printf.printf "%s\n " (Z3.Model.FuncInterp.to_string lam);
-                                                                 ()
-
-
-                                                                 
-                                                | None -> ()
-                      
-      *)
-       
-      (*
-      let lam = Option.value_exn (Z3.Model.get_const_interp m func) ?message:(Some "getting lam") in
-      Printf.printf "%s\n " (Z3.Expr.to_string lam);
-      let func = Z3.Expr.get_func_decl lam in 
-      Printf.printf "%s\n " (Z3.FuncDecl.to_string func); *)
-      (* let interp = Option.value_exn (Z3.Model.get_func_interp m func) ?message:(Some "getting interp")  in 
-      Printf.printf "Makde it this far";
-      let entries = F.get_entries interp in 
-      List.iter entries ~f:(fun entry -> Printf.printf "%s\n" (F.FuncEntry.to_string entry))*)
-
-
-
-
-   (**
-   
-  getconstinterp:
-   Z3.Error("Non-zero arity functions and arrays have FunctionInterpretations as a model. Use FuncInterp.")
-    getfuncinterp:
-    Z3.Error("Argument was not an array constant")
-
-   Z3.Boolean.is_ite
-
-(define-fun mem0 () (Array (_ BitVec 64) (_ BitVec 8))
-  (lambda ((x!1 (_ BitVec 64))) (ite (= x!1 #x0000000000000000) #x03 #x00)))
-
-    *)
-
 
 
 let print_result (solver : Solver.solver) (status : Solver.status)
@@ -219,12 +143,8 @@ let output_gdb (solver : Solver.solver) (status : Solver.status)
             let hex_value = expr_to_hex data in
             Printf.fprintf t "set $%s = %s \n" (String.lowercase (Var.name key)) hex_value;
         );
-        List.iter mem_model ~f:(fun (addr,value) -> 
+        List.iter mem_model.model ~f:(fun (addr,value) -> 
             Printf.fprintf t "set {int}%s = %s \n" (expr_to_hex addr) (expr_to_hex value)  );
         ()
     )
   | _ -> ()
-
-(*
-set {int}0x83040 = 4
- *)

--- a/wp/lib/bap_wp/src/output.ml
+++ b/wp/lib/bap_wp/src/output.ml
@@ -138,7 +138,7 @@ let output_gdb (solver : Solver.solver) (status : Solver.status)
     let reg_val_map = VarMap.map ~f:(fun z3_reg -> Constr.eval_model_exn model z3_reg) regmap in
     Out_channel.with_file gdb_filename  ~f:(fun t ->
         Printf.fprintf t "break *%s\n" func; (* The "*" is necessary to break before some slight setup *)
-        Printf.fprintf t "start\n";
+        Printf.fprintf t "run\n";
         VarMap.iteri reg_val_map ~f:(fun ~key ~data -> 
             let hex_value = expr_to_hex data in
             Printf.fprintf t "set $%s = %s \n" (String.lowercase (Var.name key)) hex_value;

--- a/wp/lib/bap_wp/src/output.ml
+++ b/wp/lib/bap_wp/src/output.ml
@@ -131,16 +131,9 @@ let output_gdb (solver : Solver.solver) (status : Solver.status)
     (env : Env.t) ~func:(func : string) ~filename:(gdb_filename : string) : unit =
   match status with
   | Solver.SATISFIABLE ->
-<<<<<<< HEAD
     let model = Constr.get_model_exn solver in
-    let varmap = Env.get_var_map env in
-=======
-    Printf.printf "Z3 Version: %s\n" (Z3.Version.to_string);
-    let model = Solver.get_model solver
-                |> Option.value_exn ?here:None ?error:None ?message:None in
     let option_mem_model = get_mem model env in
-    let varmap = Env.get_var_map env in 
->>>>>>> 874382e... Tests and simple mem-model extractor for gdb
+    let varmap = Env.get_var_map env in
     let module Target = (val target_of_arch (Env.get_arch env)) in
     let regmap = VarMap.filter_keys ~f:(Target.CPU.is_reg) varmap in 
     let reg_val_map = VarMap.map ~f:(fun z3_reg -> Constr.eval_model_exn model z3_reg) regmap in

--- a/wp/lib/bap_wp/src/output.mli
+++ b/wp/lib/bap_wp/src/output.mli
@@ -40,4 +40,9 @@ val print_result : Z3.Solver.solver -> Z3.Solver.status -> Constr.t
 (** Prints to file a gdb script that will fill the appropriate registers with the countermodel *)
 val output_gdb : Z3.Solver.solver -> Z3.Solver.status -> Env.t -> func:string -> filename:string -> unit
 
-val extract_array : Z3.Expr.expr -> (Z3.Expr.expr * Z3.Expr.expr) list 
+type mem_model = {default : Z3.Expr.expr ; model : (Z3.Expr.expr * Z3.Expr.expr) list}
+
+(** [extract_array] takes a z3 expression that is a seqeunce of store and converts it into
+    a mem_model, which consists of a key/value association list and a default value *)
+
+val extract_array : Z3.Expr.expr -> mem_model

--- a/wp/lib/bap_wp/src/output.mli
+++ b/wp/lib/bap_wp/src/output.mli
@@ -40,9 +40,12 @@ val print_result : Z3.Solver.solver -> Z3.Solver.status -> Constr.t
 (** Prints to file a gdb script that will fill the appropriate registers with the countermodel *)
 val output_gdb : Z3.Solver.solver -> Z3.Solver.status -> Env.t -> func:string -> filename:string -> unit
 
-type mem_model = {default : Z3.Expr.expr ; model : (Z3.Expr.expr * Z3.Expr.expr) list}
+(** [mem_model] The default value stores the final else branch of a memory model. The model holds an association list of addresses and
+    values held at those adresses. *)
+
+type mem_model = {default : Constr.z3_expr ; model : (Constr.z3_expr * Constr.z3_expr) list}
 
 (** [extract_array] takes a z3 expression that is a seqeunce of store and converts it into
     a mem_model, which consists of a key/value association list and a default value *)
 
-val extract_array : Z3.Expr.expr -> mem_model
+val extract_array : Constr.z3_expr -> mem_model

--- a/wp/lib/bap_wp/src/output.mli
+++ b/wp/lib/bap_wp/src/output.mli
@@ -39,3 +39,5 @@ val print_result : Z3.Solver.solver -> Z3.Solver.status -> Constr.t
 
 (** Prints to file a gdb script that will fill the appropriate registers with the countermodel *)
 val output_gdb : Z3.Solver.solver -> Z3.Solver.status -> Env.t -> func:string -> filename:string -> unit
+
+val extract_array : Z3.Expr.expr -> (Z3.Expr.expr * Z3.Expr.expr) list 

--- a/wp/lib/bap_wp/src/output.mli
+++ b/wp/lib/bap_wp/src/output.mli
@@ -45,7 +45,7 @@ val output_gdb : Z3.Solver.solver -> Z3.Solver.status -> Env.t -> func:string ->
 
 type mem_model = {default : Constr.z3_expr ; model : (Constr.z3_expr * Constr.z3_expr) list}
 
-(** [extract_array] takes a z3 expression that is a seqeunce of store and converts it into
+(** [extract_array] takes a z3 expression that is a sequence of stores and converts it into
     a mem_model, which consists of a key/value association list and a default value *)
 
 val extract_array : Constr.z3_expr -> mem_model

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -835,7 +835,12 @@ let check ?refute:(refute = true) (solver : Solver.solver) (ctx : Z3.context)
     else
       pre'
   in
+<<<<<<< HEAD
   Solver.check solver [is_correct]
+=======
+  let () = Z3.Solver.add solver [is_correct] in
+  Z3.Solver.check solver []
+>>>>>>> 874382e... Tests and simple mem-model extractor for gdb
 
 let exclude (solver : Solver.solver) (ctx : Z3.context) ~var:(var : Constr.z3_expr)
     ~pre:(pre : Constr.t) : Solver.status =

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -835,12 +835,8 @@ let check ?refute:(refute = true) (solver : Solver.solver) (ctx : Z3.context)
     else
       pre'
   in
-<<<<<<< HEAD
-  Solver.check solver [is_correct]
-=======
   let () = Z3.Solver.add solver [is_correct] in
   Z3.Solver.check solver []
->>>>>>> 874382e... Tests and simple mem-model extractor for gdb
 
 let exclude (solver : Solver.solver) (ctx : Z3.context) ~var:(var : Constr.z3_expr)
     ~pre:(pre : Constr.t) : Solver.status =

--- a/wp/lib/bap_wp/tests/unit/test.ml
+++ b/wp/lib/bap_wp/tests/unit/test.ml
@@ -15,7 +15,7 @@ open OUnit2
 
 let suite =
   "Unit Tests" >::: [
-    "Precondition" >::: Test_precondition.suite; 
+    "Precondition" >::: Test_precondition.suite;
     "Compare"      >::: Test_compare.suite;
     "Constraint"   >::: Test_constraint.suite;
     "Output"       >::: Test_output.suite; 

--- a/wp/lib/bap_wp/tests/unit/test.ml
+++ b/wp/lib/bap_wp/tests/unit/test.ml
@@ -15,9 +15,10 @@ open OUnit2
 
 let suite =
   "Unit Tests" >::: [
-    "Precondition" >::: Test_precondition.suite;
+    "Precondition" >::: Test_precondition.suite; 
     "Compare"      >::: Test_compare.suite;
     "Constraint"   >::: Test_constraint.suite;
+    "Output"       >::: Test_output.suite; 
   ]
 
 let _ = run_test_tt_main suite

--- a/wp/lib/bap_wp/tests/unit/test_output.ml
+++ b/wp/lib/bap_wp/tests/unit/test_output.ml
@@ -25,7 +25,7 @@ let test_get_model (test_ctx : test_ctxt) : unit =
                             let f_decl = Option.value_exn (List.hd decls) in
                             let f_interp = Option.value_exn (Z3.Model.get_const_interp model f_decl) in
                             let mem_model = extract_array f_interp in
-                            assert_equal (List.hd_exn mem_model) (three,four) ~ctxt:test_ctx ~cmp:(fun (e1,e2) (n1,n2) -> (Z3.Expr.equal e1 n1) && (Z3.Expr.equal e2 n2) )
+                            assert_equal (List.hd_exn mem_model.model) (three,four) ~ctxt:test_ctx ~cmp:(fun (e1,e2) (n1,n2) -> (Z3.Expr.equal e1 n1) && (Z3.Expr.equal e2 n2) )
                     | None       -> assert_failure "No Model Found"
 
 let suite = [

--- a/wp/lib/bap_wp/tests/unit/test_output.ml
+++ b/wp/lib/bap_wp/tests/unit/test_output.ml
@@ -1,0 +1,33 @@
+open !Core_kernel
+open OUnit2
+open Bap_wp
+open Output
+
+
+
+let test_get_model (test_ctx : test_ctxt) : unit =
+    let ctx = Z3.mk_context [] in 
+    let solver = Z3.Solver.mk_solver ctx None in 
+    let three = Z3.BitVector.mk_numeral ctx "3" 64 in
+    let four = Z3.BitVector.mk_numeral ctx "4" 64 in
+    let bvsort = Z3.BitVector.mk_sort ctx 64 in 
+    let f =  Z3.Z3Array.mk_const_s ctx "f" bvsort bvsort in 
+    let c' = Z3.Boolean.mk_eq ctx (Z3.Z3Array.mk_select ctx f three) four in
+    let c'' = Z3.Boolean.mk_eq ctx (Z3.Z3Array.mk_select ctx f four) three in
+    let () = Z3.Solver.add solver [c' ; c''] in
+    match Z3.Solver.check solver [] with
+        | Z3.Solver.UNKNOWN -> assert_failure "Solver Status UNKNOWN"
+        | Z3.Solver.UNSATISFIABLE -> assert_failure "Solver Status UNSAT"
+        | Z3.Solver.SATISFIABLE ->
+              match Z3.Solver.get_model solver with
+                    | Some(model) -> 
+                            let decls = Z3.Model.get_decls model |> List.filter ~f:(fun decl -> (Z3.Symbol.to_string (Z3.FuncDecl.get_name decl)) = "f") in
+                            let f_decl = Option.value_exn (List.hd decls) in
+                            let f_interp = Option.value_exn (Z3.Model.get_const_interp model f_decl) in
+                            let mem_model = extract_array f_interp in
+                            assert_equal (List.hd_exn mem_model) (three,four) ~ctxt:test_ctx ~cmp:(fun (e1,e2) (n1,n2) -> (Z3.Expr.equal e1 n1) && (Z3.Expr.equal e2 n2) )
+                    | None       -> assert_failure "No Model Found"
+
+let suite = [
+  "Get Memory Model"              >:: test_get_model;
+]

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -106,7 +106,7 @@ let analyze_proj (proj : project) (var_gen : Env.var_gen) (ctx : Z3.context)
   let pre, env' = Pre.visit_sub env post main_sub in
   Format.printf "\nSub:\n%s\nPre:\n%a\n%!"
     (Sub.to_string main_sub) Constr.pp_constr pre;
-  (pre, env', env)
+  (pre, env, env')
 
 let compare_projs (proj : project) (file1: string) (file2 : string)
     (var_gen : Env.var_gen) (ctx : Z3.context)


### PR DESCRIPTION
After a long journey of Z3 build troubles and api confusion, adds the ability to extract memory models for gdb-output. Having said that, they are totally faulty and case gdb to fail immediately when they try to write to memory locations it has no access to.

I am concerned about what it will do if it encounters a lambda model, but it is profitable to open a pull review at this point I think.