### PR TITLE
Fortunac/mem read fix

### DIFF
--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -455,7 +455,12 @@ let spec_verifier_assume (sub : Sub.t) (_ : Arch.t) : Env.fun_spec option =
     None
 
 let spec_verifier_nondet (sub : Sub.t) (_ : Arch.t) : Env.fun_spec option =
-  if String.is_prefix (Sub.name sub) ~prefix:"__VERIFIER_nondet_" then
+  let is_nondet name = String.(
+    (is_prefix name ~prefix:"__VERIFIER_nondet_")
+    || (equal name "calloc")
+    || (equal name "malloc"))
+  in
+  if is_nondet (Sub.name sub) then
     let open Env in
     Some {
       spec_name = "spec_verifier_nondet";
@@ -468,31 +473,6 @@ let spec_verifier_nondet (sub : Sub.t) (_ : Arch.t) : Env.fun_spec option =
                match Seq.find args
                        ~f:(fun a -> Bap.Std.Arg.intent a = Some Bap.Std.Out ||
                                     Bap.Std.Arg.intent a = Some Bap.Std.Both) with
-               | Some o -> o
-               | None -> failwith "Verifier headerfile must be specified with --api-path" in
-             let vars = output |> Bap.Std.Arg.rhs |> Exp.free_vars in
-             let v = Var.Set.choose_exn vars in
-             let z3_v, env = Env.get_var env v in
-             let name = Format.sprintf "%s_ret_%s" (Sub.name sub) (Expr.to_string z3_v) in
-             let fresh = new_z3_expr env ~name:name (Var.typ v) in
-             Constr.substitute_one post z3_v fresh, env)
-    }
-  else
-    None
-
-let spec_calloc (sub : Sub.t) (_ : Arch.t) : Env.fun_spec option =
-  if String.equal (Sub.name sub) "calloc" then
-    let open Env in
-    Some {
-      spec_name = "spec_calloc";
-      spec = Summary
-        (* Currently stubbing this spec to mirror that of spec_verifier_nondet. *)
-        (fun env post tid ->
-             let post = set_fun_called post env tid in
-             let post, env = increment_stack_ptr post env in
-             let args = Term.enum arg_t sub in
-             let output =
-               match Seq.find args ~f:(fun a -> Bap.Std.Arg.intent a = Some Bap.Std.Out) with
                | Some o -> o
                | None -> failwith "Verifier headerfile must be specified with --api-path" in
              let vars = output |> Bap.Std.Arg.rhs |> Exp.free_vars in
@@ -645,7 +625,7 @@ let num_unroll : int ref = ref 5
 let default_fun_specs (to_inline : Sub.t Seq.t) :
   (Sub.t -> Arch.t -> Env.fun_spec option) list =
   [spec_verifier_error; spec_verifier_assume; spec_verifier_nondet; spec_afl_maybe_log;
-   spec_calloc; spec_inline to_inline; spec_arg_terms; spec_chaos_caller_saved; spec_rax_out]
+   spec_inline to_inline; spec_arg_terms; spec_chaos_caller_saved; spec_rax_out]
 
 let default_stack_range : int * int = 0x00007fffffff0000, 0x00007fffffffffff
 

--- a/wp/plugin/tests/test_wp.ml
+++ b/wp/plugin/tests/test_wp.ml
@@ -20,8 +20,6 @@ let bin_dir : string = "../resources/sample_binaries"
 
 let timeout_msg : string = "Test times out!"
 
-let not_added_msg : string = "Test not yet added to sample_binaries directory!"
-
 let fail_msg : string = "Test currently fails!"
 
 let sat : string = "SAT!"

--- a/wp/plugin/tests/test_wp.ml
+++ b/wp/plugin/tests/test_wp.ml
@@ -77,7 +77,6 @@ let test_skip (msg : string) (_ : test_ctxt -> unit) (_ : test_ctxt) : unit =
   skip_if true msg
 
 let suite = [
-<<<<<<< HEAD
 
   (* Test elf comparison *)
 

--- a/wp/plugin/tests/test_wp.ml
+++ b/wp/plugin/tests/test_wp.ml
@@ -77,6 +77,7 @@ let test_skip (msg : string) (_ : test_ctxt -> unit) (_ : test_ctxt) : unit =
   skip_if true msg
 
 let suite = [
+<<<<<<< HEAD
 
   (* Test elf comparison *)
 
@@ -119,7 +120,7 @@ let suite = [
 
   "No stack protection"            >:: test_plugin "no_stack_protection" sat;
 
-  "Pointer input"                  >:: test_skip not_added_msg (test_plugin "pointer_input" unsat);
+  "Pointer input"                  >:: test_plugin "pointer_input" unsat;
 
   "Retrowrite stub: pop RSP"       >:: test_plugin "retrowrite_stub" unsat;
   "Retrowrite stub: inline AFL"    >:: test_plugin "retrowrite_stub" unsat ~script:"run_wp_inline_afl.sh";
@@ -141,9 +142,8 @@ let suite = [
   "Function spec: inline all "     >:: test_plugin "function_spec" unsat ~script:"run_wp_inline_all.sh";
   "Function spec: inline garbage"  >:: test_plugin "function_spec" sat ~script:"run_wp_inline_garbage.sh";
 
-  "Goto string"                    >:: test_skip not_added_msg (test_plugin "goto_string" sat);
-  "Goto string: inline all"        >:: test_skip not_added_msg (test_plugin "goto_string" sat
-                                                                  ~script:"run_wp_inline.sh");
+  "Goto string"                    >:: test_plugin "goto_string" sat;
+  "Goto string: inline all"        >:: test_plugin "goto_string" sat ~script:"run_wp_inline.sh";
 
   "Init var value in post: UNSAT:" >:: test_plugin "init_var" unsat;
   "Init var value in post: SAT"    >:: test_plugin "init_var" sat ~script:"run_wp_sat.sh";

--- a/wp/resources/sample_binaries/double_deference/Makefile
+++ b/wp/resources/sample_binaries/double_deference/Makefile
@@ -1,0 +1,16 @@
+include ../optimization_flags.mk
+
+BASE=main
+PROG1=$(BASE)_1
+PROG2=$(BASE)_2
+
+all: $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj
+
+%: %.c
+	$(CC) -Wall $(FLAGS) -g -o $@ $<
+
+%.bpj: %
+	bap $< --pass=save-project --save-project-filename=$@
+
+clean:
+	rm -f $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj

--- a/wp/resources/sample_binaries/double_deference/main_1.c
+++ b/wp/resources/sample_binaries/double_deference/main_1.c
@@ -1,0 +1,5 @@
+#include <stdlib.h>
+
+int main(int argc, char *argv[]) {
+  return **argv;
+}

--- a/wp/resources/sample_binaries/double_deference/main_2.c
+++ b/wp/resources/sample_binaries/double_deference/main_2.c
@@ -1,0 +1,5 @@
+#include <stdlib.h>
+
+int main(int argc, char *argv[]) {
+  return **argv;
+}

--- a/wp/resources/sample_binaries/double_deference/run_wp.sh
+++ b/wp/resources/sample_binaries/double_deference/run_wp.sh
@@ -1,0 +1,17 @@
+set -x
+
+dummy_dir=../dummy
+
+compile () {
+  make
+}
+
+run () {
+  bap $dummy_dir/hello_world.out --pass=wp \
+    --wp-compare=true \
+    --wp-file1=main_1.bpj \
+    --wp-file2=main_2.bpj \
+    --wp-mem-offset
+}
+
+compile && run

--- a/wp/resources/sample_binaries/double_deference/run_wp.sh
+++ b/wp/resources/sample_binaries/double_deference/run_wp.sh
@@ -1,3 +1,8 @@
+# This binary returns a double dereference to argv. This test
+# compares the binary with itself.
+
+# Should return UNSAT
+
 set -x
 
 dummy_dir=../dummy
@@ -8,7 +13,7 @@ compile () {
 
 run () {
   bap $dummy_dir/hello_world.out --pass=wp \
-    --wp-compare=true \
+    --wp-compare \
     --wp-file1=main_1.bpj \
     --wp-file2=main_2.bpj \
     --wp-mem-offset

--- a/wp/resources/sample_binaries/goto_string/Makefile
+++ b/wp/resources/sample_binaries/goto_string/Makefile
@@ -1,0 +1,15 @@
+BASE=main
+
+all: x86-64
+
+x86-64: $(BASE)
+
+$(BASE): $(BASE).c
+	gcc -g -Wall -o $(BASE) $(BASE).c
+
+$(BASE).s : $(BASE).c
+	gcc -S -o $(BASE).s $(BASE).c
+
+
+clean:
+	rm -f $(BASE)

--- a/wp/resources/sample_binaries/goto_string/main.c
+++ b/wp/resources/sample_binaries/goto_string/main.c
@@ -1,0 +1,29 @@
+#include <assert.h>
+#include <stdlib.h>
+#include "../../../plugin/api/c/cbat.h"
+
+#define STRING_MAX 10
+
+char * my_string_alloc(int size){
+  return (char *) __VERIFIER_nondet_long ();
+}
+
+int main(int argc, char* argv[])
+{
+  char *string1, *string2;
+  string1 = my_string_alloc(STRING_MAX);
+  string2 = my_string_alloc(STRING_MAX);
+
+  if ( !(string2) )
+    goto gotoExample_string2;
+
+  //important code goes here
+  assert(string1 && string2);
+
+gotoExample_string2:
+  free(string2);
+gotoExample_string1:
+  free(string1);
+
+  return 0;
+}

--- a/wp/resources/sample_binaries/goto_string/run_wp.sh
+++ b/wp/resources/sample_binaries/goto_string/run_wp.sh
@@ -1,0 +1,11 @@
+set -x
+
+compile () {
+  make
+}
+
+run () {
+  bap main --pass=wp --wp-func=main --wp-print-path=true
+}
+
+compile && run

--- a/wp/resources/sample_binaries/goto_string/run_wp_inline.sh
+++ b/wp/resources/sample_binaries/goto_string/run_wp_inline.sh
@@ -3,9 +3,9 @@
 # that frees the memory region. If the program does not jump to any of the gotos,
 # there is an assert that the results of the function calls are non-null.
 
-# This tests the default function spec that chaoses the caller-saved registers
-# at a function call. This shows that it is possible for string1 to be NULL while
-# string2 is non-null, reaching the assert_fail.
+# This tests inlining my_string_alloc in order to analyze the call to
+# __VERIFIER_nondet_long, and show that the non-deterministic nature of
+# __VERIFIER_nondet_long can cause execution to reach assert_fail.
 
 # Should return SAT
 
@@ -16,7 +16,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp
+  bap main --pass=wp --wp-inline=.*
 }
 
 compile && run

--- a/wp/resources/sample_binaries/pointer_input/Makefile
+++ b/wp/resources/sample_binaries/pointer_input/Makefile
@@ -1,0 +1,16 @@
+include ../optimization_flags.mk
+
+BASE=main
+PROG1=$(BASE)_1
+PROG2=$(BASE)_2
+
+all: $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj
+
+%: %.c
+	$(CC) -Wall $(FLAGS) -g -o $@ $<
+
+%.bpj: %
+	bap $< --pass=save-project --save-project-filename=$@
+
+clean:
+	rm -f $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj

--- a/wp/resources/sample_binaries/pointer_input/main_1.c
+++ b/wp/resources/sample_binaries/pointer_input/main_1.c
@@ -1,0 +1,5 @@
+#include <stdlib.h>
+
+int main(int argc, char *argv[]) {
+  return *argv;
+}

--- a/wp/resources/sample_binaries/pointer_input/main_2.c
+++ b/wp/resources/sample_binaries/pointer_input/main_2.c
@@ -1,0 +1,5 @@
+#include <stdlib.h>
+
+int main(int argc, char *argv[]) {
+  return *argv;
+}

--- a/wp/resources/sample_binaries/pointer_input/run_wp.sh
+++ b/wp/resources/sample_binaries/pointer_input/run_wp.sh
@@ -1,0 +1,17 @@
+set -x
+
+dummy_dir=../dummy
+
+compile () {
+  make
+}
+
+run () {
+  bap $dummy_dir/hello_world.out --pass=wp \
+    --wp-compare=true \
+    --wp-file1=main_1.bpj \
+    --wp-file2=main_2.bpj \
+    --wp-mem-offset
+}
+
+compile && run

--- a/wp/resources/sample_binaries/pointer_input/run_wp.sh
+++ b/wp/resources/sample_binaries/pointer_input/run_wp.sh
@@ -1,3 +1,8 @@
+# This binary returns a pointer that was passed in as an argument. This test
+# compares the binary with itself.
+
+# Should return UNSAT
+
 set -x
 
 dummy_dir=../dummy
@@ -8,7 +13,7 @@ compile () {
 
 run () {
   bap $dummy_dir/hello_world.out --pass=wp \
-    --wp-compare=true \
+    --wp-compare \
     --wp-file1=main_1.bpj \
     --wp-file2=main_2.bpj \
     --wp-mem-offset


### PR DESCRIPTION
1.  At a memory read, rather than generating a constraint of 
```
(Heap(x) => init_mem_orig[x] = init_mem_mod[x + d]) ^ (Stack(x) => init_mem_orig[x] = init_mem_mod[x])
```
we generate a constraint in the form of
```
if stack(x) then
  init_mem_orig[x] = init_mem_mod[x]
else if heap(x) then
  init_mem_orig[x] = init_mem_mod[x + d]
else
  init_mem_orig[x] = init_mem_mod[x]
```
in order to cover all of memory.

2. Fix bug where `__VERIFIER_nondet` was not freshening the variable we are chaosing.

3. Add a stub spec for `calloc`, which has the same behavior as `__VERIFIER_nondet`.