### PR TITLE
Update sample binary makefiles to prevent bug in saving projects

### DIFF
--- a/wp/Makefile
+++ b/wp/Makefile
@@ -1,5 +1,6 @@
 BAP_WP = lib/bap_wp
 WP = plugin
+SAMPLE_BINS = resources/sample_binaries
 
 .PHONY: install doc test clean reinstall
 
@@ -13,6 +14,9 @@ doc:
 test: install
 	$(MAKE) -C $(BAP_WP) $@
 	$(MAKE) -C $(WP) $@
+
+test.clean:
+	$(MAKE) -C $(SAMPLE_BINS) clean
 
 clean:
 	$(MAKE) -C $(WP) $@

--- a/wp/resources/sample_binaries/.gitignore
+++ b/wp/resources/sample_binaries/.gitignore
@@ -6,3 +6,4 @@ main_1.bpj
 main_2
 main_2.s
 main_2.bpj
+*.gdb

--- a/wp/resources/sample_binaries/Makefile
+++ b/wp/resources/sample_binaries/Makefile
@@ -2,14 +2,12 @@ SAMPLE_DIRS = $(wildcard */)
 BUILD_DIRS = $(SAMPLE_DIRS:%=build-%)
 CLEAN_DIRS = $(SAMPLE_DIRS:%=clean-%)
 
-.PHONY: all clean
-.PHONY: subdirs $(BUILD_DIRS)
-.PHONY: subdirs $(CLEAN_DIRS)
-
+.PHONY: all subdirs $(BUILD_DIRS)
 all: $(BUILD_DIRS)
 $(BUILD_DIRS):
 	$(MAKE) -C $(@:build-%=%)
 
+.PHONY: clean subdirs $(CLEAN_DIRS)
 clean: $(CLEAN_DIRS)
 $(CLEAN_DIRS):
 	$(MAKE) -C $(@:clean-%=%) clean

--- a/wp/resources/sample_binaries/diff_pointer_val/Makefile
+++ b/wp/resources/sample_binaries/diff_pointer_val/Makefile
@@ -1,34 +1,16 @@
 include ../optimization_flags.mk
 
 BASE=main
-
 PROG1=$(BASE)_1
-
 PROG2=$(BASE)_2
 
-all: prog1 prog2
+all: $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj
 
-prog1: $(PROG1) $(PROG1).s $(PROG1).bpj
+%: %.c
+	$(CC) -Wall $(FLAGS) -g -o $@ $<
 
-$(PROG1): $(PROG1).c
-	gcc -Wall $(FLAGS) -g -o $(PROG1) $(PROG1).c
-
-$(PROG1).s: $(PROG1)
-	objdump -Sd $(PROG1) > $(PROG1).s
-
-$(PROG1).bpj: $(PROG1)
-	bap --pass=save-project --save-project-filename=$(PROG1).bpj $(PROG1)
-
-prog2: $(PROG2) $(PROG2).s $(PROG2).bpj
-
-$(PROG2): $(PROG2).c
-	gcc -Wall $(FLAGS) -g -o $(PROG2) $(PROG2).c
-
-$(PROG2).s: $(PROG2)
-	objdump -Sd $(PROG2) > $(PROG2).s
-
-$(PROG2).bpj: $(PROG2)
-	bap --pass=save-project --save-project-filename=$(PROG2).bpj $(PROG2)
+%.bpj: %
+	bap $< --pass=save-project --save-project-filename=$@
 
 clean:
-	rm -f $(PROG1) $(PROG1).s $(PROG1).bpj  $(PROG2) $(PROG2).s $(PROG2).bpj
+	rm -f $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj

--- a/wp/resources/sample_binaries/diff_ret_val/Makefile
+++ b/wp/resources/sample_binaries/diff_ret_val/Makefile
@@ -1,34 +1,16 @@
 include ../optimization_flags.mk
 
 BASE=main
-
 PROG1=$(BASE)_1
-
 PROG2=$(BASE)_2
 
-all: prog1 prog2
+all: $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj
 
-prog1: $(PROG1) $(PROG1).s $(PROG1).bpj
+%: %.c
+	$(CC) -Wall $(FLAGS) -g -o $@ $<
 
