### PR TITLE
Fortunac/registers along path

### DIFF
--- a/wp/lib/bap_wp/src/constraint.ml
+++ b/wp/lib/bap_wp/src/constraint.ml
@@ -159,9 +159,12 @@ let get_refuted_goals (constr : t) (solver : Z3.Solver.solver)
     | ITE (jmp, cond, c1, c2) ->
       let cond_val = Expr.substitute cond olds news in
       let cond_res = eval_model_exn model cond_val in
+      (* FIXME: Still getting some values that don't necessarily match up with
+         their values when running the program in GDB. *)
       let registers =
         List.fold (List.zip_exn olds news) ~init:[]
           ~f:(fun regs (reg, value) ->
+              (* Manually removing mem from the list of variables being updates. *)
               if String.is_prefix ~prefix:"mem" (Expr.to_string reg) then
                 regs
               else

--- a/wp/lib/bap_wp/src/constraint.mli
+++ b/wp/lib/bap_wp/src/constraint.mli
@@ -112,8 +112,12 @@ val substitute : t -> z3_expr list -> z3_expr list -> t
 (** [substitute_one c e d] is equivalent to [substitute c [e] [d]]. *)
 val substitute_one : t -> z3_expr -> z3_expr -> t
 
-(** Obtains a list of goals that have been refuted by a Z3 model. *)
-val get_refuted_goals : t -> Z3.Solver.solver -> Z3.context -> refuted_goal Bap.Std.Seq.t
+(** [get_refuted_goals ~filter c solver ctx] obtains a list of goals that have
+    been refuted by a Z3 model. The register map in the refuted goal will not
+    save any z3 variable in [filter]. *)
+val get_refuted_goals :
+  ?filter_out:z3_expr list -> t -> Z3.Solver.solver -> Z3.context ->
+  refuted_goal Bap.Std.Seq.t
 
 (** Evaluates an expression in the current model. May raise an error if
     evaluation fails in the case that the argument contains quantifiers, is

--- a/wp/lib/bap_wp/src/constraint.mli
+++ b/wp/lib/bap_wp/src/constraint.mli
@@ -47,6 +47,10 @@ type goal
     boolean, which marks whether the path was taken or not. *)
 type path = bool Bap.Std.Jmp.Map.t
 
+type reg_map = (z3_expr * z3_expr) list Bap.Std.Jmp.Map.t
+
+type refuted_goal = { goal : goal; path : path; reg_map : reg_map }
+
 (** [mk_goal name e] creates a goal using a Z3 boolean expression and
     a name. *)
 val mk_goal : string -> z3_expr -> goal
@@ -59,10 +63,6 @@ val path_to_string : path -> string
 
 (** Pretty prints a path. *)
 val pp_path : Format.formatter -> path -> unit
-
-(** Creates a string representation of a goal that has been refuted given the model.
-    This string shows the lhs and rhs of a goal that compares two values. *)
-val refuted_goal_to_string : goal -> Z3.Model.model -> string
 
 (** Obtains a goal's tagged name. *)
 val get_goal_name : goal -> string
@@ -101,14 +101,9 @@ val substitute : t -> z3_expr list -> z3_expr list -> t
 (** [substitute_one c e d] is equivalent to [substitute c [e] [d]]. *)
 val substitute_one : t -> z3_expr -> z3_expr -> t
 
-(** Obtains a list of pairs of goals and a path to that goal that have
-    been refuted by a Z3 model. *)
-val get_refuted_goals_and_paths :
-  t -> Z3.Solver.solver -> Z3.context -> (goal * path) Core_kernel.Sequence.t
-
 (** Obtains a list of goals that have been refuted by a Z3 model. *)
 val get_refuted_goals :
-  t -> Z3.Solver.solver -> Z3.context -> goal Core_kernel.Sequence.t
+  t -> Z3.Solver.solver -> Z3.context -> refuted_goal Bap.Std.Seq.t
 
 (** Evaluates an expression in the current model. May raise an error if
     evaluation fails in the case that the argument contains quantifiers, is

--- a/wp/lib/bap_wp/src/constraint.mli
+++ b/wp/lib/bap_wp/src/constraint.mli
@@ -51,7 +51,7 @@ type path = bool Bap.Std.Jmp.Map.t
     in the program. *)
 type reg_map = (z3_expr * z3_expr) list Bap.Std.Jmp.Map.t
 
-(** A goal that has been refuted by th Z3 model during WP analysis. Contains
+(** A goal that has been refuted by the Z3 model during WP analysis. Contains
     the path taken in the binary to reach the goal, as well as a map of register
     values at each jump in the path. *)
 type refuted_goal = { goal : goal; path : path; reg_map : reg_map }
@@ -107,8 +107,7 @@ val substitute : t -> z3_expr list -> z3_expr list -> t
 val substitute_one : t -> z3_expr -> z3_expr -> t
 
 (** Obtains a list of goals that have been refuted by a Z3 model. *)
-val get_refuted_goals :
-  t -> Z3.Solver.solver -> Z3.context -> refuted_goal Bap.Std.Seq.t
+val get_refuted_goals : t -> Z3.Solver.solver -> Z3.context -> refuted_goal Bap.Std.Seq.t
 
 (** Evaluates an expression in the current model. May raise an error if
     evaluation fails in the case that the argument contains quantifiers, is

--- a/wp/lib/bap_wp/src/constraint.mli
+++ b/wp/lib/bap_wp/src/constraint.mli
@@ -47,8 +47,13 @@ type goal
     boolean, which marks whether the path was taken or not. *)
 type path = bool Bap.Std.Jmp.Map.t
 
+(** A map containing a pair of registers and their values at a specific jump
+    in the program. *)
 type reg_map = (z3_expr * z3_expr) list Bap.Std.Jmp.Map.t
 
+(** A goal that has been refuted by th Z3 model during WP analysis. Contains
+    the path taken in the binary to reach the goal, as well as a map of register
+    values at each jump in the path. *)
 type refuted_goal = { goal : goal; path : path; reg_map : reg_map }
 
 (** [mk_goal name e] creates a goal using a Z3 boolean expression and

--- a/wp/lib/bap_wp/src/constraint.mli
+++ b/wp/lib/bap_wp/src/constraint.mli
@@ -47,14 +47,10 @@ type goal
     boolean, which marks whether the path was taken or not. *)
 type path = bool Bap.Std.Jmp.Map.t
 
-(** A map containing a pair of registers and their values at a specific jump
-    in the program. *)
-type reg_map = (z3_expr * z3_expr) list Bap.Std.Jmp.Map.t
-
 (** A goal that has been refuted by the Z3 model during WP analysis. Contains
     the path taken in the binary to reach the goal, as well as a map of register
     values at each jump in the path. *)
-type refuted_goal = { goal : goal; path : path; reg_map : reg_map }
+type refuted_goal
 
 (** [mk_goal name e] creates a goal using a Z3 boolean expression and
     a name. *)
@@ -66,8 +62,18 @@ val goal_to_string : goal -> string
 (** Creates a string representation of a path. *)
 val path_to_string : path -> string
 
-(** Pretty prints a path. *)
-val pp_path : Format.formatter -> path -> unit
+(** Creates a string representation of a mapping of BAP variables to their [z3_expr]s. *)
+val format_values : Format.formatter -> (Bap.Std.Var.t * z3_expr) list -> unit
+
+(** Creates a string representation of a goal that has been refuted given the model.
+    This string shows the lhs and rhs of a goal that compares two values. If print_path
+    is set, it also shows the path taken to reach the refuted goal and the register
+    values along that path. *)
+val format_refuted_goal :
+  refuted_goal -> Z3.Model.model -> z3_expr Bap.Std.Var.Map.t -> print_path:bool -> string
+
+(** Obtains the goal data type from a refuted goal. *)
+val goal_of_refuted_goal : refuted_goal -> goal
 
 (** Obtains a goal's tagged name. *)
 val get_goal_name : goal -> string

--- a/wp/lib/bap_wp/src/environment.ml
+++ b/wp/lib/bap_wp/src/environment.ml
@@ -318,3 +318,7 @@ let fold_fun_tids (env : t) ~init:(init : 'a)
     ~f:(f : key:string -> data:Tid.t -> 'a -> 'a) : 'a =
   StringMap.fold env.fun_name_tid ~init:init ~f:f
 
+let is_x86 (a : Arch.t) : bool =
+  match a with
+  | #Arch.x86 -> true
+  | _ -> false

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -175,6 +175,9 @@ val get_arch : t -> Bap.Std.Arch.t
 val fold_fun_tids :
   t -> init:'a -> f:(key:string -> data:Bap.Std.Tid.t -> 'a -> 'a) -> 'a
 
+(** Checks if the architecture is part of the x86 family. *)
+val is_x86 : Bap.Std.Arch.t -> bool
+
 (*-------- Z3 constant creation utilities ----------*)
 
 (** Create a constant Z3 expression of a type that corresponds to a bap type, where

--- a/wp/lib/bap_wp/src/output.ml
+++ b/wp/lib/bap_wp/src/output.ml
@@ -65,9 +65,11 @@ let format_registers (fmt : Format.formatter) (regs : Constr.reg_map) (jmp : Jmp
     let var_map = Env.get_var_map env in
     let reg_vals = VarMap.fold var_map ~init:[]
         ~f:(fun ~key ~data pairs ->
-            let regs = List.filter_map regs ~f:(fun (r, value) ->
+            let regs = List.find_map regs ~f:(fun (r, value) ->
                 if Expr.equal data r then Some (key, value) else None) in
-            List.append pairs regs)
+            match regs with
+            | None -> pairs
+            | Some r -> r :: pairs)
     in
     format_values fmt reg_vals;
     Format.fprintf fmt "\n%!"
@@ -84,7 +86,7 @@ let format_path (fmt : Format.formatter) (p : Constr.path) (regs : Constr.reg_ma
         let taken_str = if taken then "(taken)" else "(not taken)" in
         begin
           match Term.get_attr jmp address with
-          | None -> Format.fprintf fmt "\t%s %s\n%!" jmp_str taken_str
+          | None -> Format.fprintf fmt "\t%s %s (Address not found) \n%!" jmp_str taken_str
           | Some addr ->
             Format.fprintf fmt "\t%s %s (Address: %s)\n%!"
               jmp_str taken_str (Addr.to_string addr)

--- a/wp/lib/bap_wp/src/output.ml
+++ b/wp/lib/bap_wp/src/output.ml
@@ -27,15 +27,6 @@ module Constr = Constraint
 
 module VarMap = Var.Map
 
-let format_values (fmt : Format.formatter) (vals : (Var.t * Constr.z3_expr) list) : unit =
-  List.iter vals
-    ~f:(fun (var, value) ->
-        let var_str = Var.to_string var in
-        let pad_size = Int.max (5 - (String.length var_str)) 1 in
-        let pad = String.make pad_size ' ' in
-        Format.fprintf fmt
-          "\t%s%s|->  @[%s@]@\n" var_str pad (Expr.to_string value))
-
 let format_model (model : Model.model) (env1 : Env.t) (_env2 : Env.t) : string =
   let var_map = Env.get_var_map env1 in
   let key_val = Env.EnvMap.fold var_map ~init:[]
@@ -44,7 +35,7 @@ let format_model (model : Model.model) (env1 : Env.t) (_env2 : Env.t) : string =
           (key, value)::pairs)
   in
   let fmt = Format.str_formatter in
-  format_values fmt key_val;
+  Constr.format_values fmt key_val;
   let fun_defs =
     model
     |> Model.get_func_decls
@@ -57,115 +48,50 @@ let format_model (model : Model.model) (env1 : Env.t) (_env2 : Env.t) : string =
       Format.fprintf fmt "%s  %s\n" (Fun.to_string def) (FInterp.to_string interp));
   Format.flush_str_formatter ()
 
-let format_registers (fmt : Format.formatter) (regs : Constr.reg_map) (jmp : Jmp.t)
-    (env : Env.t) : unit =
-  match Jmp.Map.find regs jmp with
-  | None -> ()
-  | Some regs ->
-    let var_map = Env.get_var_map env in
-    let reg_vals = VarMap.fold var_map ~init:[]
-        ~f:(fun ~key ~data pairs ->
-            match List.find regs ~f:(fun (r, _) -> Expr.equal data r) with
-            | None -> pairs
-            | Some (_, value) -> (key, value) :: pairs)
-    in
-    format_values fmt reg_vals;
-    Format.fprintf fmt "\n%!"
-
-let format_path (fmt : Format.formatter) (p : Constr.path) (regs : Constr.reg_map)
-    (env : Env.t) : unit =
-  Format.fprintf fmt "\n\tPath:\n%!";
-  Jmp.Map.iteri p
-    ~f:(fun ~key:jmp ~data:taken ->
-        let jmp_str =
-          jmp
-          |> Jmp.to_string
-          |> String.substr_replace_first ~pattern:"\n" ~with_:"" in
-        let taken_str = if taken then "(taken)" else "(not taken)" in
-        begin
-          match Term.get_attr jmp address with
-          | None -> Format.fprintf fmt "\t%s %s (Address not found)\n%!" jmp_str taken_str
-          | Some addr ->
-            Format.fprintf fmt "\t%s %s (Address: %s)\n%!"
-              jmp_str taken_str (Addr.to_string addr)
-        end;
-        format_registers fmt regs jmp env)
-
-let format_goal (fmt : Format.formatter) (g : Constr.goal) (model : Model.model) : unit =
-  let goal_name = Constr.get_goal_name g in
-  let goal_val = Constr.get_goal_val g in
-  Format.fprintf fmt "%s:" goal_name;
-  if Bool.is_eq goal_val then
-    begin
-      let args = Expr.get_args goal_val in
-      Format.fprintf fmt "\n\tConcrete values: = ";
-      List.iter args ~f:(fun arg ->
-          let value = Constr.eval_model_exn model arg in
-          Format.fprintf fmt "%s " (Expr.to_string value));
-      Format.fprintf fmt "\n\tZ3 Expression: = ";
-      List.iter args ~f:(fun arg ->
-          let simplified = Expr.simplify arg None in
-          Format.fprintf fmt "%s " (Expr.to_string simplified));
-    end
-  else
-    Format.fprintf fmt "\n\tZ3 Expression: %s"
-      (Expr.to_string (Expr.simplify goal_val None))
-
-let format_refuted_goal (rg : Constr.refuted_goal) (model : Model.model) (env : Env.t)
-    ~print_path:(print_path : bool) : string =
-  let fmt = Format.str_formatter in
-  format_goal fmt rg.goal model;
-  if print_path then format_path fmt rg.path rg.reg_map env;
-  Format.flush_str_formatter ()
-
 type mem_model = {default : Constr.z3_expr ; model : (Constr.z3_expr * Constr.z3_expr) list}
 
 (** [extract_array] takes a z3 expression that is a seqeunce of store and converts it into
     a mem_model, which consists of a key/value association list and a default value *)
 
 let extract_array (e : Constr.z3_expr) : mem_model  = 
-      let rec extract_array' (partial_map : (Constr.z3_expr * Constr.z3_expr) list) (e : Constr.z3_expr) : mem_model =
-          let numargs = Z3.Expr.get_num_args e in
-          let args = Z3.Expr.get_args e in
-          let f_decl = Z3.Expr.get_func_decl e in
-          let f_name = Z3.FuncDecl.get_name f_decl |> Z3.Symbol.to_string in
-          if ( Int.(numargs = 3) && String.(f_name = "store"))
-          then begin 
-                let next_arr = List.nth_exn args 0 in
-                let key = List.nth_exn args 1 in
-                let value = List.nth_exn args 2 in
-                extract_array' (( key , value ) :: partial_map) next_arr
-                end
-          else if ( Int.(numargs = 1) && String.(f_name = "const")) then begin
-                let key = List.nth_exn args 0 in
-                { default = key; model = List.rev partial_map}
-                end
-          else begin
-                warning "Unexpected case destructing Z3 array: %s" (Z3.Expr.to_string e);
-                {default = e ; model = partial_map}
-                end
-      in
-      extract_array' [] e
-
-let is_x86 (a : Arch.t) : bool =
-  match a with
-  | #Arch.x86 -> true
-  | _ -> false
+  let rec extract_array' (partial_map : (Constr.z3_expr * Constr.z3_expr) list) (e : Constr.z3_expr) : mem_model =
+    let numargs = Z3.Expr.get_num_args e in
+    let args = Z3.Expr.get_args e in
+    let f_decl = Z3.Expr.get_func_decl e in
+    let f_name = Z3.FuncDecl.get_name f_decl |> Z3.Symbol.to_string in
+    if ( Int.(numargs = 3) && String.(f_name = "store"))
+    then begin
+      let next_arr = List.nth_exn args 0 in
+      let key = List.nth_exn args 1 in
+      let value = List.nth_exn args 2 in
+      extract_array' (( key , value ) :: partial_map) next_arr
+    end
+    else if ( Int.(numargs = 1) && String.(f_name = "const")) then begin
+      let key = List.nth_exn args 0 in
+      { default = key; model = List.rev partial_map}
+    end
+    else begin
+      warning "Unexpected case destructing Z3 array: %s" (Z3.Expr.to_string e);
+      {default = e ; model = partial_map}
+    end
+  in
+  extract_array' [] e
 
 let get_mem (m : Z3.Model.model) (env : Env.t) : mem_model option =
-    let arch = Env.get_arch env in
-    if is_x86 arch then
+  let arch = Env.get_arch env in
+  if Env.is_x86 arch then
     begin
       let module Target = (val target_of_arch arch) in
       let mem, _ = Env.get_var env Target.CPU.mem in
       Some (extract_array (Constr.eval_model_exn m mem))
     end
-    else
-      None
+  else
+    None
 
 let print_result (solver : Solver.solver) (status : Solver.status) (goals: Constr.t)
     ~print_path:(print_path : bool)  ~orig:(env1 : Env.t) ~modif:(env2 : Env.t) : unit =
   let ctx = Env.get_context env1 in
+  let var_map = Env.get_var_map env1 in
   match status with
   | Solver.UNSATISFIABLE -> Format.printf "\nUNSAT!\n%!"
   | Solver.UNKNOWN -> Format.printf "\nUNKNOWN!\n%!"
@@ -176,7 +102,8 @@ let print_result (solver : Solver.solver) (status : Solver.status) (goals: Const
     let refuted_goals = Constr.get_refuted_goals goals solver ctx in
     Format.printf "\nRefuted goals:\n%!";
     Seq.iter refuted_goals ~f:(fun goal ->
-        Format.printf "%s\n%!" (format_refuted_goal goal model env1 ~print_path))
+        Format.printf "%s\n%!"
+          (Constr.format_refuted_goal goal model var_map ~print_path))
 
 (** [output_gdb] is similar to [print_result] except chews on the model and outputs a gdb script with a
     breakpoint at the subroutine and fills the appropriate registers *)
@@ -199,11 +126,11 @@ let output_gdb (solver : Solver.solver) (status : Solver.status)
         VarMap.iteri reg_val_map ~f:(fun ~key ~data -> 
             let hex_value = expr_to_hex data in
             Printf.fprintf t "set $%s = %s \n" (String.lowercase (Var.name key)) hex_value;
-        );
+          );
         match option_mem_model with
         | None -> ()
         | Some mem_model ->  List.iter mem_model.model ~f:(fun (addr,value) -> 
-                             Printf.fprintf t "set {int}%s = %s \n" (expr_to_hex addr) (expr_to_hex value)  );
-                             ()
-    )
+            Printf.fprintf t "set {int}%s = %s \n" (expr_to_hex addr) (expr_to_hex value)  );
+          ()
+      )
   | _ -> ()

--- a/wp/lib/bap_wp/src/output.mli
+++ b/wp/lib/bap_wp/src/output.mli
@@ -13,13 +13,29 @@
 
 (**
 
-   This module exports types and utilities to process and report results found uisng the wp plugin.
+   This module exports types and utilities to process and report results found
+   using the WP plugin.
+
+   The report contains information about the result of the WP analysis, and in
+   the case the result is [SAT], prints out the model that contains the input
+   register and memory values that result in the program refuting a goal, the path
+   taken to the refuted goal, and the register values at each jump in the path.
 
 *)
 
 module Env = Environment
 
 module Constr = Constraint
+
+(** Creates a string representation of a Z3 Model where duplicate entries representing
+    the same registers are removed. *)
+val format_model : Z3.Model.model -> Env.t -> Env.t -> string
+
+(* Creates a string representation of a goal that has been refuted given the model.
+   This string shows the lhs and rhs of a goal that compares two values. It also
+   shows the path taken to reach the refuted goal, along with the register values
+   along that path. *)
+val format_refuted_goal : Constr.refuted_goal -> Z3.Model.model -> Env.t -> string
 
 (** Prints out the result from check, and if the result is [SAT], generate a model that
     represents the registers and memory values that lead to a specific program state. *)

--- a/wp/lib/bap_wp/src/output.mli
+++ b/wp/lib/bap_wp/src/output.mli
@@ -31,27 +31,29 @@ module Constr = Constraint
     the same registers are removed. *)
 val format_model : Z3.Model.model -> Env.t -> Env.t -> string
 
-(* Creates a string representation of a goal that has been refuted given the model.
-   This string shows the lhs and rhs of a goal that compares two values. It also
-   shows the path taken to reach the refuted goal, along with the register values
-   along that path. *)
-val format_refuted_goal : Constr.refuted_goal -> Z3.Model.model -> Env.t -> string
+(** Creates a string representation of a goal that has been refuted given the model.
+    This string shows the lhs and rhs of a goal that compares two values. If print_path
+    is set, it also shows the path taken to reach the refuted goal and the register
+    values along that path. *)
+val format_refuted_goal :
+  Constr.refuted_goal -> Z3.Model.model -> Env.t -> print_path:bool -> string
 
 (** Prints out the result from check, and if the result is [SAT], generate a model that
-    represents the registers and memory values that lead to a specific program state. *)
-val print_result : Z3.Solver.solver -> Z3.Solver.status -> Constr.t
-  -> orig:Env.t -> modif:Env.t -> unit
-
+    represents the registers and memory values that lead to a specific program state,
+    a list of goals that have been refuted, and if specified, the paths that lead to
+    the refuted goals. *)
+val print_result :
+  Z3.Solver.solver -> Z3.Solver.status -> Constr.t -> print_path:bool ->
+  orig:Env.t -> modif:Env.t -> unit
 
 (** Prints to file a gdb script that will fill the appropriate registers with the countermodel *)
