### PR TITLE
Added flag to print smtlib2 (and now also incorporates fix for issue #162)

### DIFF
--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -1090,7 +1090,7 @@ let exclude (solver : Solver.solver) (ctx : Z3.context) ~var:(var : Constr.z3_ex
   Solver.add solver [cond];
   info "Added constraints: %s\n%!"
     (Solver.get_assertions solver |> List.to_string ~f:Expr.to_string);
-  check solver ctx pre ~output_smtlib2:false
+  check solver ctx pre
 
 let get_output_vars (env : Env.t) (t : Sub.t) (var_names : string list) : Var.Set.t =
   let all_vars = get_vars env t in

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -1066,7 +1066,8 @@ let mem_read_offsets (env2 : Env.t) (offset : Constr.z3_expr -> Constr.z3_expr)
   else
     Some (Assume (AfterExec (Constr.mk_goal name (Bool.mk_and ctx conds))))
 
-let check ?refute:(refute = true) ?(output_smtlib2 = false) (solver : Solver.solver) (ctx : Z3.context) (pre : Constr.t)  : Solver.status =
+let check ?refute:(refute = true) ?(print_constr = []) (solver : Solver.solver)
+    (ctx : Z3.context) (pre : Constr.t)  : Solver.status =
   printf "Evaluating precondition.\n%!";
   let pre' = Constr.eval pre ctx in
   printf "Checking precondition with Z3.\n%!";
@@ -1077,7 +1078,7 @@ let check ?refute:(refute = true) ?(output_smtlib2 = false) (solver : Solver.sol
       pre'
   in
   Z3.Solver.add solver [is_correct];
-  if (output_smtlib2) then (
+  if (List.mem print_constr "smtlib" (String.equal)) then (
     Printf.printf "Z3 : %s \n %!" (Z3.Solver.to_string solver) );
   Z3.Solver.check solver []
 

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -1069,6 +1069,8 @@ let mem_read_offsets (env2 : Env.t) (offset : Constr.z3_expr -> Constr.z3_expr)
 let check ?refute:(refute = true) ?(print_constr = []) (solver : Solver.solver)
     (ctx : Z3.context) (pre : Constr.t)  : Solver.status =
   printf "Evaluating precondition.\n%!";
+  if (List.mem print_constr "internal" ~equal:(String.equal)) then (
+     Printf.printf "Internal : %s \n %!" (Constr.to_string pre) ) ;
   let pre' = Constr.eval pre ctx in
   printf "Checking precondition with Z3.\n%!";
   let is_correct =
@@ -1079,7 +1081,7 @@ let check ?refute:(refute = true) ?(print_constr = []) (solver : Solver.solver)
   in
   Z3.Solver.add solver [is_correct];
   if (List.mem print_constr "smtlib" ~equal:(String.equal)) then (
-    Printf.printf "Z3 : %s \n %!" (Z3.Solver.to_string solver) );
+    Printf.printf "Z3 : \n %s \n %!" (Z3.Solver.to_string solver) );
   Z3.Solver.check solver []
 
 let exclude (solver : Solver.solver) (ctx : Z3.context) ~var:(var : Constr.z3_expr)

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -1067,7 +1067,7 @@ let mem_read_offsets (env2 : Env.t) (offset : Constr.z3_expr -> Constr.z3_expr)
     Some (Assume (AfterExec (Constr.mk_goal name (Bool.mk_and ctx conds))))
 
 let check ?refute:(refute = true) (solver : Solver.solver) (ctx : Z3.context)
-    (pre : Constr.t) : Solver.status =
+    (pre : Constr.t) ~output_smtlib2:(output_smtlib2 : bool) : Solver.status =
   printf "Evaluating precondition.\n%!";
   let pre' = Constr.eval pre ctx in
   printf "Checking precondition with Z3.\n%!";
@@ -1078,6 +1078,10 @@ let check ?refute:(refute = true) (solver : Solver.solver) (ctx : Z3.context)
       pre'
   in
   Z3.Solver.add solver [is_correct];
+  if (output_smtlib2) then (
+      (* Printf.printf "Z3 : %s \n %!" (Z3.Expr.to_string (Z3.Expr.simplify is_correct None)); *)
+    Printf.printf "Z3 : %s \n %!" (Z3.Solver.to_string solver);
+    Printf.printf "Assertions: %d \n %!" (Z3.Solver.get_num_assertions solver));
   Z3.Solver.check solver []
 
 let exclude (solver : Solver.solver) (ctx : Z3.context) ~var:(var : Constr.z3_expr)
@@ -1089,7 +1093,7 @@ let exclude (solver : Solver.solver) (ctx : Z3.context) ~var:(var : Constr.z3_ex
   Solver.add solver [cond];
   info "Added constraints: %s\n%!"
     (Solver.get_assertions solver |> List.to_string ~f:Expr.to_string);
-  check solver ctx pre
+  check solver ctx pre ~output_smtlib2:false
 
 let get_output_vars (env : Env.t) (t : Sub.t) (var_names : string list) : Var.Set.t =
   let all_vars = get_vars env t in

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -1078,7 +1078,7 @@ let check ?refute:(refute = true) ?(print_constr = []) (solver : Solver.solver)
       pre'
   in
   Z3.Solver.add solver [is_correct];
-  if (List.mem print_constr "smtlib" (String.equal)) then (
+  if (List.mem print_constr "smtlib" ~equal:(String.equal)) then (
     Printf.printf "Z3 : %s \n %!" (Z3.Solver.to_string solver) );
   Z3.Solver.check solver []
 

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -1079,9 +1079,7 @@ let check ?refute:(refute = true) (solver : Solver.solver) (ctx : Z3.context)
   in
   Z3.Solver.add solver [is_correct];
   if (output_smtlib2) then (
-      (* Printf.printf "Z3 : %s \n %!" (Z3.Expr.to_string (Z3.Expr.simplify is_correct None)); *)
-    Printf.printf "Z3 : %s \n %!" (Z3.Solver.to_string solver);
-    Printf.printf "Assertions: %d \n %!" (Z3.Solver.get_num_assertions solver));
+    Printf.printf "Z3 : %s \n %!" (Z3.Solver.to_string solver) );
   Z3.Solver.check solver []
 
 let exclude (solver : Solver.solver) (ctx : Z3.context) ~var:(var : Constr.z3_expr)

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -1066,8 +1066,7 @@ let mem_read_offsets (env2 : Env.t) (offset : Constr.z3_expr -> Constr.z3_expr)
   else
     Some (Assume (AfterExec (Constr.mk_goal name (Bool.mk_and ctx conds))))
 
-let check ?refute:(refute = true) (solver : Solver.solver) (ctx : Z3.context)
-    (pre : Constr.t) ~output_smtlib2:(output_smtlib2 : bool) : Solver.status =
+let check ?refute:(refute = true) ?(output_smtlib2 = false) (solver : Solver.solver) (ctx : Z3.context) (pre : Constr.t)  : Solver.status =
   printf "Evaluating precondition.\n%!";
   let pre' = Constr.eval pre ctx in
   printf "Checking precondition with Z3.\n%!";

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -275,7 +275,13 @@ val visit_sub : Env.t -> Constr.t -> Bap.Std.Sub.t -> Constr.t * Env.t
 
 (** Calls Z3 to check for a countermodel for the precondition of a BIR program. If
     refute is set to false, it checks for a model instead. *)
-val check : ?refute:bool -> ?output_smtlib2:bool -> Z3.Solver.solver -> Z3.context -> Constr.t -> Z3.Solver.status
+val check 
+  : ?refute:bool 
+  -> ?output_smtlib2:bool 
+  -> Z3.Solver.solver 
+  -> Z3.context 
+  -> Constr.t 
+  -> Z3.Solver.status
 
 (** Adds a constraint to the Z3 solver in which var does not equal its value from
     the original Z3 model, then runs the Z3 solver again.

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -275,7 +275,7 @@ val visit_sub : Env.t -> Constr.t -> Bap.Std.Sub.t -> Constr.t * Env.t
 
 (** Calls Z3 to check for a countermodel for the precondition of a BIR program. If
     refute is set to false, it checks for a model instead. *)
-val check : ?refute:bool -> Z3.Solver.solver -> Z3.context -> Constr.t -> output_smtlib2:bool -> Z3.Solver.status
+val check : ?refute:bool -> ?output_smtlib2:bool -> Z3.Solver.solver -> Z3.context -> Constr.t -> Z3.Solver.status
 
 (** Adds a constraint to the Z3 solver in which var does not equal its value from
     the original Z3 model, then runs the Z3 solver again.

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -275,7 +275,7 @@ val visit_sub : Env.t -> Constr.t -> Bap.Std.Sub.t -> Constr.t * Env.t
 
 (** Calls Z3 to check for a countermodel for the precondition of a BIR program. If
     refute is set to false, it checks for a model instead. *)
-val check : ?refute:bool -> Z3.Solver.solver -> Z3.context -> Constr.t -> Z3.Solver.status
+val check : ?refute:bool -> Z3.Solver.solver -> Z3.context -> Constr.t -> output_smtlib2:bool -> Z3.Solver.status
 
 (** Adds a constraint to the Z3 solver in which var does not equal its value from
     the original Z3 model, then runs the Z3 solver again.

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -275,12 +275,12 @@ val visit_sub : Env.t -> Constr.t -> Bap.Std.Sub.t -> Constr.t * Env.t
 
 (** Calls Z3 to check for a countermodel for the precondition of a BIR program. If
     refute is set to false, it checks for a model instead. *)
-val check 
-  : ?refute:bool 
-  -> ?output_smtlib2:bool 
-  -> Z3.Solver.solver 
-  -> Z3.context 
-  -> Constr.t 
+val check
+  : ?refute:bool
+  -> ?print_constr: (string list)
+  -> Z3.Solver.solver
+  -> Z3.context
+  -> Constr.t
   -> Z3.Solver.status
 
 (** Adds a constraint to the Z3 solver in which var does not equal its value from

--- a/wp/plugin/README.md
+++ b/wp/plugin/README.md
@@ -367,6 +367,10 @@ The various options are:
   original binary, then that same address is also non-null in the modified binary.
   Defaults to false.
 
+- `--wp-output-smtlib2=[true|false]`. If set, Z3's SMT-LIB 2 query will be dumped, 
+  printing the query of the solver. This flag is mainly for pedagogical and debugging 
+  purposes. If the flag is not called, it defaults to false and the query won't be printed. 
+
 ## C checking API
 
 There is a `cbat.h` file in the `api/c` folder which contains headers

--- a/wp/plugin/README.md
+++ b/wp/plugin/README.md
@@ -323,13 +323,13 @@ The various options are:
   --wp-inline=.\* or --wp-inline=foo|bar will inline the functions foo and bar.
 
 - `--wp-precond=smt-lib-string`. If present, allows the introduction of assertions
-  to the beginning of a query. This allows pruning of possible models. For 
+  to the beginning of a query. This allows pruning of possible models. For
   comparative predicates, one may refer to variables in the original and modified program by appending the suffix "_orig" and "_mod" to variable names in the smt-lib expression.
   For examples `--wp-precond="(assert (= RDI_mod #x0000000000000003))  (assert (= RDI_orig #x0000000000000003))"`
 
 - `--wp-postcond=smt-lib-string`. If present, replaces the
   default post-condition by the user-specified one, using the
-  [smt-lib2] format. Similar to `--wp-precond`, one may create comparative 
+  [smt-lib2] format. Similar to `--wp-precond`, one may create comparative
   postconditions on variables by appending "_orig" and "_mod" to register names.
 
 - `--wp-num-unroll=num`. If present, replaces the default number of
@@ -367,9 +367,12 @@ The various options are:
   original binary, then that same address is also non-null in the modified binary.
   Defaults to false.
 
-- `--wp-output-smtlib2=[true|false]`. If set, Z3's SMT-LIB 2 query will be dumped, 
-  printing the query of the solver. This flag is mainly for pedagogical and debugging 
-  purposes. If the flag is not called, it defaults to false and the query won't be printed. 
+- `--wp-print-constr=[internal|smtlib] or both/neither`. If set, the preconditions
+  and Z3's SMT-LIB 2 are both printed. One or both outputs can be explicitly
+  called with the respective names `internal` and `smtlib`, which will print only
+  what is stated. Both can also be called like `--wp-print-constr=internal,smtlib`.
+  In the case of a comparison, the precondition (internal) is not printed, so the
+  flag has no effect. If the flag is not called, it defaults to printing neither.
 
 ## C checking API
 
@@ -398,4 +401,3 @@ By default, logs are printed to `STDERR`. You can save the logs to a file by spe
 By default, `debug` logs are not shown. To show debug logs:
 
     export BAP_DEBUG=true
-

--- a/wp/plugin/README.md
+++ b/wp/plugin/README.md
@@ -371,8 +371,7 @@ The various options are:
   and Z3's SMT-LIB 2 are both printed. One or both outputs can be explicitly
   called with the respective names `internal` and `smtlib`, which will print only
   what is stated. Both can also be called like `--wp-print-constr=internal,smtlib`.
-  In the case of a comparison, the precondition (internal) is not printed, so the
-  flag has no effect. If the flag is not called, it defaults to printing neither.
+  If the flag is not called, it defaults to printing neither.
 
 ## C checking API
 

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -37,7 +37,8 @@ type flags =
     print_path : bool;
     use_fun_input_regs : bool;
     mem_offset : bool;
-    check_null_deref : bool
+    check_null_deref : bool;
+    output_smtlib2 : bool 
   }
 
 let missing_func_msg (func : string) : string =
@@ -273,7 +274,7 @@ let main (flags : flags) (proj : project) : unit =
     else
       analyze_proj ctx var_gen proj flags
   in
-  let result = Pre.check solver ctx pre in
+  let result = Pre.check solver ctx pre ~output_smtlib2:flags.output_smtlib2 in
   let () = match flags.gdb_filename with
     | None -> ()
     | Some f ->
@@ -365,6 +366,10 @@ module Cmdline = struct
             not dereference a NULL, then that same read or write in the modified \
             binary also does not dereference a NULL. Defaults to false."
 
+  let output_smtlib2 = param bool "output-smtlib2" ~as_flag:true ~default:false
+      ~doc:"If set, the smtlib2 query will be dumped, printing the query as well \
+            as the number of assertions. Defaults to false."          
+
   let () = when_ready (fun {get=(!!)} ->
       let flags =
         {
@@ -382,7 +387,8 @@ module Cmdline = struct
           print_path = !!print_path;
           use_fun_input_regs = !!use_fun_input_regs;
           mem_offset = !!mem_offset;
-          check_null_deref = !!check_null_deref
+          check_null_deref = !!check_null_deref; 
+          output_smtlib2 = !!output_smtlib2 
         }
       in
       Project.register_pass' @@

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -367,8 +367,10 @@ module Cmdline = struct
             binary also does not dereference a NULL. Defaults to false."
 
   let output_smtlib2 = param bool "output-smtlib2" ~as_flag:true ~default:false
-      ~doc:"If set, the smtlib2 query will be dumped, printing the query as well \
-            as the number of assertions. Defaults to false."          
+      ~doc:"If set, Z3's SMT-LIB 2 query will be dumped, printing the query of the \
+            solver. This flag is mainly for pedagogical and debugging purposes. \
+            If the flag is not called, it defaults to false and the query won't \
+            be printed."          
 
   let () = when_ready (fun {get=(!!)} ->
       let flags =

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -153,11 +153,8 @@ let analyze_proj (ctx : Z3.context) (var_gen : Env.var_gen) (proj : project)
   let pre, env = Pre.visit_sub env post main_sub in
   let pre = Constr.mk_clause [Z3_utils.mk_smtlib2_single env flags.pre_cond] [pre] in
   let pre = Constr.mk_clause hyps [pre] in
-  (* Print statement for constrain-style prover output: *)
-  let printer =
-    if (List.mem flags.print_constr "internal" ~equal:(String.equal))
-    then Format.printf else debug in
-      printer "\nSub:\n%s\nPre:\n%a\n%!" (Sub.to_string main_sub) Constr.pp_constr pre;
+    (* Print statement for constraint-style prover output: *)
+    Format.printf "\nSub:\n%s\nPre:\n%!" (Sub.to_string main_sub);
   (pre, env, env)
 
 let check_calls (flag : bool) : (Comp.comparator * Comp.comparator) option =
@@ -373,10 +370,8 @@ module Cmdline = struct
       ~doc:"If set, the preconditions and Z3's SMT-LIB 2 are both printed. \
             One or both outputs can be explicitly called with the respective names \
             internal and smtlib, which will print only what is stated. Both can \
-            also be called like --wp-print-constr=internal,smtlib. In the case of \
-            a comparison, the precondition (internal) is not printed, so the \
-            flag has no effect. If the flag is not called, it defaults to printing \
-            neither."
+            also be called like --wp-print-constr=internal,smtlib. If the flag \
+            is not called, it defaults to printing neither."
 
   let () = when_ready (fun {get=(!!)} ->
       let flags =

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -274,7 +274,7 @@ let main (flags : flags) (proj : project) : unit =
     else
       analyze_proj ctx var_gen proj flags
   in
-  let result = Pre.check solver ctx pre ~output_smtlib2:flags.output_smtlib2 in
+  let result = Pre.check ~output_smtlib2:flags.output_smtlib2 solver ctx pre  in
   let () = match flags.gdb_filename with
     | None -> ()
     | Some f ->


### PR DESCRIPTION
A new wp flag is created for wp, following the suggestions from philzook58. The flag is:

  --wp-output-smtlib2

with the description:

 _If set, Z3's SMT-LIB 2 query will be dumped, printing the query of the solver. This flag is mainly for pedagogical and debugging purposes. If the flag is not called, it defaults to false and the query won't be printed._