### PR TITLE
Update package versions in READMEs

### DIFF
--- a/wp/lib/bap_wp/README.md
+++ b/wp/lib/bap_wp/README.md
@@ -9,8 +9,8 @@ A weakest-precondition analysis library, for BAP plugins/tools.
 
 Before installing `bap_wp`, the following requirements must be met:
 
-* BAP 2.0.0+ must be available. Confirm with `bap --version`.
-* z3 4.8.6+ must be available to `findlib` under the name `z3`
+* BAP 2.1.0+ must be available. Confirm with `bap --version`.
+* z3 4.8.8+ must be available to `findlib` under the name `z3`
   (note the lowercase `z`). Confirm with `ocamlfind query z3`.
 * core 0.12.4+ must be available. Confirm with `ocamlfind query core`.
 * oUnit must be available to `findlib` under the name `oUnit`
@@ -90,7 +90,6 @@ plugin. However, it may also be used as a standalone library, to
 invoke a WP computation over a bap subroutine or block.
 
 The file [src/precondition.mli] describes the main API. The general
-approach is to use `mk_default_env` or `mk_inline_env` to create an
-analysis environment, and then call `visit_sub` with a given
-postcondition and subroutine, to get the corresponding precondition,
-which can then be checked with `check`.
+approach is to use `mk_env` to create an analysis environment, and then call
+`visit_sub` with a given postcondition and subroutine, to get the
+corresponding precondition, which can then be checked with `check`.

--- a/wp/plugin/README.md
+++ b/wp/plugin/README.md
@@ -4,20 +4,16 @@
 
 Depends on:
 
-    - ocaml 4.05.0
+    - ocaml 4.07.0
     - core_kernel 0.12.4+
-    - bap 2.0.0
+    - bap 2.1.0
     - ounit 2.0.8
-    - z3 4.8.6
+    - z3 4.8.8
     - re 1.9.0
 
 All these can be installed with
 
     opam install package_name
-
-The latest z3 version can be installed with
-
-    opam pin add z3.4.8.6 --dev-repo
 
 To build and install the plugin:
 


### PR DESCRIPTION
Addresses #110. Now that opam has Z3 4.8.8, we can just install Z3 with `opam install z3` similarly to how we install other libraries. This PR reflects this change and updates the version numbers for the libraries we are using.