-val output_gdb : Z3.Solver.solver -> Z3.Solver.status -> Env.t -> func:string -> filename:string -> unit
+val output_gdb :
+  Z3.Solver.solver -> Z3.Solver.status -> Env.t -> func:string -> filename:string -> unit
 
 (** [mem_model] The default value stores the final else branch of a memory model. The model holds an association list of addresses and
     values held at those adresses. *)
-
 type mem_model = {default : Constr.z3_expr ; model : (Constr.z3_expr * Constr.z3_expr) list}
 
 (** [extract_array] takes a z3 expression that is a sequence of stores and converts it into
     a mem_model, which consists of a key/value association list and a default value *)
-
 val extract_array : Constr.z3_expr -> mem_model

--- a/wp/lib/bap_wp/src/output.mli
+++ b/wp/lib/bap_wp/src/output.mli
@@ -17,16 +17,6 @@
 
 *)
 
-module Expr = Z3.Expr
-
-module Arith = Z3.Arithmetic
-
-module BV = Z3.BitVector
-
-module Bool = Z3.Boolean
-
-module Array = Z3.Z3Array
-
 module Env = Environment
 
 module Constr = Constraint

--- a/wp/lib/bap_wp/src/output.mli
+++ b/wp/lib/bap_wp/src/output.mli
@@ -27,17 +27,6 @@ module Env = Environment
 
 module Constr = Constraint
 
