### PR TITLE
Added flag to suppress precondition.

### DIFF
--- a/wp/plugin/README.md
+++ b/wp/plugin/README.md
@@ -366,6 +366,11 @@ The various options are:
   contraint that if a memory read or write dereferences a non-null address in the
   original binary, then that same address is also non-null in the modified binary.
   Defaults to false.
+  
+-- `--wp-suppress-precond=[true|false]` If present, suppresses the printing of 
+  generated precondition(s) (shows in the log instead of stdout). Only applies 
+  in the single binary analysis case. In the comparative case, has no effect. 
+  Defaults to false.
 
 ## C checking API
 


### PR DESCRIPTION
Addresses issue #160 by adding in the flag `--wp-suppress-precond`. This flag defaults to false, and when set, prints the precondition to the log instead of stdout in the single binary case (in the comparative case, since the precondition is not printed, the flag has no effect). An example invocation might be:

`bap main --pass=wp --wp-suppress-precond`