### PR TITLE
Fortunac/model printing

### DIFF
--- a/wp/lib/bap_wp/src/compare.ml
+++ b/wp/lib/bap_wp/src/compare.ml
@@ -97,8 +97,8 @@ let compare_subs
   let hyps, env1, env2 =
     hyps ~original:(sub1, env1) ~modified:(sub2, env2) ~rename_set:vars in
   info "\nHypotheses:\n%s\n%!" (Constr.to_string hyps);
-  let pre_mod, _ = Pre.visit_sub env2 post sub2 in
-  let pre_combined, _ = Pre.visit_sub env1 pre_mod sub1 in
+  let pre_mod, env2 = Pre.visit_sub env2 post sub2 in
+  let pre_combined, env1 = Pre.visit_sub env1 pre_mod sub1 in
   let goal = Constr.mk_clause [hyps] [pre_combined] in
   goal, env1, env2
 

--- a/wp/lib/bap_wp/src/environment.ml
+++ b/wp/lib/bap_wp/src/environment.ml
@@ -311,6 +311,9 @@ let get_var_map (env : t) : Constr.z3_expr EnvMap.t =
 let get_init_var_map (env : t) : Constr.z3_expr EnvMap.t =
   env.init_vars
 
+let get_call_map (env : t) : string TidMap.t =
+  env.call_map
+
 let find_var (env : t) (var : Var.t) : Constr.z3_expr option =
   EnvMap.find env.var_map var
 

--- a/wp/lib/bap_wp/src/environment.ml
+++ b/wp/lib/bap_wp/src/environment.ml
@@ -48,6 +48,7 @@ type t = {
   stack : Constr.z3_expr -> Constr.z3_expr; (* takes in a memory address as a z3_var *)
   heap : Constr.z3_expr -> Constr.z3_expr;
   init_vars : Constr.z3_expr EnvMap.t;
+  consts : Constr.z3_expr list
 }
 
 and fun_spec_type =
@@ -271,7 +272,8 @@ let mk_env
     use_fun_input_regs = fun_input_regs;
     stack = init_mem_range ctx arch stack_range;
     heap = init_mem_range ctx arch heap_range;
-    init_vars = EnvMap.empty
+    init_vars = EnvMap.empty;
+    consts = []
   }
 
 let env_to_string (env : t) : string =
@@ -291,6 +293,9 @@ let set_freshen (env : t) (freshen : bool) = { env with freshen = freshen }
 
 let add_var (env : t) (v : Var.t) (x : Constr.z3_expr) : t =
   { env with var_map = EnvMap.set env.var_map ~key:v ~data:x }
+
+let add_const (env : t) (v : Constr.z3_expr) : t =
+  { env with consts = v :: env.consts }
 
 let remove_var (env : t) (v : Var.t) : t =
   { env with var_map = EnvMap.remove env.var_map v }
@@ -359,6 +364,9 @@ let get_int_handler (env : t) : int_spec =
 let get_loop_handler (env : t) :
   t -> Constr.t -> start:Graphs.Ir.Node.t -> Graphs.Ir.t -> t =
   env.loop_handler.handle
+
+let get_consts (env : t) : Constr.z3_expr list =
+  env.consts
 
 let get_arch (env : t) : Arch.t =
   env.arch

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -128,6 +128,10 @@ val get_fresh : ?name:string -> var_gen -> string
     create fresh variables. *)
 val set_freshen : t -> bool -> t
 
+(** Add a z3 expression representing a constant generated during the analysis to
+    the environment. *)
+val add_const : t -> Constr.z3_expr -> t
+
 (** A reference to {!Precondition.visit_sub} that is needed in the
     loop handler of the environment simulating "open recursion". *)
 val wp_rec_call :
@@ -206,6 +210,10 @@ val get_loop_handler :
 
 (** Obtains the architecture of the program. *)
 val get_arch : t -> Bap.Std.Arch.t
+
+(** Obtains a list of all the {!Constr.z3_expr}s that represents constants that
+    were generated during analysis. *)
+val get_consts : t -> Constr.z3_expr list
 
 (** Performs a fold on the map of of function names to tids to generate a
     {!Constr.z3_expr}. *)

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -27,6 +27,8 @@ module EnvMap = Bap.Std.Var.Map
 
 module Constr = Constraint
 
+module ExprSet : Core_kernel.Set.S with type Elt.t = Constr.z3_expr
+
 (** The state type which is maintained when creating preconditions. It contains, among
     other things, summaries for subroutines, the associations between BIR variables
     and Z3 constants, and preconditions for already visited blocks, if relevant. *)
@@ -132,6 +134,11 @@ val set_freshen : t -> bool -> t
     the environment. *)
 val add_const : t -> Constr.z3_expr -> t
 
