### PR TITLE
bump core version from 0.11 to 0.12.4

### DIFF
--- a/explicit_edge/README.md
+++ b/explicit_edge/README.md
@@ -11,7 +11,7 @@ Build
 Before installing `explicit_edge`, the following requirements must be met:
 
 * BAP 2.0.0-alpha+ must be available. Confirm with `bap --version`.
-* core 0.11+ must be available. Confirm with `ocamlfind query core`.
+* core 0.12.4+ must be available. Confirm with `ocamlfind query core`.
 * ppx\_deriving must be available. Confirm with `ocamlfind query ppx_deriving`
 * cbat\_value\_set must be available. Confirm with `ocamlfind query cbat_value_set`
 * Dune 1.6+ must be available. Confirm with `dune --version`.

--- a/value_set/README.md
+++ b/value_set/README.md
@@ -10,7 +10,7 @@ Build
 Before installing `value_set`, the following requirements must be met:
 
 * BAP 2.0.0-alpha+ must be available. Confirm with `bap --version`.
-* core 0.11+ must be available. Confirm with `ocamlfind query core`.
+* core 0.12.4+ must be available. Confirm with `ocamlfind query core`.
 * ppx\_deriving must be available. Confirm with `ocamlfind query ppx_deriving`
 * oUnit must be available to `findlib` under the name `oUnit`
   (confirm with `ocamlfind query oUnit`) and it must be available

--- a/value_set/lib/src/cbat_ai_memmap.ml
+++ b/value_set/lib/src/cbat_ai_memmap.ml
@@ -185,7 +185,7 @@ module Key = struct
      an ordered sequence of non-overlapping keys with the side they came from.
   *)
   let seq_product (s1 : t seq) (s2 : t seq) : (side * t) seq =
-    let combined = Seq.merge_with_duplicates s1 s2 ~cmp:compare in
+    let combined = Seq.merge_with_duplicates s1 s2 ~compare:compare in
     Seq.unfold_step ~init:combined ~f:begin fun s ->
       Option.value_map ~default:Seq.Step.Done (Seq.next s) ~f: begin
         fun (hd, tl) -> match hd with

--- a/wp/lib/bap_wp/README.md
+++ b/wp/lib/bap_wp/README.md
@@ -12,7 +12,7 @@ Before installing `bap_wp`, the following requirements must be met:
 * BAP 2.0.0+ must be available. Confirm with `bap --version`.
 * z3 4.8.6+ must be available to `findlib` under the name `z3`
   (note the lowercase `z`). Confirm with `ocamlfind query z3`.
-* core 0.11+ must be available. Confirm with `ocamlfind query core`.
+* core 0.12.4+ must be available. Confirm with `ocamlfind query core`.
 * oUnit must be available to `findlib` under the name `oUnit`
   (confirm with `ocamlfind query oUnit`) and it must be available
   to `opam` under the name `ounit` (confirm with `opam show ounit`).

--- a/wp/plugin/README.md
+++ b/wp/plugin/README.md
@@ -5,7 +5,7 @@
 Depends on:
 
     - ocaml 4.05.0
-    - core_kernel 0.11
+    - core_kernel 0.12.4+
     - bap 2.0.0
     - ounit 2.0.8
     - z3 4.8.6


### PR DESCRIPTION
value_set will not compile under version 12 of core due to a name change in core from `cmp` to [`compare`](https://ocaml.janestreet.com/ocaml-core/v0.12/doc/base/Base/Sequence/#val-compare). This PR bumps the version of core to 12.4 in the relevant READMEs, and switches the usage (one occurrence) to be compatible with version 12. Note that this is a breaking change; cbat_toools will no longer be compatible with version 11 of core.