-$(PROG1): $(PROG1).c
-	gcc -Wall $(FLAGS) -g -o $(PROG1) $(PROG1).c
-
-$(PROG1).s: $(PROG1)
-	objdump -Sd $(PROG1) > $(PROG1).s
-
-$(PROG1).bpj: $(PROG1)
-	bap --pass=save-project --save-project-filename=$(PROG1).bpj $(PROG1)
-
-prog2: $(PROG2) $(PROG2).s $(PROG2).bpj
-
-$(PROG2): $(PROG2).c
-	gcc -Wall $(FLAGS) -g -o $(PROG2) $(PROG2).c
-
-$(PROG2).s: $(PROG2)
-	objdump -Sd $(PROG2) > $(PROG2).s
-
-$(PROG2).bpj: $(PROG2)
-	bap --pass=save-project --save-project-filename=$(PROG2).bpj $(PROG2)
+%.bpj: %
+	bap $< --pass=save-project --save-project-filename=$@
 
 clean:
-	rm -f $(PROG1) $(PROG1).s $(PROG1).bpj  $(PROG2) $(PROG2).s $(PROG2).bpj
+	rm -f $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj

--- a/wp/resources/sample_binaries/dummy/Makefile
+++ b/wp/resources/sample_binaries/dummy/Makefile
@@ -3,8 +3,8 @@ BASE := hello_world
 all: $(BASE)
 
 $(BASE):
-	nasm -w+all -f elf64 -o '$(BASE).o' '$(BASE).asm'
-	ld -o '$(BASE).out' '$(BASE).o'
+	nasm -w+all -f elf64 -o $@.o $@.asm
+	ld -o $@.out $@.o
 
 clean:
 	rm -f $(BASE).out $(BASE).o

--- a/wp/resources/sample_binaries/equiv_argc/Makefile
+++ b/wp/resources/sample_binaries/equiv_argc/Makefile
@@ -1,34 +1,16 @@
 include ../optimization_flags.mk
 
 BASE=main
-
 PROG1=$(BASE)_1
-
 PROG2=$(BASE)_2
 
-all: prog1 prog2
+all: $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj
 
-prog1: $(PROG1) $(PROG1).s $(PROG1).bpj
+%: %.c
+	$(CC) -Wall $(FLAGS) -g -o $@ $<
 
-$(PROG1): $(PROG1).c
-	gcc -Wall $(FLAGS) -g -o $(PROG1) $(PROG1).c
-
-$(PROG1).s: $(PROG1)
-	objdump -Sd $(PROG1) > $(PROG1).s
-
-$(PROG1).bpj: $(PROG1)
-	bap --pass=save-project --save-project-filename=$(PROG1).bpj $(PROG1)
-
-prog2: $(PROG2) $(PROG2).s $(PROG2).bpj
-
-$(PROG2): $(PROG2).c
-	gcc -Wall $(FLAGS) -g -o $(PROG2) $(PROG2).c
-
-$(PROG2).s: $(PROG2)
-	objdump -Sd $(PROG2) > $(PROG2).s
-
-$(PROG2).bpj: $(PROG2)
-	bap --pass=save-project --save-project-filename=$(PROG2).bpj $(PROG2)
+%.bpj: %
+	bap $< --pass=save-project --save-project-filename=$@
 
 clean:
-	rm -f $(PROG1) $(PROG1).s $(PROG1).bpj  $(PROG2) $(PROG2).s $(PROG2).bpj
+	rm -f $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj

--- a/wp/resources/sample_binaries/equiv_null_check/Makefile
+++ b/wp/resources/sample_binaries/equiv_null_check/Makefile
@@ -1,34 +1,16 @@
 include ../optimization_flags.mk
 
 BASE=main
-
 PROG1=$(BASE)_1
-
 PROG2=$(BASE)_2
 
-all: prog1 prog2
+all: $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj
 
-prog1: $(PROG1) $(PROG1).s $(PROG1).bpj
+%: %.c
+	$(CC) -Wall $(FLAGS) -g -o $@ $<
 
