### PR TITLE
Fortunac/rename vars

### DIFF
--- a/wp/lib/bap_wp/src/compare.ml
+++ b/wp/lib/bap_wp/src/compare.ml
@@ -51,6 +51,7 @@ let set_to_eqs (env1 : Env.t) (env2 : Env.t) (vars : Var.Set.t) : Constr.t list 
 (* Adds the hypothesis: [var == init_var] for each variable in the set. *)
 let init_vars (env1 : Env.t) (env2 : Env.t) (vars : Var.Set.t)
   : Constr.t list * Env.t * Env.t =
+  let vars = Set.filter vars ~f:Var.is_physical in
   let inits1, env1 = Pre.init_vars vars env1 in
   let inits2, env2 = Pre.init_vars vars env2 in
   (inits1 @ inits2), env1, env2

--- a/wp/plugin/tests/test_wp.ml
+++ b/wp/plugin/tests/test_wp.ml
@@ -55,7 +55,7 @@ let test_plugin
     (elf_dir : string)
     (expected : string)
     (ctxt : test_ctxt)
-    : unit =
+  : unit =
   let target = Format.sprintf "%s/%s" bin_dir elf_dir in
   let script = Format.sprintf "./%s" script in
   assert_command ~foutput:(fun res -> check_result res expected ctxt)
@@ -81,8 +81,8 @@ let suite = [
   (* Test elf comparison *)
 
   "Multicompiler: csmith"          >:: test_plugin "cbat-multicompiler-samples/csmith" unsat;
-  "Multicompiler: csmith inline"   >:: test_skip fail_msg (test_plugin "cbat-multicompiler-samples/csmith" unsat
-    ~script:"run_wp_inline.sh");
+  "Multicompiler: csmith inline"   >:: test_skip timeout_msg (test_plugin "cbat-multicompiler-samples/csmith" unsat
+                                                                ~script:"run_wp_inline.sh");
   "Multicompiler: equiv argc"      >:: test_plugin "cbat-multicompiler-samples/equiv_argc" unsat;
   "Multicompiler: switch cases"    >:: test_plugin "cbat-multicompiler-samples/switch_case_assignments" unsat;
 


### PR DESCRIPTION
Solving issue #126.

The issue is that the original `csmith-10684` contains the 64-bit variable `#55` in the function `platform_main_begin` and the modified `csmith-16912` has the 32-bit variable `#55` in `main`. When we reach the `#55` in the original binary, the env believes the `#55` is 32-bits when it is supposed to be 64-bits.

The solution is to collect all the variables in inlined functions during the initial `get_vars` pass.