### PR TITLE
Run ocamlformat on WP

### DIFF
--- a/wp/Makefile
+++ b/wp/Makefile
@@ -2,7 +2,7 @@ BAP_WP = lib/bap_wp
 WP = plugin
 SAMPLE_BINS = resources/sample_binaries
 
-.PHONY: install doc test clean reinstall
+.PHONY: install doc test clean reinstall format
 
 install:
 	$(MAKE) -C $(BAP_WP) $@.local
@@ -10,6 +10,10 @@ install:
 
 doc:
 	$(MAKE) -C $(BAP_WP) $@
+
+format:
+	$(MAKE) -C $(BAP_WP) $@
+	$(MAKE) -C $(WP) $@
 
 test: install
 	$(MAKE) -C $(BAP_WP) $@

--- a/wp/lib/bap_wp/.ocamlformat
+++ b/wp/lib/bap_wp/.ocamlformat
@@ -1,0 +1,2 @@
+doc-comments = before
+doc-comments-val = before

--- a/wp/lib/bap_wp/Makefile
+++ b/wp/lib/bap_wp/Makefile
@@ -25,6 +25,9 @@ test.performance:
 doc:
 	dune build @doc
 
+format:
+	-dune build @fmt --auto-promote
+
 check.installed.findlib:
 	ocamlfind query $(project)
 

--- a/wp/lib/bap_wp/README.md
+++ b/wp/lib/bap_wp/README.md
@@ -16,9 +16,11 @@ Before installing `bap_wp`, the following requirements must be met:
 * oUnit must be available to `findlib` under the name `oUnit`
   (confirm with `ocamlfind query oUnit`) and it must be available
   to `opam` under the name `ounit` (confirm with `opam show ounit`).
-* Dune 1.6+ must be available. Confirm with `dune --version`.
+* Dune 2.5+ must be available. Confirm with `dune --version`.
 * To build the documentation, you need odoc 1.4.0, which can also be
   installed with `opam install odoc`.
+* To format the code, you need ocamlformat 0.14.2, which can also be
+  installed with `opam install ocamlformat`.
 
 
 ### Install (local)

--- a/wp/lib/bap_wp/dune-project
+++ b/wp/lib/bap_wp/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.7)
+(lang dune 2.5)
 (name bap_wp)

--- a/wp/plugin/.ocamlformat
+++ b/wp/plugin/.ocamlformat
@@ -1,0 +1,2 @@
+doc-comments = before
+doc-comments-val = before

--- a/wp/plugin/Makefile
+++ b/wp/plugin/Makefile
@@ -4,7 +4,7 @@ SAMPLE_BIN_DIR = ../resources/sample_binaries
 SAVE_PROJECT_DIR = ./save_project
 API_PATH = $(shell bap --api-list-paths)
 
-.PHONY: all build install clean verifier save_project
+.PHONY: all build install clean verifier save_project format
 
 all: install
 
@@ -27,6 +27,9 @@ save_project:
 
 dummy:
 	$(MAKE) -C $(SAMPLE_BIN_DIR)/dummy
+
+format:
+	ocamlformat -i $(PASS_NAME).ml tests/*
 
 clean:
 	$(MAKE) -C $(SAVE_PROJECT_DIR) $@

--- a/wp/plugin/README.md
+++ b/wp/plugin/README.md
@@ -10,6 +10,7 @@ Depends on:
     - ounit 2.0.8
     - z3 4.8.8
     - re 1.9.0
+    - ocamlformat 0.14.2
 
 All these can be installed with
 


### PR DESCRIPTION
- `ocamlformat` should be installed with `opam install ocamlformat`
- You can format your code with `make format`