+(** Removes all z3 expressions representing constants from the environment. This is used
+    because the initial pass through a binary generates constants that are not
+    used during precondition computation. *)
+val clear_consts : t -> t
+
 (** A reference to {!Precondition.visit_sub} that is needed in the
     loop handler of the environment simulating "open recursion". *)
 val wp_rec_call :
@@ -169,10 +176,6 @@ val get_var_map : t -> Constr.z3_expr EnvMap.t
 (** Obtains the var_map containing a mapping of BIR variables to the Z3 variables
     that represent their initial states. *)
 val get_init_var_map : t -> Constr.z3_expr EnvMap.t
-
-(** Obtains the call_map that contains the names of all the Z3 constants that
-    represent whether a function was called or not. *)
-val get_call_map : t -> string Bap.Std.Tid.Map.t
 
 (** Looks up the Z3 variable that represents a BIR variable. Produces fresh z3_expr if not found. *)
 val get_var : t -> Bap.Std.Var.t -> Constr.z3_expr * t
@@ -213,7 +216,7 @@ val get_arch : t -> Bap.Std.Arch.t
 
 (** Obtains a list of all the {!Constr.z3_expr}s that represents constants that
     were generated during analysis. *)
-val get_consts : t -> Constr.z3_expr list
+val get_consts : t -> ExprSet.t
 
 (** Performs a fold on the map of of function names to tids to generate a
     {!Constr.z3_expr}. *)

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -166,6 +166,10 @@ val get_var_map : t -> Constr.z3_expr EnvMap.t
     that represent their initial states. *)
 val get_init_var_map : t -> Constr.z3_expr EnvMap.t
 
+(** Obtains the call_map that contains the names of all the Z3 constants that
+    represent whether a function was called or not. *)
+val get_call_map : t -> string Bap.Std.Tid.Map.t
+
 (** Looks up the Z3 variable that represents a BIR variable. Produces fresh z3_expr if not found. *)
 val get_var : t -> Bap.Std.Var.t -> Constr.z3_expr * t
 

--- a/wp/lib/bap_wp/src/output.ml
+++ b/wp/lib/bap_wp/src/output.ml
@@ -40,7 +40,7 @@ let format_mem_model (fmt : Format.formatter) (mem_model : mem_model) : unit =
 (** [extract_array] takes a z3 expression that is a seqeunce of store and converts it into
     a mem_model, which consists of a key/value association list and a default value *)
 
-let extract_array (e : Constr.z3_expr) : mem_model  = 
+let extract_array (e : Constr.z3_expr) : mem_model =
   let rec extract_array' (partial_map : (Constr.z3_expr * Constr.z3_expr) list) (e : Constr.z3_expr) : mem_model =
     let numargs = Z3.Expr.get_num_args e in
     let args = Z3.Expr.get_args e in
@@ -64,11 +64,30 @@ let extract_array (e : Constr.z3_expr) : mem_model  =
   in
   extract_array' [] e
 
