### PR TITLE
Fortunac/code cleanup

### DIFF
--- a/wp/lib/bap_wp/src/bil_to_bir.ml
+++ b/wp/lib/bap_wp/src/bil_to_bir.ml
@@ -18,11 +18,12 @@
    [example]
 
    Note that not all BIL instructions are supported, only
-   [x := e], [while_ e b] and [if_ e a b] are for now. *)
+   [x := e], [while_ e b] and [if_ e a b] are for now.
+
+*)
 
 open !Core_kernel
 open Bap.Std
-
 
 let mk_assert_fail () : Sub.t * Exp.t =
   let call_tid = Tid.create () in

--- a/wp/lib/bap_wp/src/bil_to_bir.ml
+++ b/wp/lib/bap_wp/src/bil_to_bir.ml
@@ -30,80 +30,90 @@ let mk_assert_fail () : Sub.t * Exp.t =
   let call_sub = Sub.create ~tid:call_tid ~name:"__assert_fail" () in
   call_sub, Bil.unknown (Tid.to_string call_tid) reg64_t
 
-
-let rec stmt_to_blks (stmt : Bil.Types.stmt)
+let rec stmt_to_blks
+    (stmt : Bil.Types.stmt)
     (sub : Sub.Builder.t)
     (tail_blk : Blk.Builder.t)
   : Sub.Builder.t * Blk.Builder.t =
   match stmt with