-(** Creates a string representation of a Z3 Model where duplicate entries representing
-    the same registers are removed. *)
-val format_model : Z3.Model.model -> Env.t -> Env.t -> string
-
-(** Creates a string representation of a goal that has been refuted given the model.
-    This string shows the lhs and rhs of a goal that compares two values. If print_path
-    is set, it also shows the path taken to reach the refuted goal and the register
-    values along that path. *)
-val format_refuted_goal :
-  Constr.refuted_goal -> Z3.Model.model -> Env.t -> print_path:bool -> string
-
 (** Prints out the result from check, and if the result is [SAT], generate a model that
     represents the registers and memory values that lead to a specific program state,
     a list of goals that have been refuted, and if specified, the paths that lead to

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -247,14 +247,9 @@ let set_fun_called (post : Constr.t) (env : Env.t) (tid : Tid.t) : Constr.t =
                                       Option.value_exn ?here:None ?error:None ?message:None) in
   Constr.substitute_one post fun_name (Bool.mk_true ctx)
 
-let is_x86 (a : Arch.t) : bool =
-  match a with
-  | #Arch.x86 -> true
-  | _ -> false
-
 let increment_stack_ptr (post : Constr.t) (env : Env.t) : Constr.t * Env.t =
   let arch = Env.get_arch env in