+(* We also want to print out the variables in the var_map of the modified binary's
+   if they already don't exist in the var_map of the original binary. *)
+let combine_maps (map1 : Constr.z3_expr Var.Map.t) (map2 : Constr.z3_expr Var.Map.t)
+  : Constr.z3_expr VarMap.t =
+  Var.Map.fold map2 ~init:map1 ~f:(fun ~key ~data map ->
+      match Var.Map.add map ~key ~data with
+      | `Ok m -> m
+      | `Duplicate -> map)
+
 let format_model (model : Model.model) (env1 : Env.t) (env2 : Env.t) : string =
   let arch = Env.get_arch env1 in
   let module Target = (val target_of_arch arch) in
-  let var_map = Env.get_var_map env1 in
-  let mem_map, reg_map = Env.EnvMap.partitioni_tf var_map ~f:(fun ~key ~data:_ -> Target.CPU.is_mem key) in
+  let var_map1 = Env.get_var_map env1 in
+  let var_map2 = Env.get_var_map env2 in
+  let init_var_map1 = Env.get_init_var_map env1 in
+  let init_var_map2 = Env.get_init_var_map env2 in
+  let call_map1 = Env.get_call_map env1 in
+  let call_map2 = Env.get_call_map env2 in
+  let mem_map, reg_map =
+    combine_maps var_map1 var_map2
+    |> Env.EnvMap.partitioni_tf ~f:(fun ~key ~data:_ -> Target.CPU.is_mem key)
+  in
+
+  (* Print registers *)
   let key_val = Env.EnvMap.fold reg_map ~init:[]
       ~f:(fun ~key ~data pairs ->
           let key_str = Var.to_string key in
@@ -77,10 +96,12 @@ let format_model (model : Model.model) (env1 : Env.t) (env2 : Env.t) : string =
   in
   let fmt = Format.str_formatter in
   Constr.format_values fmt key_val;
-  Env.EnvMap.iteri mem_map ~f:(fun ~key ~data:mem_orig -> 
+
+  (* Print memory *)
+  Env.EnvMap.iteri mem_map ~f:(fun ~key ~data:mem_orig ->
       let key_str = Var.to_string key in
       let mem_mod, _ = Env.get_var env2 key in
-      let val_orig = Constr.eval_model_exn model mem_orig in 
+      let val_orig = Constr.eval_model_exn model mem_orig in
       let val_mod = Constr.eval_model_exn model mem_mod in
       Format.fprintf fmt "\t%s_orig |-> [\n" key_str;
       format_mem_model fmt (extract_array val_orig);
@@ -90,9 +111,39 @@ let format_model (model : Model.model) (env1 : Env.t) (env2 : Env.t) : string =
         begin
           Format.fprintf fmt "\t%s_mod |-> [\n" key_str;
           format_mem_model fmt (extract_array val_mod)
-        end 
+        end
       else (Format.fprintf fmt "\t%s_mod = %s_orig" key_str key_str);
     );
+
+  (* Print other constant decls found in the model *)
+  let const_decls =
+    model
+    |> Model.get_const_decls
+    |> List.filter_map ~f:(fun decl ->
+        let exp = Fun.apply decl [] in
+        let name = Expr.to_string exp in
+        let interp = Option.value_exn (Model.get_const_interp model decl) in
+        (* Do not print decl if it is a register/mem that we already printed or is an
+           init variable that contains redundant information. *)
+        let in_map var =
+          List.exists [var_map1; var_map2; init_var_map1; init_var_map2]
+            ~f:(Var.Map.exists ~f:(fun z3_var -> Expr.equal var z3_var))
+        in
+        (* We have decls that represent whether a function has been called or not. We
+           do not print them if they are set to false. *)
+        let not_called var =
+          List.exists [call_map1; call_map2]
+            ~f:(Tid.Map.exists ~f:(fun name -> String.equal var name && Bool.is_false interp))
+        in
+        if in_map exp || not_called name then
+          None
+        else
+          Some (name, interp))
+  in
+  Format.fprintf fmt "\n%!";
+  Constr.format_values fmt const_decls;
+
+  (* Print function declarations found in the model *)
   let fun_defs =
     model
     |> Model.get_func_decls

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -137,13 +137,10 @@ let analyze_proj (ctx : Z3.context) (var_gen : Env.var_gen) (proj : project)
      environment with variables *)
   let true_constr = Pre.Bool.mk_true ctx |> Constr.mk_goal "true" |> Constr.mk_constr in
   let _, env = Pre.visit_sub env true_constr main_sub in
-  (* Initialize all the variables that have just been added to the environment. *)
-  let vars =
-    env
-    |> Env.get_var_map
-    |> Var.Map.fold ~init:Var.Set.empty ~f:(fun ~key:v ~data:_ set -> Var.Set.add set v)
-  in
-  let hyps, env = Pre.init_vars vars env in
+  (* Remove the constants generated and stored in the environment because they aren't
+     going to be used in the wp analysis. *)
+  let env = Env.clear_consts env in
+  let hyps, env = Pre.init_vars (Pre.get_vars env main_sub) env in
   let hyps = (Pre.set_sp_range env) :: hyps in
   let post =
     if String.is_empty flags.post_cond then


### PR DESCRIPTION
In the function spec for nondeterministic functions, we generate a fresh constant variable that represents the output of the function call (i.e. `__VERIFIER_nondet_int_ret_RAX039`). We then save this variable in a set in the environment, and iterate over the set when printing out the model.

For example, the output for `equiv_null_check` is:

```
Model:
	ZF  |->  #b0
	SF  |->  #b0
	RSP |->  #x00007fffffff0c00
	RSI |->  #x0000000000000000
	RDX |->  #x0000000000000000
	RDI |->  #x0000000000000000
	RCX |->  #x0000000000000000
	RBP |->  #x0000000000000000
	RAX |->  #x0000000000000000
	R9  |->  #x0000000000000000
	R8  |->  #x0000000000000000
	PF  |->  #b0
	OF  |->  #b0
	CF  |->  #b0
	AF  |->  #b0
	mem_orig |-> [
		else |-> #x00]
	mem_mod = mem_orig
	malloc_ret_RAX053   |->  #x00007fdfff7efff3
	malloc_ret_RAX02252 |->  #x0000000000000000
```