-$(PROG1): $(PROG1).c
-	gcc -Wall $(FLAGS) -g -o $(PROG1) $(PROG1).c
-
-$(PROG1).s: $(PROG1)
-	objdump -Sd $(PROG1) > $(PROG1).s
-
-$(PROG1).bpj: $(PROG1)
-	bap --pass=save-project --save-project-filename=$(PROG1).bpj $(PROG1)
-
-prog2: $(PROG2) $(PROG2).s $(PROG2).bpj
-
-$(PROG2): $(PROG2).c
-	gcc -Wall $(FLAGS) -g -o $(PROG2) $(PROG2).c
-
-$(PROG2).s: $(PROG2)
-	objdump -Sd $(PROG2) > $(PROG2).s
-
-$(PROG2).bpj: $(PROG2)
-	bap --pass=save-project --save-project-filename=$(PROG2).bpj $(PROG2)
+%.bpj: %
+	bap $< --pass=save-project --save-project-filename=$@
 
 clean:
-	rm -f $(PROG1) $(PROG1).s $(PROG1).bpj  $(PROG2) $(PROG2).s $(PROG2).bpj
+	rm -f $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj

--- a/wp/resources/sample_binaries/function_call/Makefile
+++ b/wp/resources/sample_binaries/function_call/Makefile
@@ -5,11 +5,7 @@ all: x86-64
 x86-64: $(BASE)
 
 $(BASE): $(BASE).c
-	gcc -g -Wall -o $(BASE) $(BASE).c
-
-$(BASE).s : $(BASE).c
-	gcc -S -o $(BASE).s $(BASE).c
-
+	$(CC) -g -Wall -o $@ $<
 
 clean:
 	rm -f $(BASE)

--- a/wp/resources/sample_binaries/function_spec/Makefile
+++ b/wp/resources/sample_binaries/function_spec/Makefile
@@ -5,11 +5,7 @@ all: x86-64
 x86-64: $(BASE)
 
 $(BASE): $(BASE).c
-	gcc -g -Wall -o $(BASE) $(BASE).c
-
-$(BASE).s : $(BASE).c
-	gcc -S -o $(BASE).s $(BASE).c
-
+	$(CC) -g -Wall -o $@ $<
 
 clean:
 	rm -f $(BASE)

--- a/wp/resources/sample_binaries/nested_function_calls/Makefile
+++ b/wp/resources/sample_binaries/nested_function_calls/Makefile
@@ -5,11 +5,7 @@ all: x86-64
 x86-64: $(BASE)
 
 $(BASE): $(BASE).c
-	gcc -g -Wall -o $(BASE) $(BASE).c
-
-$(BASE).s : $(BASE).c
-	gcc -S -o $(BASE).s $(BASE).c
-
+	$(CC) -g -Wall -o $@ $<
 
 clean:
 	rm -f $(BASE)

--- a/wp/resources/sample_binaries/no_stack_protection/Makefile
+++ b/wp/resources/sample_binaries/no_stack_protection/Makefile
@@ -1,32 +1,18 @@
 BASE=main
 
 PROG1=$(BASE)_1
-
 PROG2=$(BASE)_2
 
-all: prog1 prog2
-
-prog1: $(PROG1) $(PROG1).s $(PROG1).bpj
+all: $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj
 
 $(PROG1): $(PROG1).c
-	gcc -Wall -fstack-protector -g -o $(PROG1) $(PROG1).c
-
-$(PROG1).s: $(PROG1)
-	objdump -Sd $(PROG1) > $(PROG1).s
-
-$(PROG1).bpj: $(PROG1)
-	bap --pass=save-project --save-project-filename=$(PROG1).bpj $(PROG1)
-
-prog2: $(PROG2) $(PROG2).s $(PROG2).bpj
+	$(CC) -Wall -fstack-protector -g -o $@ $<
 
 $(PROG2): $(PROG2).c
-	gcc -Wall -fno-stack-protector -g -o $(PROG2) $(PROG2).c
+	$(CC) -Wall -fno-stack-protector -g -o $@ $<
 
-$(PROG2).s: $(PROG2)
-	objdump -Sd $(PROG2) > $(PROG2).s
-
-$(PROG2).bpj: $(PROG2)
-	bap --pass=save-project --save-project-filename=$(PROG2).bpj $(PROG2)
+%.bpj: %
+	bap $< --pass=save-project --save-project-filename=$@
 
 clean:
-	rm -f $(PROG1) $(PROG1).s $(PROG1).bpj  $(PROG2) $(PROG2).s $(PROG2).bpj
+	rm -f $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj

--- a/wp/resources/sample_binaries/retrowrite_stub/Makefile
+++ b/wp/resources/sample_binaries/retrowrite_stub/Makefile
@@ -4,23 +4,13 @@ PROG2=$(BASE)_2
 
 FLAGS=-nostdlib
 