-  if is_x86 arch then
+  if Env.is_x86 arch then
     begin
       let module Target = (val target_of_arch arch) in
       let sp, env = Env.get_var env Target.CPU.sp in

--- a/wp/lib/bap_wp/tests/unit/test_constraint.ml
+++ b/wp/lib/bap_wp/tests/unit/test_constraint.ml
@@ -48,7 +48,7 @@ let test_get_refuted_goals (test_ctx : test_ctxt) : unit =
   let goals = Constr.get_refuted_goals clause solver ctx in
   Sequence.iter goals ~f:(fun g ->
       assert_equal ~ctxt:test_ctx ~printer:Expr.to_string ~cmp:Expr.equal
-        (Bool.mk_eq ctx x two) (Constr.get_goal_val g))
+        (Bool.mk_eq ctx x two) (Constr.get_goal_val g.goal))
 
 let test_get_refuted_goals_mem (test_ctx : test_ctxt) : unit =
   let ctx = Z3.mk_context [] in
@@ -71,7 +71,7 @@ let test_get_refuted_goals_mem (test_ctx : test_ctxt) : unit =
   let goals = Constr.get_refuted_goals constr solver ctx in
   Sequence.iter goals ~f:(fun g ->
       assert_equal ~ctxt:test_ctx ~printer:Expr.to_string ~cmp:Expr.equal
-        goal (Constr.get_goal_val g))
+        goal (Constr.get_goal_val g.goal))
 
 let test_substitute (test_ctx : test_ctxt) : unit =
   let ctx = Z3.mk_context [] in
