### PR TITLE
Use regex to match symbols

### DIFF
--- a/wp/plugin/tests/test_wp.ml
+++ b/wp/plugin/tests/test_wp.ml
@@ -115,6 +115,8 @@ let suite = [
 
   "Diff stack values"              >:: test_plugin "memory_samples/diff_stack" sat;
 
+  "Name matching"                  >:: test_plugin "memory_samples/name_matching" unsat;
+
   "No stack protection"            >:: test_plugin "no_stack_protection" sat;
 
   "Null dereference: no check"     >:: test_plugin "non_null_check" unsat;

--- a/wp/resources/sample_binaries/memory_samples/name_matching/Makefile
+++ b/wp/resources/sample_binaries/memory_samples/name_matching/Makefile
@@ -1,0 +1,16 @@
+include ../../optimization_flags.mk
+
+BASE=main
+PROG1=$(BASE)_1
+PROG2=$(BASE)_2
+
+all: $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj
+
+%: %.c
+	$(CC) -Wall $(FLAGS) -g -o $@ $<
+
+%.bpj: %
+	bap $< --pass=save-project --save-project-filename=$@
+
+clean:
+	rm -f $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj

--- a/wp/resources/sample_binaries/memory_samples/name_matching/main_1.c
+++ b/wp/resources/sample_binaries/memory_samples/name_matching/main_1.c
@@ -1,0 +1,9 @@
+#include <stdlib.h>
+
+int x = 1;
+
+int main(void) {
+
+  return x;
+
+}

--- a/wp/resources/sample_binaries/memory_samples/name_matching/main_2.c
+++ b/wp/resources/sample_binaries/memory_samples/name_matching/main_2.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+
+int x_1234 = 1;
+int x1_1234 = 1;
+int y = 1;
+
+int main(void) {
+
+  return x_1234;
+
+}

--- a/wp/resources/sample_binaries/memory_samples/name_matching/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/name_matching/run_wp.sh
@@ -1,0 +1,26 @@
+# A binary that returns the value of a global variable.
+
+# This tests matching a symbol in the original binary with that of the modified
+# binary whose name has been updated similarly to retrowrite's instrumentation
+# and whose address is at a different location.
+
+# Should return UNSAT
+
+set -x
+
+dummy_dir=../../dummy
+
+compile () {
+  make
+}
+
+run () {
+  bap $dummy_dir/hello_world.out --pass=wp \
+    --wp-compare \
+    --wp-file1=main_1.bpj \
+    --wp-file2=main_2.bpj \
+    --wp-mem-offset
+
+}
+
+compile && run


### PR DESCRIPTION
Fixes the finicky prefix hack we used to match symbols from the original binary to the modified binary.