### PR TITLE
Move hypotheses to generic sub comparator

### DIFF
--- a/wp/lib/bap_wp/src/compare.mli
+++ b/wp/lib/bap_wp/src/compare.mli
@@ -39,6 +39,8 @@ val compare_blocks
   -> output:Bap.Std.Var.Set.t
   -> original:(Bap.Std.Blk.t * Env.t)
   -> modified:(Bap.Std.Blk.t * Env.t)
+  -> smtlib_post:string
+  -> smtlib_hyp:string
   -> Constr.t * Env.t * Env.t
 
 (** Compare two subroutines by composition for equality of return
@@ -65,6 +67,8 @@ val compare_subs_eq
 val compare_subs_empty
   :  original:(Bap.Std.Sub.t * Env.t)
   -> modified:(Bap.Std.Sub.t * Env.t)
+  -> smtlib_post:string
+  -> smtlib_hyp:string
   -> Constr.t * Env.t * Env.t
 
 (** Compare two subroutines by composition for an empty
@@ -78,6 +82,8 @@ val compare_subs_empty_post
   :  input:Bap.Std.Var.Set.t
   -> original:(Bap.Std.Sub.t * Env.t)
   -> modified:(Bap.Std.Sub.t * Env.t)
+  -> smtlib_post:string
+  -> smtlib_hyp:string
   -> Constr.t * Env.t * Env.t
 
 (** Compare two subroutines by composition for conservation of function calls:
@@ -89,4 +95,6 @@ val compare_subs_empty_post
 val compare_subs_fun
   :  original:(Bap.Std.Sub.t * Env.t)
   -> modified:(Bap.Std.Sub.t * Env.t)
+  -> smtlib_post:string
+  -> smtlib_hyp:string
   -> Constr.t * Env.t * Env.t

--- a/wp/lib/bap_wp/tests/unit/test_compare.ml
+++ b/wp/lib/bap_wp/tests/unit/test_compare.ml
@@ -59,7 +59,8 @@ let test_block_pair_1 (test_ctx : test_ctxt) : unit =
   let output_vars = Var.Set.singleton z in
   let compare_prop, env1, env2 = Comp.compare_blocks
       ~input:input_vars ~output:output_vars
-      ~original:(blk1,env1) ~modified:(blk2,env2) in
+      ~original:(blk1,env1) ~modified:(blk2,env2)
+      ~smtlib_post:"" ~smtlib_hyp:"" in
   assert_z3_compare test_ctx ~orig:env1 ~modif:env2
     (Blk.to_string blk1) (Blk.to_string blk2)
     compare_prop Z3.Solver.UNSATISFIABLE
@@ -82,7 +83,8 @@ let test_block_pair_2 (test_ctx : test_ctxt) : unit =
   let output_vars = Var.Set.singleton z in
   let compare_prop, env1, env2 = Comp.compare_blocks
       ~input:input_vars ~output:output_vars
-      ~original:(blk1,env1) ~modified:(blk2,env2) in
+      ~original:(blk1,env1) ~modified:(blk2,env2)
+      ~smtlib_post:"" ~smtlib_hyp:"" in
   assert_z3_compare test_ctx ~orig:env1 ~modif:env2
     (Blk.to_string blk1) (Blk.to_string blk2)
     compare_prop Z3.Solver.UNSATISFIABLE
@@ -289,7 +291,8 @@ let test_sub_pair_6 (test_ctx : test_ctxt) : unit =
   let sub2 = Bil.([if_ (read = i32 3) [if_ (read = i32 4) [][]] []]) |> bil_to_sub in
   let vars = Var.Set.of_list [mem; loc] in
   let compare_prop, env1, env2 = Comp.compare_subs_empty_post ~input:vars
-      ~original:(sub1, env1) ~modified:(sub2, env2) in
+      ~original:(sub1, env1) ~modified:(sub2, env2)
+      ~smtlib_post:"" ~smtlib_hyp:"" in
   assert_z3_compare test_ctx ~orig:env1 ~modif:env2
     (Sub.to_string sub1) (Sub.to_string sub2)
     compare_prop Z3.Solver.UNSATISFIABLE
@@ -308,7 +311,8 @@ let test_sub_pair_7 (test_ctx : test_ctxt) : unit =
   let sub2 = Bil.([if_ (read = i32 3) [if_ (read' = i32 4) [][]] []]) |> bil_to_sub in
   let vars = Var.Set.of_list [mem; loc] in
   let compare_prop, env1, env2 = Comp.compare_subs_empty_post ~input:vars
-      ~original:(sub1, env1) ~modified:(sub2, env2) in
+      ~original:(sub1, env1) ~modified:(sub2, env2)
+      ~smtlib_post:"" ~smtlib_hyp:"" in
   assert_z3_compare test_ctx ~orig:env1 ~modif:env2
     (Sub.to_string sub1) (Sub.to_string sub2)
     compare_prop Z3.Solver.SATISFIABLE
@@ -334,7 +338,8 @@ let test_sub_pair_fun_1 (test_ctx : test_ctxt) : unit =
   let env1 = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [main_sub1; call_sub]) in
   let env2 = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [main_sub2; call_sub]) in
   let compare_prop, env1, env2 = Comp.compare_subs_fun
-      ~original:(main_sub1, env1) ~modified:(main_sub2, env2) in
+      ~original:(main_sub1, env1) ~modified:(main_sub2, env2)
+      ~smtlib_post:"" ~smtlib_hyp:"" in
   assert_z3_compare test_ctx ~orig:env1 ~modif:env2
     (Sub.to_string main_sub1) (Sub.to_string main_sub2)
     compare_prop Z3.Solver.UNSATISFIABLE
@@ -359,7 +364,8 @@ let test_sub_pair_fun_2 (test_ctx : test_ctxt) : unit =
   let env1 = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [main_sub1; call_sub]) in
   let env2 = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [main_sub2; call_sub]) in
   let compare_prop, env1, env2 = Comp.compare_subs_fun
-      ~original:(main_sub1, env1) ~modified:(main_sub2, env2) in
+      ~original:(main_sub1, env1) ~modified:(main_sub2, env2)
+      ~smtlib_post:"" ~smtlib_hyp:"" in
   assert_z3_compare test_ctx ~orig:env1 ~modif:env2
     (Sub.to_string main_sub1) (Sub.to_string main_sub2)
     compare_prop Z3.Solver.SATISFIABLE
@@ -396,7 +402,8 @@ let test_sub_pair_fun_3 (test_ctx : test_ctxt) : unit =
   let env2 = Pre.mk_env ctx var_gen
       ~subs:(Seq.of_list [main_sub2; call1_sub; call2_sub]) in
   let compare_prop, env1, env2 = Comp.compare_subs_fun
-      ~original:(main_sub1, env1) ~modified:(main_sub2, env2) in
+      ~original:(main_sub1, env1) ~modified:(main_sub2, env2)
+      ~smtlib_post:"" ~smtlib_hyp:"" in
   assert_z3_compare test_ctx ~orig:env1 ~modif:env2
     (Sub.to_string main_sub1) (Sub.to_string main_sub2)
     compare_prop Z3.Solver.SATISFIABLE
@@ -434,7 +441,8 @@ let test_sub_pair_fun_4 (test_ctx : test_ctxt) : unit =
   let env2 = Pre.mk_env ctx var_gen
       ~subs:(Seq.of_list [main_sub2; call1_sub; call2_sub]) in
   let compare_prop, env1, env2 = Comp.compare_subs_fun
-      ~original:(main_sub1, env1) ~modified:(main_sub2, env2) in
+      ~original:(main_sub1, env1) ~modified:(main_sub2, env2)
+      ~smtlib_post:"" ~smtlib_hyp:"" in
   assert_z3_compare test_ctx ~orig:env1 ~modif:env2
     (Sub.to_string main_sub1) (Sub.to_string main_sub2)
     compare_prop Z3.Solver.SATISFIABLE

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -186,6 +186,7 @@ let compare_projs (ctx : Z3.context) (var_gen : Env.var_gen) (proj : project)
   let pre, env1, env2 =
     if flags.check_calls then
       Comp.compare_subs_fun ~original:(main_sub1,env1) ~modified:(main_sub2,env2)
+        ~smtlib_post:flags.post_cond ~smtlib_hyp:flags.pre_cond
     else
       begin
         let output_vars = Var.Set.union
@@ -254,7 +255,7 @@ module Cmdline = struct
   let check_calls = param bool "check-calls" ~as_flag:true ~default:false
       ~doc:"If set, compares which subroutines are invoked in the body of the \
             function. Otherwise, compares the return values computed in the function \
-            body."
+            body. This flag is only used in comparative analysis."
 
   let inline = param (some string) "inline" ~default:None
       ~doc:"Function calls to inline as specified by a POSIX regular expression. \
@@ -305,7 +306,10 @@ module Cmdline = struct
 
   let check_null_deref = param bool "check-null-deref" ~as_flag:true ~default:false
       ~doc:"If set, the WP analysis will check for inputs that would result in \
-            dereferencing a NULL value. Defaults to false."
+            dereferencing a NULL value. In the case of a comparative analysis, \
+            asserts that if a memory read or write in the original binary does \
+            not dereference a NULL, then that same read or write in the modified \
+            binary also does not dereference a NULL. Defaults to false."
 
   let () = when_ready (fun {get=(!!)} ->
       let flags =


### PR DESCRIPTION
- The default postcondition of wp compares the output registers.
- If, `--wp-check-calls` is set, we don't compare the output registers. Instead we have the postcondition: If a function was not called in the original, then it should not be called in the modified.

- You can add hooks in both cases
- Moved two hypotheses to the generic sub comparator that will be added no matter what case we are in:
  - SP points to a location on the stack
  - all variables are equal to their initial value at the beginning of a program (i.e. RDI = init_RDI)
- You can now pass in preconditions and postconditions via the command line in both cases