@@ -111,7 +111,7 @@ let test_substitute_order (test_ctx : test_ctxt) : unit =
   let goals = Constr.get_refuted_goals pre solver ctx in
   Sequence.iter goals ~f:(fun g ->
       assert_equal ~ctxt:test_ctx ~printer:Expr.to_string ~cmp:Expr.equal
-        post_expr (Constr.get_goal_val g))
+        post_expr (Constr.get_goal_val g.goal))
 
 let suite = [
   "Get Refuted Goals"             >:: test_get_refuted_goals;

--- a/wp/lib/bap_wp/tests/unit/test_precondition.ml
+++ b/wp/lib/bap_wp/tests/unit/test_precondition.ml
@@ -28,8 +28,9 @@ module BV = Z3.BitVector
 
 (* To run these tests: `make test.unit` in bap_wp directory *)
 
-let assert_z3_result (test_ctx : test_ctxt) (z3_ctx : Z3.context) (body : string)
+let assert_z3_result (test_ctx : test_ctxt) (env : Env.t) (body : string)
     (post : Constr.t) (pre : Constr.t) (expected : Z3.Solver.status) : unit =
+  let z3_ctx = Env.get_context env in
   let solver = Z3.Solver.mk_simple_solver z3_ctx in
   let result = Pre.check solver z3_ctx pre in
   assert_equal ~ctxt:test_ctx
@@ -37,7 +38,7 @@ let assert_z3_result (test_ctx : test_ctxt) (z3_ctx : Z3.context) (body : string
     ~pp_diff:(fun ff (exp, real) ->
         Format.fprintf ff "\n\nPost:\n%a\n\nAnalyzing:\n%sPre:\n%a\n\n%!"
           Constr.pp_constr post body Constr.pp_constr pre;
-        print_z3_model ff solver exp real z3_ctx pre)
+        print_z3_model solver exp real pre ~orig:env ~modif:env)
     expected result
 
 
@@ -48,7 +49,7 @@ let test_empty_block (test_ctx : test_ctxt) : unit =
   let block = Blk.create () in
   let post = true_constr ctx in
   let pre, _ = Pre.visit_block env post block in
-  assert_z3_result test_ctx ctx (Blk.to_string block) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Blk.to_string block) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_assign_1 (test_ctx : test_ctxt) : unit =
@@ -64,7 +65,7 @@ let test_assign_1 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_block env post block in
-  assert_z3_result test_ctx ctx (Blk.to_string block) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Blk.to_string block) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_assign_2 (test_ctx : test_ctxt) : unit =
@@ -80,7 +81,7 @@ let test_assign_2 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_block env post block in
-  assert_z3_result test_ctx ctx (Blk.to_string block) post pre Z3.Solver.SATISFIABLE
+  assert_z3_result test_ctx env (Blk.to_string block) post pre Z3.Solver.SATISFIABLE
 
 
 let test_assign_3 (test_ctx : test_ctxt) : unit =
