### PR TITLE
Additional loop example

### DIFF
--- a/wp/resources/sample_binaries/loop/Makefile
+++ b/wp/resources/sample_binaries/loop/Makefile
@@ -1,0 +1,13 @@
+#include ../../../../cbat_tools/wp/resources/sample_binaries/optimization_flags.mk
+
+BASE=main
+
+all: x86-64
+
+x86-64: $(BASE)
+
+$(BASE): $(BASE).c
+	$(CC) -g -Wall -Wpedantic -o $@ $<
+
+clean:
+	rm -f $(BASE)

--- a/wp/resources/sample_binaries/loop/main.c
+++ b/wp/resources/sample_binaries/loop/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+int main(int argc, char** argv){
+        int counter = 0;
+	for(int i = 0; i <= argc; i++){
+	        counter += 1;
+	}
+	if(counter == 1){
+		assert(0);
+	}
+	return 0;
+}

--- a/wp/resources/sample_binaries/loop/run_wp.sh
+++ b/wp/resources/sample_binaries/loop/run_wp.sh
@@ -1,0 +1,14 @@
+compile() {
+        make
+}
+
+run() {
+        bap main --pass=wp --wp-num-unroll=100
+
+}
+
+clean() {
+        make clean
+}
+
+clean && compile && run


### PR DESCRIPTION
Adds loop example that tests that the loop is unrolled when cbat performs analysis. The assert should be triggered when argc is 0.