### PR TITLE
Add function input registers to get_vars

### DIFF
--- a/wp/lib/bap_wp/src/compare.ml
+++ b/wp/lib/bap_wp/src/compare.ml
@@ -99,7 +99,7 @@ let compare_subs
   : Constr.t * Env.t * Env.t =
   let env2 = Env.set_freshen env2 true in
   let vars = Var.Set.union
-      (Pre.get_vars sub1) (Pre.get_vars sub2) in
+      (Pre.get_vars env1 sub1) (Pre.get_vars env2 sub2) in
   let post, env1, env2 =
     postcond ~original:(sub1, env1) ~modified:(sub2, env2) ~rename_set:vars in
   info "\nPostcondition:\n%s\n%!" (Constr.to_string post);

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -491,6 +491,7 @@ let spec_arg_terms (sub : Sub.t) (_ : Arch.t) : Env.fun_spec option =
                      | Some Both -> var :: ins, var :: outs
                      | None -> ins, outs)
              in
+             let inputs = if Env.use_input_regs env then inputs else [] in
              subst_fun_outputs env sub post ~inputs:inputs ~outputs:outputs, env)
     }
   else

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -64,11 +64,11 @@ val cast : Z3.context -> Bap.Std.cast -> int -> Constr.z3_expr -> Constr.z3_expr
 val lookup_sub : Bap.Std.Label.t -> Constr.t -> Env.t -> Constr.t * Env.t
 
 (** Get {e every} variable from a subroutine. *)
-val get_vars : Bap.Std.Sub.t -> Bap.Std.Var.Set.t
+val get_vars : Env.t -> Bap.Std.Sub.t -> Bap.Std.Var.Set.t
 
 (** Find the set of BAP variables in a subroutine for equivalence checking
     given the name of each variable. *)
-val get_output_vars : Bap.Std.Sub.t -> string list -> Bap.Std.Var.Set.t
+val get_output_vars : Env.t -> Bap.Std.Sub.t -> string list -> Bap.Std.Var.Set.t
 
 (** Generates a list of constraints: [var == init_var] where init_var refers to
     the initial state of the variable var. Also updates the environment to contain

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -83,7 +83,7 @@ let analyze_proj (proj : project) (var_gen : Env.var_gen) (ctx : Z3.context)
      environment with variables *)
   let true_constr = Pre.Bool.mk_true ctx |> Constr.mk_goal "true" |> Constr.mk_constr in
   let _, env' = Pre.visit_sub env true_constr main_sub in
-  let hyps, env' = Pre.init_vars (Pre.get_vars main_sub) env' in
+  let hyps, env' = Pre.init_vars (Pre.get_vars env' main_sub) env' in
   let post =
     if String.(post_cond = "") then
       true_constr
@@ -133,14 +133,14 @@ let compare_projs (proj : project) (file1: string) (file2 : string)
     let env2 = Pre.mk_env ctx var_gen ~subs:subs2 ~arch:arch ~to_inline:to_inline2
         ~use_fun_input_regs in
     let env2 = Env.set_freshen env2 true in
-    let _, env2 = Pre.init_vars (Pre.get_vars main_sub2) env2 in
+    let _, env2 = Pre.init_vars (Pre.get_vars env2 main_sub2) env2 in
     env2
   in
   let env1 =
     let to_inline1 = match_inline to_inline subs1 in
     let env1 = Pre.mk_env ctx var_gen ~subs:subs1 ~arch:arch ~to_inline:to_inline1
         ~use_fun_input_regs ~exp_conds:(get_exp_conds env2 mem_offset) in
-    let _, env1 = Pre.init_vars (Pre.get_vars main_sub1) env1 in
+    let _, env1 = Pre.init_vars (Pre.get_vars env1 main_sub1) env1 in
     env1
   in
   let pre, env1, env2 =
@@ -149,10 +149,10 @@ let compare_projs (proj : project) (file1: string) (file2 : string)
     else
       begin
         let output_vars = Var.Set.union
-            (Pre.get_output_vars main_sub1 output_vars)
-            (Pre.get_output_vars main_sub2 output_vars) in
+            (Pre.get_output_vars env1 main_sub1 output_vars)
+            (Pre.get_output_vars env2 main_sub2 output_vars) in
         let input_vars = Var.Set.union
-            (Pre.get_vars main_sub1) (Pre.get_vars main_sub2) in
+            (Pre.get_vars env1 main_sub1) (Pre.get_vars env2 main_sub2) in
         debug "Input: %s%!" (varset_to_string input_vars);
         debug "Output: %s%!" (varset_to_string output_vars);
         Comp.compare_subs_eq ~input:input_vars ~output:output_vars


### PR DESCRIPTION
Handles #117. Passes in `env` to `get_vars` to determine whether we are using the input registers at function call sites, and if we are, include those input registers to the set of variables we are collecting.