@@ -100,7 +101,7 @@ let test_assign_3 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_block env post block in
-  assert_z3_result test_ctx ctx (Blk.to_string block) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Blk.to_string block) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_phi_1 (test_ctx : test_ctxt) : unit =
@@ -123,7 +124,7 @@ let test_phi_1 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_block env post block in
-  assert_z3_result test_ctx ctx (Blk.to_string block) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Blk.to_string block) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_read_write_1 (test_ctx : test_ctxt) : unit =
@@ -145,7 +146,7 @@ let test_read_write_1 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_block env post block in
-  assert_z3_result test_ctx ctx (Blk.to_string block) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Blk.to_string block) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_read_write_2 (test_ctx : test_ctxt) : unit =
@@ -167,7 +168,7 @@ let test_read_write_2 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_block env post block in
-  assert_z3_result test_ctx ctx (Blk.to_string block) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Blk.to_string block) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_read_write_3 (test_ctx : test_ctxt) : unit =
@@ -189,7 +190,7 @@ let test_read_write_3 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_block env post block in
-  assert_z3_result test_ctx ctx (Blk.to_string block) post pre Z3.Solver.SATISFIABLE
+  assert_z3_result test_ctx env (Blk.to_string block) post pre Z3.Solver.SATISFIABLE
 
 
 let test_read_write_4 (test_ctx : test_ctxt) : unit =
@@ -211,7 +212,7 @@ let test_read_write_4 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_block env post block in
-  assert_z3_result test_ctx ctx (Blk.to_string block) post pre Z3.Solver.SATISFIABLE
+  assert_z3_result test_ctx env (Blk.to_string block) post pre Z3.Solver.SATISFIABLE
 
 
 let test_bit_shift_1 (test_ctx : test_ctxt) : unit =
@@ -233,7 +234,7 @@ let test_bit_shift_1 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_block env post block in
-  assert_z3_result test_ctx ctx (Blk.to_string block) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Blk.to_string block) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_bit_shift_2 (test_ctx : test_ctxt) : unit =
@@ -255,7 +256,7 @@ let test_bit_shift_2 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_block env post block in
-  assert_z3_result test_ctx ctx (Blk.to_string block) post pre Z3.Solver.SATISFIABLE
+  assert_z3_result test_ctx env (Blk.to_string block) post pre Z3.Solver.SATISFIABLE
 
 
 let test_bit_ashift_1 (test_ctx : test_ctxt) : unit =
@@ -277,7 +278,7 @@ let test_bit_ashift_1 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_block env post block in
-  assert_z3_result test_ctx ctx (Blk.to_string block) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Blk.to_string block) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_bit_ashift_2 (test_ctx : test_ctxt) : unit =
@@ -299,7 +300,7 @@ let test_bit_ashift_2 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_block env post block in
-  assert_z3_result test_ctx ctx (Blk.to_string block) post pre Z3.Solver.SATISFIABLE
+  assert_z3_result test_ctx env (Blk.to_string block) post pre Z3.Solver.SATISFIABLE
 
 
 let test_ite_assign_1 (test_ctx : test_ctxt) : unit =
@@ -320,7 +321,7 @@ let test_ite_assign_1 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_block env post block in
-  assert_z3_result test_ctx ctx (Blk.to_string block) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Blk.to_string block) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_subroutine_1 (test_ctx : test_ctxt) : unit =
@@ -348,7 +349,7 @@ let test_subroutine_1 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_sub env post sub in
-  assert_z3_result test_ctx ctx (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_subroutine_1_2 (test_ctx : test_ctxt) : unit =
@@ -377,7 +378,7 @@ let test_subroutine_1_2 (test_ctx : test_ctxt) : unit =
       "(assert (and (bvsle (bvsub z0 x0) #x00000001) (bvsle #xffffffff (bvsub z0 x0))))"
   in
   let pre, _ = Pre.visit_sub env post sub in
-  assert_z3_result test_ctx ctx (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_subroutine_2 (test_ctx : test_ctxt) : unit =
@@ -423,7 +424,7 @@ let test_subroutine_2 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_sub env post sub in
-  assert_z3_result test_ctx ctx (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_subroutine_3 (test_ctx : test_ctxt) : unit =
@@ -447,7 +448,7 @@ let test_subroutine_3 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_sub env post sub in
-  assert_z3_result test_ctx ctx (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_subroutine_4 (test_ctx : test_ctxt) : unit =
@@ -478,7 +479,7 @@ let test_subroutine_4 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_sub env post sub in
-  assert_z3_result test_ctx ctx (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_subroutine_5 (test_ctx : test_ctxt) : unit =
@@ -505,7 +506,7 @@ let test_subroutine_5 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_sub env post sub in
-  assert_z3_result test_ctx ctx (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_subroutine_6 (test_ctx : test_ctxt) : unit =
@@ -523,7 +524,7 @@ let test_subroutine_6 (test_ctx : test_ctxt) : unit =
   let env = Pre.mk_default_env ~subs ctx var_gen in
   let post = true_constr ctx in
   let pre, _ = Pre.visit_sub env post sub in
-  assert_z3_result test_ctx ctx (Sub.to_string sub) post pre Z3.Solver.SATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string sub) post pre Z3.Solver.SATISFIABLE
 
 
 let test_subroutine_7 (test_ctx : test_ctxt) : unit =
@@ -535,7 +536,7 @@ let test_subroutine_7 (test_ctx : test_ctxt) : unit =
   let env = Pre.mk_default_env ~subs ctx var_gen in
   let post = true_constr ctx in
   let pre, _ = Pre.visit_sub env post sub in
-  assert_z3_result test_ctx ctx (Sub.to_string sub) post pre Z3.Solver.SATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string sub) post pre Z3.Solver.SATISFIABLE
 
 
 let test_call_1 (test_ctx : test_ctxt) : unit =
@@ -562,7 +563,7 @@ let test_call_1 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_sub env post main_sub in
-  assert_z3_result test_ctx ctx (Sub.to_string main_sub) post pre Z3.Solver.SATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string main_sub) post pre Z3.Solver.SATISFIABLE
 
 
 let test_call_2 (test_ctx : test_ctxt) : unit =
@@ -588,7 +589,7 @@ let test_call_2 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_sub env post main_sub in
-  assert_z3_result test_ctx ctx (Sub.to_string main_sub) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string main_sub) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_call_3 (test_ctx : test_ctxt) : unit =
@@ -610,7 +611,7 @@ let test_call_3 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_sub env post main_sub in
-  assert_z3_result test_ctx ctx (Sub.to_string main_sub) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string main_sub) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_call_4 (test_ctx : test_ctxt) : unit =
@@ -630,7 +631,7 @@ let test_call_4 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_sub env post main_sub in
-  assert_z3_result test_ctx ctx (Sub.to_string main_sub) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string main_sub) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_call_5 (test_ctx : test_ctxt) : unit =
@@ -656,7 +657,7 @@ let test_call_5 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_sub env post main_sub in
-  assert_z3_result test_ctx ctx (Sub.to_string main_sub) post pre Z3.Solver.SATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string main_sub) post pre Z3.Solver.SATISFIABLE
 
 
 let test_call_6 (test_ctx : test_ctxt) : unit =
