### PR TITLE
Add tests that demonstrate pic and non-pic

### DIFF
--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -643,8 +643,15 @@ let num_unroll : int ref = ref 5
 
 let default_fun_specs (to_inline : Sub.t Seq.t) :
   (Sub.t -> Arch.t -> Env.fun_spec option) list =
-  [spec_verifier_error; spec_verifier_assume; spec_verifier_nondet; spec_afl_maybe_log;
-   spec_inline to_inline; spec_arg_terms; spec_chaos_caller_saved; spec_rax_out]
+  [ spec_verifier_error;
+    spec_verifier_assume;
+    spec_verifier_nondet;
+    spec_afl_maybe_log;
+    spec_inline to_inline;
+    spec_arg_terms;
+    spec_chaos_caller_saved;
+    spec_rax_out
+  ]
 
 let default_stack_range : int * int = 0x00007fffffff0000, 0x00007fffffffffff
 

--- a/wp/plugin/tests/test_wp.ml
+++ b/wp/plugin/tests/test_wp.ml
@@ -117,12 +117,16 @@ let suite = [
 
   "Name matching"                  >:: test_plugin "memory_samples/name_matching" unsat;
 
+  "No position independent"        >:: test_plugin "no_position_independent" sat;
+
   "No stack protection"            >:: test_plugin "no_stack_protection" sat;
 
   "Null dereference: no check"     >:: test_plugin "non_null_check" unsat;
   "Null dereference: with check"   >:: test_plugin "non_null_check" sat ~script:"run_wp_null_deref.sh";
 
   "Pointer input"                  >:: test_plugin "pointer_input" unsat;
+
+  "Position independent"           >:: test_plugin "position_independent" sat;
 
   "Retrowrite stub: pop RSP"       >:: test_plugin "retrowrite_stub" unsat;
   "Retrowrite stub: inline AFL"    >:: test_plugin "retrowrite_stub" unsat ~script:"run_wp_inline_afl.sh";

--- a/wp/resources/sample_binaries/.gitignore
+++ b/wp/resources/sample_binaries/.gitignore
@@ -2,8 +2,10 @@ main
 main.s
 main_1
 main_1.s
+main_1.so
 main_1.bpj
 main_2
 main_2.s
+main_2.so
 main_2.bpj
 *.gdb

--- a/wp/resources/sample_binaries/no_position_independent/Makefile
+++ b/wp/resources/sample_binaries/no_position_independent/Makefile
@@ -1,0 +1,14 @@
+BASE=main
+PROG1=$(BASE)_1
+PROG2=$(BASE)_2
+
+all: $(PROG1).so $(PROG1).bpj $(PROG2).so $(PROG2).bpj
+
+%.so: %.c
+	$(CC) -fno-stack-protector -Wall -o $@ $<
+
+%.bpj: %.so
+	bap $< --pass=save-project --save-project-filename=$@
+
+clean:
+	rm -f $(PROG1).so $(PROG1).bpj $(PROG2).so $(PROG2).bpj

--- a/wp/resources/sample_binaries/no_position_independent/main_1.c
+++ b/wp/resources/sample_binaries/no_position_independent/main_1.c
@@ -1,0 +1,15 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+int8_t init(){
+  return 0;
+}
+
+int8_t example(){
+  int8_t err = init();
+  return err;
+}
+
+int main(int argc, void * argv[]) {
+  return 0;
+}

--- a/wp/resources/sample_binaries/no_position_independent/main_2.c
+++ b/wp/resources/sample_binaries/no_position_independent/main_2.c
@@ -1,0 +1,15 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+int8_t init(){
+  return 1;
+}
+
+int8_t example(){
+  int8_t err = init();
+  return err;
+}
+
+int main(int argc, void * argv[]) {
+  return 0;
+}

--- a/wp/resources/sample_binaries/no_position_independent/run_wp.sh
+++ b/wp/resources/sample_binaries/no_position_independent/run_wp.sh
@@ -1,0 +1,24 @@
+# This tests inlining a function that has been compiled without the  fPIC flag.
+# init() returns different values, and if inlined properly, WP should be able
+# to capture this.
+
+# Should return SAT.
+
+set -x
+
+dummy_dir=../dummy
+
+compile () {
+  make
+}
+
+run () {
+  bap $dummy_dir/hello_world.out --pass=wp \
+    --wp-compare \
+    --wp-file1=main_1.bpj \
+    --wp-file2=main_2.bpj \
+    --wp-function=example \
+    --wp-inline=init
+}
+
+compile && run

--- a/wp/resources/sample_binaries/position_independent/Makefile
+++ b/wp/resources/sample_binaries/position_independent/Makefile
@@ -1,0 +1,14 @@
+BASE=main
+PROG1=$(BASE)_1
+PROG2=$(BASE)_2
+
+all: $(PROG1).so $(PROG1).bpj $(PROG2).so $(PROG2).bpj
+
+%.so: %.c
+	$(CC) -fPIC -fno-stack-protector -shared -Wall -o $@ $<
+
+%.bpj: %.so
+	bap $< --pass=save-project --save-project-filename=$@
+
+clean:
+	rm -f $(PROG1).so $(PROG1).bpj $(PROG2).so $(PROG2).bpj

--- a/wp/resources/sample_binaries/position_independent/main_1.c
+++ b/wp/resources/sample_binaries/position_independent/main_1.c
@@ -1,0 +1,11 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+int8_t init(){
+  return 0;
+}
+
+int8_t example(){
+  int8_t err = init();
+  return err;
+}

--- a/wp/resources/sample_binaries/position_independent/main_2.c
+++ b/wp/resources/sample_binaries/position_independent/main_2.c
@@ -1,0 +1,11 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+int8_t init(){
+  return 1;
+}
+
+int8_t example(){
+  int8_t err = init();
+  return err;
+}

--- a/wp/resources/sample_binaries/position_independent/run_wp.sh
+++ b/wp/resources/sample_binaries/position_independent/run_wp.sh
@@ -1,0 +1,24 @@
+# This tests inlining a function that has been compiled with fPIC.
+# init() returns different values, and if inlined properly, WP should be able
+# to capture this.
+
+# Should return SAT.
+
+set -x
+
+dummy_dir=../dummy
+
+compile () {
+  make FLAGS="-fPIC -shared"
+}
+
+run () {
+  bap $dummy_dir/hello_world.out --pass=wp \
+    --wp-compare \
+    --wp-file1=main_1.bpj \
+    --wp-file2=main_2.bpj \
+    --wp-function=example \
+    --wp-inline=init
+}
+
+compile && run


### PR DESCRIPTION
With BAP's new stub resolver, we don't need the PLT spec, and can just inline the target function itself. This PR adds two tests that should work with the resolver, one with PIC enabled and another with PIC disabled.

Addresses #132.