### PR TITLE
bumped core version to 0.12.4 in opam files

### DIFF
--- a/value_set/lib/cbat_value_set.opam
+++ b/value_set/lib/cbat_value_set.opam
@@ -15,7 +15,7 @@ bug-reports: "https://github.com/draperlaboratory/cbat_tools"
 dev-repo: "git+https://github.com/draperlaboratory/cbat_tools"
 depends: [
   "bap" {>= "master"}
-  "core" {>= "0.11"}
+  "core" {>= "0.12.4"}
   "ppx_deriving"
   "ppx_bin_prot"
   "ppx_sexp_conv"

--- a/wp/lib/bap_wp/bap_wp.opam
+++ b/wp/lib/bap_wp/bap_wp.opam
@@ -19,7 +19,7 @@ bug-reports: "https://github.com/draperlaboratory/cbat_tools"
 dev-repo: "git+https://github.com/draperlaboratory/cbat_tools"
 depends: [
   "bap" {>= "master"}
-  "core" {>= "0.11"}
+  "core" {>= "0.12.4"}
   "z3" {>= "4.8.6"}
   "ounit"
 ]


### PR DESCRIPTION
The opam files also need to bump the core dependency 0.11 to 0.12.4. This PR performs this bump.