@@ -689,7 +690,7 @@ let test_call_6 (test_ctx : test_ctxt) : unit =
     |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_sub env post main_sub in
-  assert_z3_result test_ctx ctx (Sub.to_string main_sub) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string main_sub) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_call_7 (test_ctx : test_ctxt) : unit =
@@ -727,7 +728,7 @@ let test_call_7 (test_ctx : test_ctxt) : unit =
   in
   let pre, _ = Pre.visit_sub env post main_sub in
   let fmtr = (Sub.to_string main_sub) ^ (Sub.to_string call_sub) in
-  assert_z3_result test_ctx ctx fmtr post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env fmtr post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_call_8 (test_ctx : test_ctxt) : unit =
@@ -762,7 +763,7 @@ let test_call_8 (test_ctx : test_ctxt) : unit =
   in
   let pre, _ = Pre.visit_sub env post main_sub in
   let fmtr = (Sub.to_string main_sub) ^ (Sub.to_string call_sub) in
-  assert_z3_result test_ctx ctx fmtr post pre Z3.Solver.SATISFIABLE
+  assert_z3_result test_ctx env fmtr post pre Z3.Solver.SATISFIABLE
 
 let test_call_9 (test_ctx : test_ctxt) : unit =
   let ctx = Env.mk_ctx () in
@@ -806,7 +807,7 @@ let test_call_9 (test_ctx : test_ctxt) : unit =
   in
   let pre, _ = Pre.visit_sub env post main_sub in
   let fmtr = (Sub.to_string main_sub) ^ (Sub.to_string call1_sub) ^ (Sub.to_string call2_sub) in
-  assert_z3_result test_ctx ctx fmtr post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env fmtr post pre Z3.Solver.UNSATISFIABLE
 
 let test_call_10 (test_ctx : test_ctxt) : unit =
   let ctx = Env.mk_ctx () in
@@ -850,7 +851,7 @@ let test_call_10 (test_ctx : test_ctxt) : unit =
   in
   let pre, _ = Pre.visit_sub env post main_sub in
   let fmtr = (Sub.to_string main_sub) ^ (Sub.to_string call1_sub) ^ (Sub.to_string call2_sub) in
-  assert_z3_result test_ctx ctx fmtr post pre Z3.Solver.SATISFIABLE
+  assert_z3_result test_ctx env fmtr post pre Z3.Solver.SATISFIABLE
 
 let test_int_1 (test_ctx : test_ctxt) : unit =
   let ctx = Env.mk_ctx () in
