### PR TITLE
Fortunac/bildb

### DIFF
--- a/wp/lib/bap_wp/src/output.ml
+++ b/wp/lib/bap_wp/src/output.ml
@@ -225,7 +225,7 @@ let output_bildb (solver : Solver.solver) (status : Solver.status) (env : Env.t)
         | None -> ()
         | Some m ->
           if not @@ List.is_empty m.model then begin
-            Printf.fprintf t "Memory:\n";
+            Printf.fprintf t "Locations:\n";
             List.iter m.model ~f:(fun (addr, value) ->
                 Printf.fprintf t "  %s: %s\n" (expr_to_hex addr) (expr_to_hex value))
           end

--- a/wp/lib/bap_wp/src/output.ml
+++ b/wp/lib/bap_wp/src/output.ml
@@ -178,6 +178,7 @@ let output_gdb (solver : Solver.solver) (status : Solver.status)
     (env : Env.t) ~func:(func : string) ~filename:(gdb_filename : string) : unit =
   match status with
   | Solver.SATISFIABLE ->
+    Printf.printf "Dumping gdb script to file: %s\n" gdb_filename;
     let model = Constr.get_model_exn solver in
     let option_mem_model = get_mem model env in
     let varmap = Env.get_var_map env in
@@ -195,5 +196,34 @@ let output_gdb (solver : Solver.solver) (status : Solver.status)
         | None -> ()
         | Some mem_model ->  List.iter mem_model.model ~f:(fun (addr,value) ->
             Printf.fprintf t "set {int}%s = %s \n" (expr_to_hex addr) (expr_to_hex value))
+      )
+  | _ -> ()
+
+let output_bildb (solver : Solver.solver) (status : Solver.status) (env : Env.t)
+    (filename : string) : unit =
+  match status with
+  | Solver.SATISFIABLE ->
+    Printf.printf "Outputting BilDB initializer to %s\n%!" filename;
+    let model = Constr.get_model_exn solver in
+    let option_mem_model = get_mem model env in
+    let varmap = Env.get_var_map env in
+    let module Target = (val target_of_arch (Env.get_arch env)) in
+    let regmap = VarMap.filter_keys ~f:(Target.CPU.is_reg) varmap in
+    let reg_val_map = VarMap.map ~f:(fun z3_reg -> Constr.eval_model_exn model z3_reg) regmap in
+    Out_channel.with_file filename  ~f:(fun t ->
+        if not @@ VarMap.is_empty reg_val_map then begin
+          Printf.fprintf t "Variables:\n";
+          VarMap.iteri reg_val_map ~f:(fun ~key ~data ->
+              let hex_value = expr_to_hex data in
+              Printf.fprintf t "  %s: %s\n" (Var.name key) hex_value)
+        end;
+        match option_mem_model with
+        | None -> ()
+        | Some mem_model ->
+          if not @@ List.is_empty mem_model.model then begin
+            Printf.fprintf t "Memory:\n";
+            List.iter mem_model.model ~f:(fun (addr, value) ->
+                Printf.fprintf t "  %s: %s\n" (expr_to_hex addr) (expr_to_hex value))
+          end
       )
   | _ -> ()

--- a/wp/lib/bap_wp/src/output.mli
+++ b/wp/lib/bap_wp/src/output.mli
@@ -39,6 +39,12 @@ val print_result :
 val output_gdb :
   Z3.Solver.solver -> Z3.Solver.status -> Env.t -> func:string -> filename:string -> unit
 
+(** [output_bildb solver status env file] prints to a YAML file that will fill
+    the appropriate registers with the values found in the countermodel in the
+    case the analysis returns SAT. This is used to initialize the BilDB plugin.*)
+val output_bildb :
+  Z3.Solver.solver -> Z3.Solver.status -> Env.t -> string -> unit
+
 (** [mem_model] The default value stores the final else branch of a memory model. The model holds an association list of addresses and
     values held at those adresses. *)
 type mem_model = {default : Constr.z3_expr ; model : (Constr.z3_expr * Constr.z3_expr) list}

--- a/wp/plugin/README.md
+++ b/wp/plugin/README.md
@@ -344,6 +344,12 @@ The various options are:
   within gdb, run `source my_exec.gdb` to set a breakpoint at the function given
   by `--wp-function` and fill the appropriate registers with a found counter-model.
 
+- `--wp-bildb-output=filename.yml`. Output a BilDB initialization script to file
+  `filename.yml`. This YAML file sets the registers and memory to the values
+  specified in the countermodel found during WP analysis, allowing BilDB to
+  follow the same execution trace. In the case the analysis returns UNSAT or
+  UNKNOWN, no script will be outputted.
+
 - `--wp-print-path=[true|false]`. If present, will print out the path to a refuted
   goal and the register values at each jump in the path. It also contains information
   about whehter a jump has been taken and the address of the jump if found.


### PR DESCRIPTION
Addresses #166. When the `--wp-bildb-output=file.yml` flag is set, outputs a YAML file for BilDB to load.

For example `memory_samples/arrays` that looks like this:

```
Variables:
  R8: 0x0000000000000000
  R9: 0x0000000000000000
  RAX: 0x0000000000000000
  RCX: 0x0000000000000000
  RDI: 0x0000000000000000
  RDX: 0x0000000000000000
  RSI: 0x0000000000000000
  RSP: 0x00007fffffff0000
Memory:
  0x00000000006010c3: 0x01
```
and `simple_wp` looks like this:
```
Variables:
  R8: 0x0000000000000000
  R9: 0x0000000000000000
  RAX: 0x0000000000000000
  RCX: 0x0000000000000000
  RDI: 0x0000000000000003
  RDX: 0x0000000000000000
  RSI: 0x0000000000000000
  RSP: 0x00007fffffff0000
```