-all: prog1 prog2
+all: $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj
 
-prog1: $(PROG1) $(PROG1).bpj
+%: %.S
+	$(CC) $(FLAGS) -o $@ $<
 
-$(PROG1): $(PROG1).S
-	$(CC) $(FLAGS) -o $(PROG1) $(PROG1).S
-
-$(PROG1).bpj: $(PROG1)
-	bap --pass=save-project --save-project-filename=$(PROG1).bpj $(PROG1)
-
-prog2: $(PROG2) $(PROG2).bpj
-
-$(PROG2): $(PROG2).S
-	gcc -Wall $(FLAGS) -o $(PROG2) $(PROG2).S
-
-$(PROG2).bpj: $(PROG2)
-	bap --pass=save-project --save-project-filename=$(PROG2).bpj $(PROG2)
+%.bpj: %
+	bap $< --pass=save-project --save-project-filename=$@
 
 clean:
 	rm -f $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj

--- a/wp/resources/sample_binaries/retrowrite_stub_no_ret/Makefile
+++ b/wp/resources/sample_binaries/retrowrite_stub_no_ret/Makefile
@@ -4,23 +4,13 @@ PROG2=$(BASE)_2
 
 FLAGS=-nostdlib
 
-all: prog1 prog2
+all: $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj
 
-prog1: $(PROG1) $(PROG1).bpj
+%: %.S
+	$(CC) $(FLAGS) -o $@ $<
 
-$(PROG1): $(PROG1).S
-	$(CC) $(FLAGS) -o $(PROG1) $(PROG1).S
-
-$(PROG1).bpj: $(PROG1)
-	bap --pass=save-project --save-project-filename=$(PROG1).bpj $(PROG1)
-
-prog2: $(PROG2) $(PROG2).bpj
-
-$(PROG2): $(PROG2).S
-	gcc -Wall $(FLAGS) -o $(PROG2) $(PROG2).S
-
-$(PROG2).bpj: $(PROG2)
-	bap --pass=save-project --save-project-filename=$(PROG2).bpj $(PROG2)
+%.bpj: %
+	bap $< --pass=save-project --save-project-filename=$@
 
 clean:
 	rm -f $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj

--- a/wp/resources/sample_binaries/return_argc/Makefile
+++ b/wp/resources/sample_binaries/return_argc/Makefile
@@ -7,11 +7,7 @@ all: x86-64
 x86-64: $(BASE)
 
 $(BASE): $(BASE).c
-	gcc $(FLAGS) -g -Wall -Wpedantic -fno-stack-protector -z execstack -o $(BASE) $(BASE).c
-
-$(BASE).s : $(BASE).c
-	gcc -S -o $(BASE).s $(BASE).c
-
+	$(CC) $(FLAGS) -g -Wall -Wpedantic -fno-stack-protector -z execstack -o $@ $<
 
 clean:
 	rm -f $(BASE)

--- a/wp/resources/sample_binaries/rop_example/Makefile
+++ b/wp/resources/sample_binaries/rop_example/Makefile
@@ -1,16 +1,12 @@
 BASE=main
 
 PROG1=$(BASE)-original
-
 PROG2=$(BASE)-rop
 
 all: $(PROG1).bpj $(PROG2).bpj
 
-$(PROG1).bpj:
-	bap --pass=save-project --save-project-filename=$(PROG1).bpj $(PROG1)
-
-$(PROG2).bpj:
-	bap --pass=save-project --save-project-filename=$(PROG2).bpj $(PROG2)
+%.bpj: %
+	bap $< --pass=save-project --save-project-filename=$@
 
 clean:
 	rm -f $(PROG1).bpj $(PROG2).bpj

--- a/wp/resources/sample_binaries/simple_wp/Makefile
+++ b/wp/resources/sample_binaries/simple_wp/Makefile
@@ -7,11 +7,7 @@ all: x86-64
 x86-64: $(BASE)
 
 $(BASE): $(BASE).c
-	gcc $(FLAGS) -g -Wall -Wpedantic -fno-stack-protector -z execstack -o $(BASE) $(BASE).c
-
-$(BASE).s : $(BASE).c
-	gcc -S -o $(BASE).s $(BASE).c
-
+	$(CC) $(FLAGS) -g -Wall -Wpedantic -fno-stack-protector -z execstack -o $@ $<
 
 clean:
 	rm -f $(BASE)