@@ -869,7 +870,7 @@ let test_int_1 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_sub env post main_sub in
-  assert_z3_result test_ctx ctx (Sub.to_string main_sub) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string main_sub) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_loop_1 (test_ctx : test_ctxt) : unit =
@@ -900,7 +901,7 @@ let test_loop_1 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_sub env post sub in
-  assert_z3_result test_ctx ctx (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_loop_2 (test_ctx : test_ctxt) : unit =
@@ -926,7 +927,7 @@ let test_loop_2 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_sub env post sub in
-  assert_z3_result test_ctx ctx (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_loop_3 (test_ctx : test_ctxt) : unit =
@@ -952,7 +953,7 @@ let test_loop_3 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_sub env post sub in
-  assert_z3_result test_ctx ctx (Sub.to_string sub) post pre Z3.Solver.SATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string sub) post pre Z3.Solver.SATISFIABLE
 
 
 let test_loop_4 (test_ctx : test_ctxt) : unit =
@@ -978,7 +979,7 @@ let test_loop_4 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre.visit_sub env post sub in
-  assert_z3_result test_ctx ctx (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
 
 
 (* Currently only testing expressions that evaluate to immediates. *)
@@ -1022,7 +1023,7 @@ let test_exp_cond_1 (test_ctx : test_ctxt) : unit =
   let blk = blk |> mk_def x load in
   let post = true_constr ctx in
   let pre, _ = Pre.visit_block env post blk in
-  assert_z3_result test_ctx ctx (Blk.to_string blk) post pre Z3.Solver.SATISFIABLE
+  assert_z3_result test_ctx env (Blk.to_string blk) post pre Z3.Solver.SATISFIABLE
 
 
 let test_exp_cond_2 (test_ctx : test_ctxt) : unit =
@@ -1039,7 +1040,7 @@ let test_exp_cond_2 (test_ctx : test_ctxt) : unit =
             |> mk_def x load in
   let post = true_constr ctx in
   let pre, _ = Pre.visit_block env post blk in
-  assert_z3_result test_ctx ctx (Blk.to_string blk) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Blk.to_string blk) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_subroutine_8 (test_ctx : test_ctxt) : unit =
@@ -1055,7 +1056,7 @@ let test_subroutine_8 (test_ctx : test_ctxt) : unit =
              |> Constr.mk_constr
   in
   let pre, _ = Pre. visit_sub env post sub in
-  assert_z3_result test_ctx ctx (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string sub) post pre Z3.Solver.UNSATISFIABLE
 
 
 let test_branches_1 (test_ctx : test_ctxt) : unit =
@@ -1099,7 +1100,7 @@ let test_branches_1 (test_ctx : test_ctxt) : unit =
   let env = Pre.mk_default_env ctx var_gen ~jmp_spec ~subs:(Seq.singleton sub) in
   let post = true_constr ctx in
   let pre, _ = Pre.visit_sub env post sub in
-  assert_z3_result test_ctx ctx (Sub.to_string sub) post pre Z3.Solver.SATISFIABLE
+  assert_z3_result test_ctx env (Sub.to_string sub) post pre Z3.Solver.SATISFIABLE
 
 
 let test_jmp_spec_reach_1 (test_ctx : test_ctxt) : unit =

--- a/wp/lib/bap_wp/tests/unit/test_utils.ml
+++ b/wp/lib/bap_wp/tests/unit/test_utils.ml
@@ -67,14 +67,11 @@ let mk_z3_expr (env : Env.t) (e : Exp.t) : Constr.z3_expr =
 let mk_z3_var (env : Env.t) (v : Var.t) : Constr.z3_expr =
   fst (Env.get_var env v)
 
-let print_z3_model (ff : Format.formatter) (solver : Z3.Solver.solver)
-    (exp : Z3.Solver.status) (real : Z3.Solver.status) (_ctx : Z3.context)
-    (_goals : Constr.t) : unit =
+let print_z3_model (solver : Z3.Solver.solver) (exp : Z3.Solver.status)
+    (real : Z3.Solver.status) (goals : Constr.t) ~orig:(env1 : Env.t)
+    ~modif:(env2 : Env.t) : unit =
   if real = exp || real = Z3.Solver.UNSATISFIABLE then () else
-    match Z3.Solver.get_model solver with
-    | None -> ()
-    | Some model ->
-      Format.fprintf ff "\n\nCountermodel:\n%s\n%!" (Z3.Model.to_string model)
+    Output.print_result solver real goals ~orig:env1 ~modif:env2
 
 (* Finds a jump in a subroutine given its jump condition. *)
 let find_jump (sub : Sub.t) (cond : Exp.t) : Jmp.t =

--- a/wp/lib/bap_wp/tests/unit/test_utils.ml
+++ b/wp/lib/bap_wp/tests/unit/test_utils.ml
@@ -67,11 +67,11 @@ let mk_z3_expr (env : Env.t) (e : Exp.t) : Constr.z3_expr =
 let mk_z3_var (env : Env.t) (v : Var.t) : Constr.z3_expr =
   fst (Env.get_var env v)
 
-let print_z3_model (solver : Z3.Solver.solver) (exp : Z3.Solver.status)
-    (real : Z3.Solver.status) (goals : Constr.t) ~orig:(env1 : Env.t)
-    ~modif:(env2 : Env.t) : unit =
+let print_z3_model ?print_path:(print_path = false) ~orig:(env1 : Env.t)
+    ~modif:(env2 : Env.t) (solver : Z3.Solver.solver) (exp : Z3.Solver.status)
+    (real : Z3.Solver.status) (goals : Constr.t) : unit =
   if real = exp || real = Z3.Solver.UNSATISFIABLE then () else
-    Output.print_result solver real goals ~orig:env1 ~modif:env2
+    Output.print_result solver real goals ~print_path ~orig:env1 ~modif:env2
 
 (* Finds a jump in a subroutine given its jump condition. *)
 let find_jump (sub : Sub.t) (cond : Exp.t) : Jmp.t =

--- a/wp/lib/bap_wp/tests/unit/test_utils.ml
+++ b/wp/lib/bap_wp/tests/unit/test_utils.ml
@@ -68,17 +68,13 @@ let mk_z3_var (env : Env.t) (v : Var.t) : Constr.z3_expr =
   fst (Env.get_var env v)
 
 let print_z3_model (ff : Format.formatter) (solver : Z3.Solver.solver)
-    (exp : Z3.Solver.status) (real : Z3.Solver.status) (ctx : Z3.context)
-    (goals : Constr.t) : unit =
+    (exp : Z3.Solver.status) (real : Z3.Solver.status) (_ctx : Z3.context)
+    (_goals : Constr.t) : unit =
   if real = exp || real = Z3.Solver.UNSATISFIABLE then () else
     match Z3.Solver.get_model solver with
     | None -> ()
     | Some model ->
-      let refuted_goals = Constr.get_refuted_goals goals solver ctx in
-      Format.fprintf ff "\n\nCountermodel:\n%s\n%!" (Z3.Model.to_string model);
-      Format.fprintf ff "\nRefuted goals:\n%!";
-      Seq.iter refuted_goals ~f:(fun g ->
-          Format.fprintf ff "%s\n%!" (Constr.refuted_goal_to_string g model))
+      Format.fprintf ff "\n\nCountermodel:\n%s\n%!" (Z3.Model.to_string model)
 
 (* Finds a jump in a subroutine given its jump condition. *)
 let find_jump (sub : Sub.t) (cond : Exp.t) : Jmp.t =


### PR DESCRIPTION
If the plugin is run with the `--wp-print-path` flag, when a model is generated, the path along with the registers/flags at each jump in the path will be printed based off the values in the model. Ex:
```
Path:
        0000063c: when ZF goto %00000634 (taken) (Address: 0x4004F4:64u)
        ZF   |->  #b1
        SF   |->  #b0
        RSP  |->  #x0000000000000008
        RDX  |->  #x0000000000000000
        RDI  |->  #x0000000000000000
        RCX  |->  #x0000000000000000
        RBP  |->  #x0000000000000000
        RAX  |->  #x0000000000000000
        PF   |->  #b1
        OF   |->  #b0
        CF   |->  #b0
        AF   |->  #b0

        0000063c: when ZF goto %00000634 (not taken) (Address: 0x4004F5:64u)
        ZF   |->  #b0
        SF   |->  #b1
        RSP  |->  #xffffffffffffffe8
        RDX  |->  #x0000000000000000
        RCX  |->  #x0000000000000000
        RBP  |->  #xfffffffffffffff8
        RAX  |->  #x0000000000000003
        PF   |->  #b1
        OF   |->  #b0
        CF   |->  #b1
        AF   |->  #b1
```

I had to change the API a bit because I made a `refuted_goal` data type which includes the goal, path, and map of register values.