-  | Bil.Types.Move (x, e) ->
-    Blk.Builder.add_def tail_blk (Def.create x e);
-    sub, tail_blk
-  | Bil.Types.If (e, ls, rs) ->
-    let tid_l = Tid.create () in
-    let tid_r = Tid.create () in
-    let sub_l, blk_l = bil_to_blks ls sub (Blk.Builder.create ~tid:tid_l ()) in
-    (* We pass along the sub builder, to add all required blocks in both branches *)
-    let sub_r, blk_r = bil_to_blks rs sub_l (Blk.Builder.create ~tid:tid_r ()) in
-    Blk.Builder.add_jmp tail_blk (Jmp.create ~cond:e (Goto (Label.direct tid_l)));
-    Blk.Builder.add_jmp tail_blk (Jmp.create (Goto (Label.direct tid_r)));
-    let old_blk = Blk.Builder.result tail_blk in
-    Sub.Builder.add_blk sub_r old_blk;
-    let merge_tid = Tid.create () in
-    let merge_blk = Blk.Builder.create ~tid:merge_tid () in
-    let lab = Label.direct merge_tid in
-    Blk.Builder.add_jmp blk_l (Jmp.create (Goto lab));
-    let lhs_blk = Blk.Builder.result blk_l in
-    Sub.Builder.add_blk sub_r lhs_blk;
-    Blk.Builder.add_jmp blk_r (Jmp.create (Goto lab));
-    let rhs_blk = Blk.Builder.result blk_r in
-    Sub.Builder.add_blk sub_r rhs_blk;
-    sub_r, merge_blk
-
-  | Bil.Types.While (e, ss) ->
-    let exit_tid = Tid.create () in
-    let entry_tid = Tid.create () in
-    let body_tid = Tid.create () in
-    let exit_block = Blk.Builder.create ~tid:exit_tid () in
-    let entry_block = Blk.Builder.create ~tid:entry_tid () in
-    let body_block = Blk.Builder.create ~tid:body_tid () in
-    Blk.Builder.add_jmp tail_blk (Jmp.create (Goto (Label.direct entry_tid)));
-    Sub.Builder.add_blk sub (Blk.Builder.result tail_blk);
-    Blk.Builder.add_jmp entry_block
-      (Jmp.create ~cond:(Bil.lnot e) (Goto (Label.direct exit_tid)));
-    Blk.Builder.add_jmp entry_block
-      (Jmp.create (Goto (Label.direct body_tid)));
-    Sub.Builder.add_blk sub (Blk.Builder.result entry_block);
-    let sub_loop, blk_loop = bil_to_blks ss sub body_block in
-    Blk.Builder.add_jmp blk_loop
-      (Jmp.create (Goto (Label.direct entry_tid)));
-    Sub.Builder.add_blk sub_loop (Blk.Builder.result blk_loop);
-    sub_loop, exit_block
-
-  | Bil.Types.Jmp e ->
-    begin
-      match e with
-      (* This is a huge hack to enable calling "special" functions with chosen names
-         and [tid]s
-      *)
-      | Bil.Unknown (tid_s, _) ->
-        let call_tid = Tid.from_string_exn tid_s in
-        Blk.Builder.add_jmp tail_blk
-          (Jmp.create (Call (Call.create ~target:(Label.direct call_tid) ())));
-        sub, tail_blk
-      | _ ->
-        Blk.Builder.add_jmp tail_blk
-          (Jmp.create (Goto (Label.indirect e)));
-        sub, tail_blk
-    end
-
-  (* We currently don't handle any of these cases *)
-
+  | Bil.Types.Move (x, e) -> mk_move x e sub tail_blk
+  | Bil.Types.If (e, ls, rs) -> mk_if e ls rs sub tail_blk
+  | Bil.Types.While (e, ss) -> mk_while e ss sub tail_blk
+  | Bil.Types.Jmp e -> mk_jmp e sub tail_blk
+  (* We currently don't handle any of these cases. *)
   | Bil.Types.Special _ -> assert false
-
   | Bil.Types.CpuExn _ -> assert false
 
-and bil_to_blks (stmts : Bil.t)
+and mk_move (x : Var.t) (e : Exp.t) (sub : Sub.Builder.t) (blk : Blk.Builder.t)
+  : Sub.Builder.t * Blk.Builder.t  =
+  Blk.Builder.add_def blk (Def.create x e);
+  sub, blk
+
+and mk_if
+    (e : Exp.t)
+    (ls : stmt list)
+    (rs : stmt list)
+    (sub : Sub.Builder.t)
+    (blk : Blk.Builder.t)
+  : Sub.Builder.t * Blk.Builder.t =
+  let tid_l = Tid.create () in
+  let tid_r = Tid.create () in
+  let sub_l, blk_l = bil_to_blks ls sub (Blk.Builder.create ~tid:tid_l ()) in
+  (* We pass along the sub builder, to add all required blocks in both branches *)
+  let sub_r, blk_r = bil_to_blks rs sub_l (Blk.Builder.create ~tid:tid_r ()) in
+  Blk.Builder.add_jmp blk (Jmp.create ~cond:e (Goto (Label.direct tid_l)));
+  Blk.Builder.add_jmp blk (Jmp.create (Goto (Label.direct tid_r)));
+  let old_blk = Blk.Builder.result blk in
+  Sub.Builder.add_blk sub_r old_blk;
+  let merge_tid = Tid.create () in
+  let merge_blk = Blk.Builder.create ~tid:merge_tid () in
+  let lab = Label.direct merge_tid in
+  Blk.Builder.add_jmp blk_l (Jmp.create (Goto lab));
+  let lhs_blk = Blk.Builder.result blk_l in
+  Sub.Builder.add_blk sub_r lhs_blk;
+  Blk.Builder.add_jmp blk_r (Jmp.create (Goto lab));
+  let rhs_blk = Blk.Builder.result blk_r in
+  Sub.Builder.add_blk sub_r rhs_blk;
+  sub_r, merge_blk
+
+and mk_while (e : Exp.t) (ss : stmt list) (sub : Sub.Builder.t) (blk : Blk.Builder.t)
+  : Sub.Builder.t * Blk.Builder.t =
+  let exit_tid = Tid.create () in
+  let entry_tid = Tid.create () in
+  let body_tid = Tid.create () in
+  let exit_block = Blk.Builder.create ~tid:exit_tid () in
+  let entry_block = Blk.Builder.create ~tid:entry_tid () in
+  let body_block = Blk.Builder.create ~tid:body_tid () in
+  Blk.Builder.add_jmp blk (Jmp.create (Goto (Label.direct entry_tid)));
+  Sub.Builder.add_blk sub (Blk.Builder.result blk);
+  Blk.Builder.add_jmp entry_block
+    (Jmp.create ~cond:(Bil.lnot e) (Goto (Label.direct exit_tid)));
+  Blk.Builder.add_jmp entry_block
+    (Jmp.create (Goto (Label.direct body_tid)));
+  Sub.Builder.add_blk sub (Blk.Builder.result entry_block);
+  let sub_loop, blk_loop = bil_to_blks ss sub body_block in
+  Blk.Builder.add_jmp blk_loop
+    (Jmp.create (Goto (Label.direct entry_tid)));
+  Sub.Builder.add_blk sub_loop (Blk.Builder.result blk_loop);
+  sub_loop, exit_block
+
+(* This is a huge hack to enable calling "special" functions with chosen names
+   and [tid]s. *)
+and mk_jmp (e : Exp.t) (sub : Sub.Builder.t) (blk : Blk.Builder.t)
+  : Sub.Builder.t * Blk.Builder.t =
+  match e with
+  | Bil.Unknown (tid_s, _) ->
+    let call_tid = Tid.from_string_exn tid_s in
+    Blk.Builder.add_jmp blk
+      (Jmp.create (Call (Call.create ~target:(Label.direct call_tid) ())));
+    sub, blk
+  | _ ->
+    Blk.Builder.add_jmp blk
+      (Jmp.create (Goto (Label.indirect e)));
+    sub, blk
+
+and bil_to_blks
+    (stmts : Bil.t)
     (sub : Sub.Builder.t)
     (tail_blk : Blk.Builder.t)
   : Sub.Builder.t * Blk.Builder.t =

--- a/wp/lib/bap_wp/src/environment.ml
+++ b/wp/lib/bap_wp/src/environment.ml
@@ -153,9 +153,9 @@ let wp_rec_call :
   (t -> Constr.t -> start:Graphs.Ir.Node.t -> Graphs.Ir.t -> t) ref =
   ref (fun _ _ ~start:_ _ -> assert false)
 
-let trivial_pre (env : t) : Constr.t =
-  let ctx = get_context env in
-  Z3.Boolean.mk_true ctx
+let trivial_constr (env : t) : Constr.t =
+  get_context env
+  |> Z3.Boolean.mk_true
   |> Constr.mk_goal "true"
   |> Constr.mk_constr
 
@@ -211,7 +211,7 @@ let init_loop_unfold (num_unroll : int) : loop_handler =
             | Some p -> p
             | None ->
               warning "Trivial precondition is being used for node %s%!" (Tid.to_string tid);
-              trivial_pre env
+              trivial_constr env
           in
           add_precond env tid pre
         else

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -247,6 +247,9 @@ val mk_init_var : t -> Bap.Std.Var.t -> Constr.z3_expr * t
     of a bap variable [var]. *)
 val get_init_var : t -> Bap.Std.Var.t -> Constr.z3_expr option
 
+(** [trivial_constr] generates a trivial constraint of just [true]. *)
+val trivial_constr : t -> Constr.t
+
 (*-------- Z3 constant creation utilities ----------*)
 
 (** Create a constant Z3 expression of a type that corresponds to a bap type, where

--- a/wp/lib/bap_wp/src/output.ml
+++ b/wp/lib/bap_wp/src/output.ml
@@ -46,31 +46,25 @@ let extract_array (e : Constr.z3_expr) : mem_model =
     let args = Z3.Expr.get_args e in
     let f_decl = Z3.Expr.get_func_decl e in
     let f_name = Z3.FuncDecl.get_name f_decl |> Z3.Symbol.to_string in
-    if ( Int.(numargs = 3) && String.(f_name = "store"))
-    then begin
+    if Int.(numargs = 3) && String.(f_name = "store") then begin
       let next_arr = List.nth_exn args 0 in
       let key = List.nth_exn args 1 in
       let value = List.nth_exn args 2 in
-      extract_array' (( key , value ) :: partial_map) next_arr
+      extract_array' ((key , value) :: partial_map) next_arr
     end
-    else if ( Int.(numargs = 1) && String.(f_name = "const")) then begin
+    else if Int.(numargs = 1) && String.(f_name = "const") then begin
       let key = List.nth_exn args 0 in
-      { default = key; model = List.rev partial_map}
+      { default = key; model = List.rev partial_map }
     end
     else begin
       warning "Unexpected case destructing Z3 array: %s" (Z3.Expr.to_string e);
-      {default = e ; model = partial_map}
+      { default = e ; model = partial_map }
     end
   in
   extract_array' [] e
 
-let format_model (model : Model.model) (env1 : Env.t) (env2 : Env.t) : string =
-  let arch = Env.get_arch env1 in
-  let module Target = (val target_of_arch arch) in
-  let var_map = Env.get_var_map env1 in
-  let mem_map, reg_map = Env.EnvMap.partitioni_tf var_map ~f:(fun ~key ~data:_ -> Target.CPU.is_mem key) in
-
-  (* Print registers *)
+let print_registers (fmt : Format.formatter) (model : Model.model)
+    (reg_map : Constr.z3_expr Var.Map.t) : unit =
   let key_val = Env.EnvMap.fold reg_map ~init:[]
       ~f:(fun ~key ~data pairs ->
           if Var.is_physical key then
@@ -80,10 +74,13 @@ let format_model (model : Model.model) (env1 : Env.t) (env2 : Env.t) : string =
           else
             pairs)
   in
-  let fmt = Format.str_formatter in
-  Constr.format_values fmt key_val;
+  Constr.format_values fmt key_val
 
-  (* Print memory *)
+(* We should pass in env2 because the values of memory can differ in the second
+   environment. We need to get the Z3 name for the memory in env2 because the
+   memory map pnly contains the Z3 name for the memory in env1. *)
+let print_memory (fmt : Format.formatter) (model : Model.model)
+    (mem_map : Constr.z3_expr Var.Map.t) (env2 : Env.t) : unit =
   Env.EnvMap.iteri mem_map ~f:(fun ~key ~data:mem_orig ->
       let key_str = Var.to_string key in
       let mem_mod, _ = Env.get_var env2 key in
@@ -98,11 +95,12 @@ let format_model (model : Model.model) (env1 : Env.t) (env2 : Env.t) : string =
           Format.fprintf fmt "\t%s_mod |-> [\n" key_str;
           format_mem_model fmt (extract_array val_mod)
         end
-      else (Format.fprintf fmt "\t%s_mod = %s_orig" key_str key_str);
-    );
+      else Format.fprintf fmt "\t%s_mod = %s_orig" key_str key_str
+    )
 
-  (* Print out constants that were generated during analysis. *)
-  let consts = Env.ExprSet.union (Env.get_consts env1) (Env.get_consts env2) in
+(* These are the constants that were generated during the analysis. *)
+let print_constants (fmt : Format.formatter) (model : Model.model)
+    (consts : Env.ExprSet.t) : unit =
   let const_vals =
     Env.ExprSet.fold consts ~init:[] ~f:(fun pairs c ->
         let name = Expr.to_string c in
@@ -110,9 +108,9 @@ let format_model (model : Model.model) (env1 : Env.t) (env2 : Env.t) : string =
         (name, value) :: pairs)
   in
   Format.fprintf fmt "\n%!";
-  Constr.format_values fmt const_vals;
+  Constr.format_values fmt const_vals
 
-  (* Print function declarations found in the model *)
+let print_fun_decls (fmt : Format.formatter) (model : Model.model) : unit =
   let fun_defs =
     model
     |> Model.get_func_decls
@@ -122,7 +120,21 @@ let format_model (model : Model.model) (env1 : Env.t) (env2 : Env.t) : string =
   in
   Format.fprintf fmt "\n";
   List.iter fun_defs ~f:(fun (def, interp) ->
-      Format.fprintf fmt "%s  %s\n" (Fun.to_string def) (FInterp.to_string interp));
+      Format.fprintf fmt "%s  %s\n" (Fun.to_string def) (FInterp.to_string interp))
+
+let format_model (model : Model.model) (env1 : Env.t) (env2 : Env.t) : string =
+  let fmt = Format.str_formatter in
+  let arch = Env.get_arch env1 in
+  let module Target = (val target_of_arch arch) in
+  let var_map = Env.get_var_map env1 in
+  let mem_map, reg_map =
+    Env.EnvMap.partitioni_tf var_map ~f:(fun ~key ~data:_ -> Target.CPU.is_mem key)
+  in
+  let consts = Env.ExprSet.union (Env.get_consts env1) (Env.get_consts env2) in
+  print_registers fmt model reg_map;
+  print_memory fmt model mem_map env2;
+  print_constants fmt model consts;
+  print_fun_decls fmt model;
   Format.flush_str_formatter ()
 
 let get_mem (m : Z3.Model.model) (env : Env.t) : mem_model option =