--- a/wp/resources/sample_binaries/switch_case_assignments/Makefile
+++ b/wp/resources/sample_binaries/switch_case_assignments/Makefile
@@ -1,32 +1,14 @@
 BASE=main
-
 PROG1=$(BASE)_1
-
 PROG2=$(BASE)_2
 
-all: prog1 prog2
+all: $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj
 
-prog1: $(PROG1) $(PROG1).s $(PROG1).bpj
+%: %.c
+	$(CC) -g -o $@ $<
 
-$(PROG1): $(PROG1).c
-	gcc -g -o $(PROG1) $(PROG1).c
-
-$(PROG1).s: $(PROG1)
-	objdump -Sd $(PROG1) > $(PROG1).s
-
-$(PROG1).bpj: $(PROG1)
-	bap --pass=save-project --save-project-filename=$(PROG1).bpj $(PROG1)
-
-prog2: $(PROG2) $(PROG2).s $(PROG2).bpj
-
-$(PROG2): $(PROG2).c
-	gcc -g -o $(PROG2) $(PROG2).c
-
-$(PROG2).s: $(PROG2)
-	objdump -Sd $(PROG2) > $(PROG2).s
-
-$(PROG2).bpj: $(PROG2)
-	bap --pass=save-project --save-project-filename=$(PROG2).bpj $(PROG2)
+%.bpj: %
+	bap $< --pass=save-project --save-project-filename=$@
 
 clean:
-	rm -f $(PROG1) $(PROG1).s $(PROG1).bpj  $(PROG2) $(PROG2).s $(PROG2).bpj
+	rm -f $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj

--- a/wp/resources/sample_binaries/switch_cases/Makefile
+++ b/wp/resources/sample_binaries/switch_cases/Makefile
@@ -1,32 +1,14 @@
 BASE=main
-
 PROG1=$(BASE)_1
-
 PROG2=$(BASE)_2
 
-all: prog1 prog2
+all: $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj
 
-prog1: $(PROG1) $(PROG1).s $(PROG1).bpj
+%: %.c
+	$(CC) -Wall -g -o $@ $<
 
-$(PROG1): $(PROG1).c
-	gcc -Wall -g -o $(PROG1) $(PROG1).c
-
-$(PROG1).s: $(PROG1)
-	objdump -Sd $(PROG1) > $(PROG1).s
-
-$(PROG1).bpj: $(PROG1)
-	bap $(PROG1) --pass=save-project --save-project-filename=$@ --no-byteweight
-
-prog2: $(PROG2) $(PROG2).s $(PROG2).bpj
-
-$(PROG2): $(PROG2).c
-	gcc -Wall -g -o $(PROG2) $(PROG2).c
-
-$(PROG2).s: $(PROG2)
-	objdump -Sd $(PROG2) > $(PROG2).s
-
-$(PROG2).bpj: $(PROG2)
-	bap $(PROG2) --pass=save-project --save-project-filename=$@ --no-byteweight
+%.bpj: %
+	bap $< --pass=save-project --save-project-filename=$@
 
 clean:
-	rm -f $(PROG1) $(PROG1).s $(PROG1).bpj  $(PROG2) $(PROG2).s $(PROG2).bpj
+	rm -f $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj

--- a/wp/resources/sample_binaries/verifier_calls/Makefile
+++ b/wp/resources/sample_binaries/verifier_calls/Makefile
@@ -6,16 +6,10 @@ PROG1=$(BASE)_assume_unsat
 PROG2=$(BASE)_assume_sat
 PROG3=$(BASE)_nondet
 
-all: prog1 prog2 prog3
+all: $(PROG1) $(PROG2) $(PROG3)
 
-prog1:
-	gcc $(FLAGS) -g -o $(PROG1) $(PROG1).c
-
-prog2:
-	gcc $(FLAGS) -g -o $(PROG2) $(PROG2).c
-
-prog3:
-	gcc $(FLAGS) -g -o $(PROG3) $(PROG3).c
+%: %.c
+	$(CC) $(FLAGS) -g -o $@ $<
 
 clean:
 	rm -f $(PROG1) $(PROG2) $(PROG3)


### PR DESCRIPTION
Fixes a bug we had with saving projects. Adds a target `test.clean` that will clean all the sample binaries.