@@ -159,8 +171,8 @@ let print_result (solver : Solver.solver) (status : Solver.status) (goals: Const
 
 (** [output_gdb] is similar to [print_result] except chews on the model and outputs a gdb script with a
     breakpoint at the subroutine and fills the appropriate registers *)
-
-let expr_to_hex (e : Constr.z3_expr) : string = Z3.Expr.to_string e |> String.substr_replace_first ~pattern:"#" ~with_:"0"
+let expr_to_hex (e : Constr.z3_expr) : string =
+  Z3.Expr.to_string e |> String.substr_replace_first ~pattern:"#" ~with_:"0"
 
 let output_gdb (solver : Solver.solver) (status : Solver.status)
     (env : Env.t) ~func:(func : string) ~filename:(gdb_filename : string) : unit =
@@ -170,19 +182,18 @@ let output_gdb (solver : Solver.solver) (status : Solver.status)
     let option_mem_model = get_mem model env in
     let varmap = Env.get_var_map env in
     let module Target = (val target_of_arch (Env.get_arch env)) in
-    let regmap = VarMap.filter_keys ~f:(Target.CPU.is_reg) varmap in 
+    let regmap = VarMap.filter_keys ~f:(Target.CPU.is_reg) varmap in
     let reg_val_map = VarMap.map ~f:(fun z3_reg -> Constr.eval_model_exn model z3_reg) regmap in
     Out_channel.with_file gdb_filename  ~f:(fun t ->
         Printf.fprintf t "break *%s\n" func; (* The "*" is necessary to break before some slight setup *)
         Printf.fprintf t "run\n";
-        VarMap.iteri reg_val_map ~f:(fun ~key ~data -> 
+        VarMap.iteri reg_val_map ~f:(fun ~key ~data ->
             let hex_value = expr_to_hex data in
             Printf.fprintf t "set $%s = %s \n" (String.lowercase (Var.name key)) hex_value;
           );
         match option_mem_model with
         | None -> ()
-        | Some mem_model ->  List.iter mem_model.model ~f:(fun (addr,value) -> 
-            Printf.fprintf t "set {int}%s = %s \n" (expr_to_hex addr) (expr_to_hex value)  );
-          ()
+        | Some mem_model ->  List.iter mem_model.model ~f:(fun (addr,value) ->
+            Printf.fprintf t "set {int}%s = %s \n" (expr_to_hex addr) (expr_to_hex value))
       )
   | _ -> ()

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -13,6 +13,7 @@
 
 open !Core_kernel
 open Bap.Std
+open Graphlib.Std
 
 include Self()
 
@@ -791,7 +792,6 @@ let visit_block (env : Env.t) (post : Constr.t) (blk : Blk.t) : Constr.t * Env.t
 
 let visit_graph (env : Env.t) (post : Constr.t)
     ~start:start (g : Graphs.Ir.t) : Constr.t * Env.t =
-  let module G = Graphlib.Std.Graphlib in
   let leave_node _ n (_, env) =
     let b = Graphs.Ir.Node.label n in
     visit_block env post b in
@@ -810,7 +810,7 @@ let visit_graph (env : Env.t) (post : Constr.t)
       end
     | _ -> p
   in
-  G.depth_first_search (module Graphs.Ir)
+  Graphlib.depth_first_search (module Graphs.Ir)
     ~enter_edge:enter_edge ~start:start ~leave_node:leave_node ~init:(post, env)
     g
 
@@ -822,7 +822,6 @@ let _ = Env.wp_rec_call :=
 (* BAP currently doesn't have a way to determine that exit does not return.
    This function removes the backedge after the call to exit. *)
 let filter (env : Env.t) (calls : string list) (cfg : Graphs.Ir.t) : Graphs.Ir.t =
-  let module G = Graphlib.Std.Graphlib in
   let enter_edge kind e cfg =
     match kind with
     | `Back -> begin
@@ -856,7 +855,7 @@ let filter (env : Env.t) (calls : string list) (cfg : Graphs.Ir.t) : Graphs.Ir.t
       end
     | _ -> cfg
   in
-  G.depth_first_search (module Graphs.Ir) ~enter_edge:enter_edge ~init:cfg cfg
+  Graphlib.depth_first_search (module Graphs.Ir) ~enter_edge:enter_edge ~init:cfg cfg
 
 let visit_sub (env : Env.t) (post : Constr.t) (sub : Sub.t) : Constr.t * Env.t =
   debug "Visiting sub:\n%s%!" (Sub.to_string sub);

--- a/wp/lib/bap_wp/src/z3_utils.ml
+++ b/wp/lib/bap_wp/src/z3_utils.ml
@@ -27,7 +27,7 @@ module Solver = Z3.Solver
 module Env = Environment
 module Constr = Constraint
 
-let get_decls_and_symbols (env : Env.t) : ((FuncDecl.func_decl * Symbol.symbol) list) = 
+let get_decls_and_symbols (env : Env.t) : ((FuncDecl.func_decl * Symbol.symbol) list) =
   let ctx = Env.get_context env in
   let var_to_decl ~key:_ ~data:z3_var decls =
     assert (Expr.is_const z3_var);
@@ -35,14 +35,15 @@ let get_decls_and_symbols (env : Env.t) : ((FuncDecl.func_decl * Symbol.symbol) 
         (Expr.to_string z3_var)
         (Expr.get_sort z3_var) in
     let sym =  Symbol.mk_string ctx (Expr.to_string z3_var) in
-    (decl,sym)::decls
+    (decl, sym) :: decls
   in
   let var_map = Env.get_var_map env in
   let init_var_map = Env.get_init_var_map env in
   let var_decls = Env.EnvMap.fold var_map ~init:[] ~f:var_to_decl in
   Env.EnvMap.fold init_var_map ~init:var_decls ~f:var_to_decl
 
-let mk_smtlib2 (ctx : Z3.context) (smtlib_str : string) (decl_syms : (Z3.FuncDecl.func_decl * Z3.Symbol.symbol) list) : Constr.t =
+let mk_smtlib2 (ctx : Z3.context) (smtlib_str : string)
+    (decl_syms : (Z3.FuncDecl.func_decl * Z3.Symbol.symbol) list) : Constr.t =
   let fun_decls, fun_symbols = List.unzip decl_syms in
   let sort_symbols = [] in
   let sorts = [] in
@@ -68,10 +69,8 @@ let tokenize (str : string) : string list =
       | `Delim g ->
         (* There should always be one value in the group. If not, we will raise an
            exception. *)
-        if Re.Group.nb_groups g <> 1 then
-          failwith "Number of groups in string delimeter is not 1"
-        else
-          Re.Group.get g 0)
+        assert (Re.Group.nb_groups g = 1);
+        Re.Group.get g 0)
 
 let build_str (tokens : string list) : string =
   List.fold tokens ~init:"" ~f:(fun post token -> token ^ post)

--- a/wp/lib/bap_wp/src/z3_utils.mli
+++ b/wp/lib/bap_wp/src/z3_utils.mli
@@ -34,21 +34,21 @@ val build_str : string list -> string
 val get_z3_name :
   Constr.z3_expr Bap.Std.Var.Map.t -> string -> (Bap.Std.Var.t -> string) -> string option
 
-(** [get_decls_and_symbols] builds from a the var_map in an environment 
+(** [get_decls_and_symbols] builds from a the var_map in an environment
     a mapping of all Z3 func_decl to their symbol. This is a helper function for
     [mk_smtlib2] *)
-val get_decls_and_symbols : Env.t -> ((Z3.FuncDecl.func_decl * Z3.Symbol.symbol) list) 
+val get_decls_and_symbols : Env.t -> ((Z3.FuncDecl.func_decl * Z3.Symbol.symbol) list)
 
 (** [mk_smtlib2_single env smtlib_str] takes in a string representing a
-    valid SMT-Lib-2 statement. 
+    valid SMT-Lib-2 statement.
     The variables in the SMT-Lib statements need to appear in the
     environment. The intended purpose of this function is generating hypothesis
      and postconditions for single binary analysis *)
 val mk_smtlib2_single : Env.t -> string -> Constr.t
 
-(** [mk_smtlib2] parses a smtlib2 string in the context that has a mapping of func_decl 
-    to symbols and returns a constraint [Constr.t] corresponding to the smtlib2 string. 
-    The [func_decl * symbol] mapping can be constructed from an [Env.t] using the 
+(** [mk_smtlib2] parses a smtlib2 string in the context that has a mapping of func_decl
+    to symbols and returns a constraint [Constr.t] corresponding to the smtlib2 string.
+    The [func_decl * symbol] mapping can be constructed from an [Env.t] using the
     [get_decls_and_symbols] function. *)
 
 val mk_smtlib2 : Z3.context -> string -> ((Z3.FuncDecl.func_decl * Z3.Symbol.symbol) list)  -> Constr.t

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -71,8 +71,9 @@ let match_inline (to_inline : string option) (subs : (Sub.t Seq.t)) : Sub.t Seq.
   | None -> Seq.empty
   | Some to_inline -> let inline_pat = Re.Posix.re to_inline |> Re.Posix.compile in
     let filter_subs = Seq.filter ~f:(fun s -> Re.execp inline_pat (Sub.name s)) subs in
-    let _ = if Seq.length_is_bounded_by ~min:1 filter_subs then
-        info "Inlining functions: %s\n"  (filter_subs |> Seq.to_list |> List.to_string ~f:(fun sub -> (Sub.name sub)))
+    let () =
+      if Seq.length_is_bounded_by ~min:1 filter_subs then
+        info "Inlining functions: %s\n" (filter_subs |> Seq.to_list |> List.to_string ~f:Sub.name)
       else
         warning "No matches on inlining\n"
     in
@@ -135,7 +136,7 @@ let analyze_proj (ctx : Z3.context) (var_gen : Env.var_gen) (proj : project)
       ~use_fun_input_regs:flags.use_fun_input_regs ~exp_conds in
   (* call visit sub with a dummy postcondition to fill the
      environment with variables *)
-  let true_constr = Pre.Bool.mk_true ctx |> Constr.mk_goal "true" |> Constr.mk_constr in
+  let true_constr = Env.trivial_constr env in
   let _, env = Pre.visit_sub env true_constr main_sub in
   (* Remove the constants generated and stored in the environment because they aren't
      going to be used in the wp analysis. *)


### PR DESCRIPTION
Code cleanup:
- broke up big functions into smaller pieces:
  - `stmt_to_blks` has been separated into
    - `mk_move`
    - `mk_if`
    - `mk_while`
    - `mk_jmp`
  - `format_model` has been separated into
    - `print_registers`
    - `print_memory`
    - `print_constants`
    - `print_fun_decls`

- Some whitespace fixes.
- Some eta reduction in a few of our anonymous functions
- Refactored out some functions we used multiple times
- Removed unused opened modules
- Changed `var = "foo"` into `String.(var = "foo")` 