### PR TITLE
Gltrost/debug flags

### DIFF
--- a/wp/lib/bap_wp/src/constraint.ml
+++ b/wp/lib/bap_wp/src/constraint.ml
@@ -224,7 +224,7 @@ let rec eval_aux ?stats:(stats = init_stats) (constr : t) (olds : z3_expr list)
 
 (* This needs to be evaluated in the same context as was used to create the root goals *)
 let eval ?debug:(debug = []) (constr : t) (ctx : Z3.context) : z3_expr =
-  (* if (List.mem debug "eval" ~equal:(String.equal)) then
+  if (List.mem debug "eval" ~equal:(String.equal)) then
     let stats = init_stats in
     let eval = eval_aux ~stats:stats constr [] [] ctx in
     let mean = (float stats.sum) /. (float stats.count)  in
@@ -232,7 +232,7 @@ let eval ?debug:(debug = []) (constr : t) (ctx : Z3.context) : z3_expr =
     Printf.printf "Statistics for olds and news in eval_aux call: \n";
     Printf.printf "mean: %f , max: %i , std dev: %f \n %!" mean stats.maximum std_dev ;
     eval
-  else *)
+  else
     eval_aux constr [] [] ctx
 
 

--- a/wp/lib/bap_wp/src/constraint.ml
+++ b/wp/lib/bap_wp/src/constraint.ml
@@ -229,7 +229,7 @@ let eval ?debug:(debug = []) (constr : t) (ctx : Z3.context) : z3_expr =
     let eval = eval_aux ~stats:stats constr [] [] ctx in
     let mean = (float stats.sum) /. (float stats.count)  in
     let std_dev = std_dev stats in
-    Printf.printf "Statistics for olds and news in eval_aux call: \n";
+    Printf.printf "Showing statistics for olds and news in eval_aux: \n";
     Printf.printf "mean: %f , max: %i , std dev: %f \n %!" mean stats.maximum std_dev ;
     eval
   else
@@ -342,6 +342,6 @@ let rec get_stats (t : t) (zstats :stats) : unit =
 let print_stats (t : t) : unit =
   let z = {goals = 0; ites = 0 ; clauses = 0; subs = 0} in
     (get_stats t z;
-    Printf.printf "Printing constr.t stats : \n ";
+    Printf.printf "Showing constr.t statistics: \n ";
     Printf.printf "goals: %i , ites: %i, clauses: %i, subs: %i, \n %!"
       z.goals z.ites z.clauses z.subs )

--- a/wp/lib/bap_wp/src/constraint.ml
+++ b/wp/lib/bap_wp/src/constraint.ml
@@ -223,8 +223,8 @@ let rec eval_aux ?stats:(stats = init_stats) (constr : t) (olds : z3_expr list)
     eval_aux ~stats:stats c (olds @ o) (news @ n') ctx
 
 (* This needs to be evaluated in the same context as was used to create the root goals *)
-let eval ?debug:(debug = []) (constr : t) (ctx : Z3.context) : z3_expr =
-  if (List.mem debug "eval" ~equal:(String.equal)) then
+let eval ?debug:(debug = false) (constr : t) (ctx : Z3.context) : z3_expr =
+  if debug then
     let stats = init_stats in
     let eval = eval_aux ~stats:stats constr [] [] ctx in
     let mean = (float stats.sum) /. (float stats.count)  in

--- a/wp/lib/bap_wp/src/constraint.mli
+++ b/wp/lib/bap_wp/src/constraint.mli
@@ -100,8 +100,10 @@ val mk_ite : Bap.Std.Jmp.t -> z3_expr -> t -> t -> t
 val mk_clause : t list -> t list -> t
 
 (** [eval c ctx] evaluates the constraint [c] to a Z3 expression,
-    using the standard Z3 encoding of if-then-else and clauses. *)
-val eval : ?debug:(string list) -> t -> Z3.context -> z3_expr
+    using the standard Z3 encoding of if-then-else and clauses.
+    If ~debug is called and is set to true, then statistics for
+    eval will be printed. *)
+val eval : ?debug:(bool) -> t -> Z3.context -> z3_expr
 
 (** [substitute c [e1;...;e_n] [d1;...;d_n]] substitutes each
     occurence in [c] of the Z3 expression [ei] with the expression
@@ -130,8 +132,17 @@ val eval_model_exn : Z3.Model.model -> z3_expr -> z3_expr
 val get_model_exn : Z3.Solver.solver -> Z3.Model.model
 
 
+(** stats, get_stats and print_stats are used for debugging purposes when
+    the flag --wp-debug=constraint-stats is set. **)
+
+(** Contains statistics for values of type t, keeping track of number of goals,
+    ites, clauses and subs that compose t **)
 type stats
 
+(** [get_stats t stats] collects statistics of t, so that the statistics are
+    held in stats **)
 val get_stats : t -> stats -> unit
 
+(** [print_stats t] calls get_stats to collect and print the statistics
+    for the number of goals, ites, clauses and subs that compose t **)
 val print_stats : t -> unit

--- a/wp/lib/bap_wp/src/constraint.mli
+++ b/wp/lib/bap_wp/src/constraint.mli
@@ -101,7 +101,7 @@ val mk_clause : t list -> t list -> t
 
 (** [eval c ctx] evaluates the constraint [c] to a Z3 expression,
     using the standard Z3 encoding of if-then-else and clauses. *)
-val eval : t -> Z3.context -> z3_expr
+val eval : ?debug:(string list) -> t -> Z3.context -> z3_expr
 
 (** [substitute c [e1;...;e_n] [d1;...;d_n]] substitutes each
     occurence in [c] of the Z3 expression [ei] with the expression

--- a/wp/lib/bap_wp/src/constraint.mli
+++ b/wp/lib/bap_wp/src/constraint.mli
@@ -128,3 +128,10 @@ val eval_model_exn : Z3.Model.model -> z3_expr -> z3_expr
     if retrieving the model fails in the case that [check] was not yet called
     to the solver or the result of the last [check] did not result in SAT. *)
 val get_model_exn : Z3.Solver.solver -> Z3.Model.model
+
+
+type stats
+
+val get_stats : t -> stats -> unit
+
+val print_stats : t -> unit

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -1066,7 +1066,7 @@ let mem_read_offsets (env2 : Env.t) (offset : Constr.z3_expr -> Constr.z3_expr)
   else
     Some (Assume (AfterExec (Constr.mk_goal name (Bool.mk_and ctx conds))))
 
-let check ?refute:(refute = true) ?(print_constr = []) ?(debug = [])
+let check ?refute:(refute = true) ?(print_constr = []) ?(debug = false)
     (solver : Solver.solver) (ctx : Z3.context) (pre : Constr.t)  : Solver.status =
   printf "Evaluating precondition.\n%!";
   if (List.mem print_constr "internal" ~equal:(String.equal)) then (

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -1066,12 +1066,12 @@ let mem_read_offsets (env2 : Env.t) (offset : Constr.z3_expr -> Constr.z3_expr)
   else
     Some (Assume (AfterExec (Constr.mk_goal name (Bool.mk_and ctx conds))))
 
-let check ?refute:(refute = true) ?(print_constr = []) (solver : Solver.solver)
-    (ctx : Z3.context) (pre : Constr.t)  : Solver.status =
+let check ?refute:(refute = true) ?(print_constr = []) ?(debug = [])
+    (solver : Solver.solver) (ctx : Z3.context) (pre : Constr.t)  : Solver.status =
   printf "Evaluating precondition.\n%!";
   if (List.mem print_constr "internal" ~equal:(String.equal)) then (
      Printf.printf "Internal : %s \n %!" (Constr.to_string pre) ) ;
-  let pre' = Constr.eval pre ctx in
+  let pre' = Constr.eval ~debug:debug pre ctx in
   printf "Checking precondition with Z3.\n%!";
   let is_correct =
     if refute then
@@ -1079,7 +1079,6 @@ let check ?refute:(refute = true) ?(print_constr = []) (solver : Solver.solver)
     else
       pre'
   in
-  Z3.set_global_param "verbose" "10";
   Z3.Solver.add solver [is_correct];
   if (List.mem print_constr "smtlib" ~equal:(String.equal)) then (
     Printf.printf "Z3 : \n %s \n %!" (Z3.Solver.to_string solver) );

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -1079,6 +1079,7 @@ let check ?refute:(refute = true) ?(print_constr = []) (solver : Solver.solver)
     else
       pre'
   in
+  Z3.set_global_param "verbose" "10";
   Z3.Solver.add solver [is_correct];
   if (List.mem print_constr "smtlib" ~equal:(String.equal)) then (
     Printf.printf "Z3 : \n %s \n %!" (Z3.Solver.to_string solver) );

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -274,11 +274,13 @@ val visit_block : Env.t -> Constr.t -> Bap.Std.Blk.t -> Constr.t * Env.t
 val visit_sub : Env.t -> Constr.t -> Bap.Std.Sub.t -> Constr.t * Env.t
 
 (** Calls Z3 to check for a countermodel for the precondition of a BIR program. If
-    refute is set to false, it checks for a model instead. *)
+    refute is set to false, it checks for a model instead. If ~print_constr is
+    called and contains "smtlib", then Z3's solver (smt lib 2) will be printed.
+    If ~debug is set, then ~debug will be passed to prints statistics on  *)
 val check
   : ?refute:bool
   -> ?print_constr: (string list)
-  -> ?debug: (string list)
+  -> ?debug: (bool)
   -> Z3.Solver.solver
   -> Z3.context
   -> Constr.t

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -278,6 +278,7 @@ val visit_sub : Env.t -> Constr.t -> Bap.Std.Sub.t -> Constr.t * Env.t
 val check
   : ?refute:bool
   -> ?print_constr: (string list)
+  -> ?debug: (string list)
   -> Z3.Solver.solver
   -> Z3.context
   -> Constr.t

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -276,7 +276,8 @@ val visit_sub : Env.t -> Constr.t -> Bap.Std.Sub.t -> Constr.t * Env.t
 (** Calls Z3 to check for a countermodel for the precondition of a BIR program. If
     refute is set to false, it checks for a model instead. If ~print_constr is
     called and contains "smtlib", then Z3's solver (smt lib 2) will be printed.
-    If ~debug is set, then ~debug will be passed to prints statistics on  *)
+    If ~debug is called and set to true, it will be passed to print statistics
+    for Constr.eval inside this function *)
 val check
   : ?refute:bool
   -> ?print_constr: (string list)

--- a/wp/plugin/README.md
+++ b/wp/plugin/README.md
@@ -383,7 +383,7 @@ The various options are:
   or some comma delimited combination`. If set, debug will print the various
   debugging statistics, including information and statistics for Z3's solver,
   global_param, constr.t, and expression-lists when calling eval. These can also
-  be called with the key-words: z3-solver-stats, z3-verbose, constr.t and
+  be called with the key-words: z3-solver-stats, z3-verbose, constraint-stats and
   eval-constraint-stats respectively. If the flag is not called, it defaults to
   printing none of them.
 

--- a/wp/plugin/README.md
+++ b/wp/plugin/README.md
@@ -379,11 +379,13 @@ The various options are:
   what is stated. Both can also be called like `--wp-print-constr=internal,smtlib`.
   If the flag is not called, it defaults to printing neither.
 
-- `--wp-debug=[solver|global|constr.t|eval] or some combination`. If set, debug
-  will print the various debugging statistics, including information and statistics
-  for Z3's solver, global_param, constr.t, and expression-lists when calling eval.
-  These can also be called with the key-words: solver, global, constr.t and eval
-  respectively. If the flag is not called, it defaults to printing none of them.
+- `--wp-debug=[z3-solver-stats|z3-verbose|constrain-stats|eval-constraint-stats]
+  or some comma delimited combination`. If set, debug will print the various
+  debugging statistics, including information and statistics for Z3's solver,
+  global_param, constr.t, and expression-lists when calling eval. These can also
+  be called with the key-words: z3-solver-stats, z3-verbose, constr.t and
+  eval-constraint-stats respectively. If the flag is not called, it defaults to
+  printing none of them.
 
 ## C checking API
 

--- a/wp/plugin/README.md
+++ b/wp/plugin/README.md
@@ -379,7 +379,7 @@ The various options are:
   what is stated. Both can also be called like `--wp-print-constr=internal,smtlib`.
   If the flag is not called, it defaults to printing neither.
 
-- `--wp-debug=[z3-solver-stats|z3-verbose|constrain-stats|eval-constraint-stats]
+- `--wp-debug=[z3-solver-stats|z3-verbose|constraint-stats|eval-constraint-stats]
   or some comma delimited combination`. If set, debug will print the various
   debugging statistics, including information and statistics for Z3's solver, Z3's
   verbosity-level, constr.t, and expression-lists when calling eval. These can also

--- a/wp/plugin/README.md
+++ b/wp/plugin/README.md
@@ -381,8 +381,8 @@ The various options are:
 
 - `--wp-debug=[z3-solver-stats|z3-verbose|constrain-stats|eval-constraint-stats]
   or some comma delimited combination`. If set, debug will print the various
-  debugging statistics, including information and statistics for Z3's solver,
-  global_param, constr.t, and expression-lists when calling eval. These can also
+  debugging statistics, including information and statistics for Z3's solver, Z3's
+  verbosity-level, constr.t, and expression-lists when calling eval. These can also
   be called with the key-words: z3-solver-stats, z3-verbose, constraint-stats and
   eval-constraint-stats respectively. If the flag is not called, it defaults to
   printing none of them.

--- a/wp/plugin/README.md
+++ b/wp/plugin/README.md
@@ -379,6 +379,12 @@ The various options are:
   what is stated. Both can also be called like `--wp-print-constr=internal,smtlib`.
   If the flag is not called, it defaults to printing neither.
 
+- `--wp-debug=[solver|global|constr.t|eval] or some combination`. If set, debug
+  will print the various debugging statistics, including information and statistics
+  for Z3's solver, global_param, constr.t, and expression-lists when calling eval.
+  These can also be called with the key-words: solver, global, constr.t and eval
+  respectively. If the flag is not called, it defaults to printing none of them.
+
 ## C checking API
 
 There is a `cbat.h` file in the `api/c` folder which contains headers

--- a/wp/plugin/tests/test_wp.ml
+++ b/wp/plugin/tests/test_wp.ml
@@ -202,8 +202,8 @@ let suite = [
   "Function spec: inline all "     >: test_plugin "function_spec" unsat ~script:"run_wp_inline_all.sh";
   "Function spec: inline garbage"  >: test_plugin "function_spec" sat ~script:"run_wp_inline_garbage.sh";
 
-  (* "Goto string"                    >: test_plugin "goto_string" sat;
-  "Goto string: inline all"        >: test_plugin "goto_string" sat ~script:"run_wp_inline.sh"; *)
+  "Goto string"                    >: test_plugin "goto_string" sat;
+  "Goto string: inline all"        >: test_plugin "goto_string" sat ~script:"run_wp_inline.sh";
 
   "Init var value in post: UNSAT:" >: test_plugin "init_var" unsat;
   "Init var value in post: SAT"    >: test_plugin "init_var" sat ~script:"run_wp_sat.sh";

--- a/wp/plugin/tests/test_wp.ml
+++ b/wp/plugin/tests/test_wp.ml
@@ -202,8 +202,8 @@ let suite = [
   "Function spec: inline all "     >: test_plugin "function_spec" unsat ~script:"run_wp_inline_all.sh";
   "Function spec: inline garbage"  >: test_plugin "function_spec" sat ~script:"run_wp_inline_garbage.sh";
 
-  "Goto string"                    >: test_plugin "goto_string" sat;
-  "Goto string: inline all"        >: test_plugin "goto_string" sat ~script:"run_wp_inline.sh";
+  (* "Goto string"                    >: test_plugin "goto_string" sat;
+  "Goto string: inline all"        >: test_plugin "goto_string" sat ~script:"run_wp_inline.sh"; *)
 
   "Init var value in post: UNSAT:" >: test_plugin "init_var" unsat;
   "Init var value in post: SAT"    >: test_plugin "init_var" sat ~script:"run_wp_sat.sh";

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -283,7 +283,7 @@ let main (flags : flags) (proj : project) : unit =
   let result = Pre.check ~print_constr:flags.print_constr ~debug:flags.debug
     solver ctx pre in
   if (List.mem flags.debug "solver" ~equal:(String.equal)) then
-    Printf.printf " statistics : \n %s \n %!" (
+    Printf.printf "Showing solver statistics : \n %s \n %!" (
       Z3.Statistics.to_string (Z3.Solver.get_statistics solver));
   let () = match flags.gdb_filename with
     | None -> ()

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -266,8 +266,8 @@ let should_compare (f : flags) : bool =
   f.compare || ((not @@ String.is_empty f.file1) && (not @@ String.is_empty f.file2))
 
 let main (flags : flags) (proj : project) : unit =
-  (* if (List.mem flags.debug "global"  ~equal:(String.equal)) then
-    Z3.set_global_param "verbose" "10"; *)
+  if (List.mem flags.debug "global"  ~equal:(String.equal)) then
+    Z3.set_global_param "verbose" "10";
   let ctx = Env.mk_ctx () in
   let var_gen = Env.mk_var_gen () in
   let solver = Z3.Solver.mk_solver ctx None in
@@ -278,13 +278,13 @@ let main (flags : flags) (proj : project) : unit =
     else
       analyze_proj ctx var_gen proj flags
   in
-  (* if (List.mem flags.debug "constr.t" ~equal:(String.equal)) then
-    Constr.print_stats (pre); *)
+  if (List.mem flags.debug "constr.t" ~equal:(String.equal)) then
+    Constr.print_stats (pre);
   let result = Pre.check ~print_constr:flags.print_constr ~debug:flags.debug
     solver ctx pre in
-  (* if (List.mem flags.debug "solver" ~equal:(String.equal)) then
+  if (List.mem flags.debug "solver" ~equal:(String.equal)) then
     Printf.printf " statistics : \n %s \n %!" (
-      Z3.Statistics.to_string (Z3.Solver.get_statistics solver)); *)
+      Z3.Statistics.to_string (Z3.Solver.get_statistics solver));
   let () = match flags.gdb_filename with
     | None -> ()
     | Some f -> Output.output_gdb solver result env2 ~func:flags.func ~filename:f in
@@ -391,7 +391,7 @@ module Cmdline = struct
             also be called like --wp-print-constr=internal,smtlib. If the flag \
             is not called, it defaults to printing neither."
 
-  let debug = param (list string) "debug" ~as_flag:[] ~default:[]
+  let debug = param (list string) "debug" ~as_flag:["solver";"global";"constr.t";"eval"] ~default:[]
       ~doc:"If set, debug will print the various debugging statistics, including \
            information and statistics for Z3's solver, global_param, constr.t, and \
            expression-lists when calling eval. These can also be called with \

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -396,10 +396,10 @@ module Cmdline = struct
   let debug = param (list string) "debug" ~as_flag:["z3-solver-stats"; "z3-verbose";
               "constraint-stats"; "eval-constraint-stats"] ~default:[]
       ~doc:"If set, debug will print the various debugging statistics, including \
-           information and statistics the Z3-solver, global_param, constr.t, and \
-           expression-lists when calling eval. These can also be called with \
-           the key-words: z3-solver-stats, z3-verbose, constraint-stats and \
-           eval-constraint-stats respectively. If the flag is not called, it \
+           information and statistics for Z3's solver, Z3's verbosity-level, \
+           constr.t, and expression-lists when calling eval. These can also be \
+           called with the key-words: z3-solver-stats, z3-verbose, constraint-stats \
+           and eval-constraint-stats respectively. If the flag is not called, it \
            defaults to printing none of them."
 
   let () = when_ready (fun {get=(!!)} ->

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -40,7 +40,7 @@ type flags =
     mem_offset : bool;
     check_null_deref : bool;
     print_constr : string list;
-    debug : bool;
+    debug : string list;
   }
 
 let missing_func_msg (func : string) : string =
@@ -266,7 +266,8 @@ let should_compare (f : flags) : bool =
   f.compare || ((not @@ String.is_empty f.file1) && (not @@ String.is_empty f.file2))
 
 let main (flags : flags) (proj : project) : unit =
-  Z3.set_global_param "verbose" "10";
+  (* if (List.mem flags.debug "global"  ~equal:(String.equal)) then
+    Z3.set_global_param "verbose" "10"; *)
   let ctx = Env.mk_ctx () in
   let var_gen = Env.mk_var_gen () in
   let solver = Z3.Solver.mk_solver ctx None in
@@ -277,11 +278,13 @@ let main (flags : flags) (proj : project) : unit =
     else
       analyze_proj ctx var_gen proj flags
   in
-  Constr.print_stats (pre);
-  let result = Pre.check ~print_constr:flags.print_constr solver ctx pre  in
-  if (flags.debug) then
+  (* if (List.mem flags.debug "constr.t" ~equal:(String.equal)) then
+    Constr.print_stats (pre); *)
+  let result = Pre.check ~print_constr:flags.print_constr ~debug:flags.debug
+    solver ctx pre in
+  (* if (List.mem flags.debug "solver" ~equal:(String.equal)) then
     Printf.printf " statistics : \n %s \n %!" (
-      Z3.Statistics.to_string (Z3.Solver.get_statistics solver) );
+      Z3.Statistics.to_string (Z3.Solver.get_statistics solver)); *)
   let () = match flags.gdb_filename with
     | None -> ()
     | Some f -> Output.output_gdb solver result env2 ~func:flags.func ~filename:f in
@@ -388,9 +391,12 @@ module Cmdline = struct
             also be called like --wp-print-constr=internal,smtlib. If the flag \
             is not called, it defaults to printing neither."
 
-  let debug = param bool "debug" ~as_flag:true ~default:false
-      ~doc:"If set, debug will print the Z3's solver statistics. Defaults to \
-           printing neither."
+  let debug = param (list string) "debug" ~as_flag:[] ~default:[]
+      ~doc:"If set, debug will print the various debugging statistics, including \
+           information and statistics for Z3's solver, global_param, constr.t, and \
+           expression-lists when calling eval. These can also be called with \
+           the key-words: solver, global, constr.t and eval respectively. \
+           If the flag is not called, it defaults to printing none of them."
 
   let () = when_ready (fun {get=(!!)} ->
       let flags =

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -396,11 +396,19 @@ module Cmdline = struct
   let debug = param (list string) "debug" ~as_flag:["z3-solver-stats"; "z3-verbose";
               "constraint-stats"; "eval-constraint-stats"] ~default:[]
       ~doc:"If set, debug will print the various debugging statistics, including \
+<<<<<<< HEAD
            information and statistics for Z3's solver, Z3's verbosity-level, \
            constr.t, and expression-lists when calling eval. These can also be \
            called with the key-words: z3-solver-stats, z3-verbose, constraint-stats \
            and eval-constraint-stats respectively. If the flag is not called, it \
            defaults to printing none of them."
+=======
+            information and statistics for Z3's solver, Z3's verbosity-level, \
+            constr.t, and expression-lists when calling eval. These can also be \
+            called with the key-words: z3-solver-stats, z3-verbose, constraint-stats \
+            and eval-constraint-stats respectively. If the flag is not called, it \
+            defaults to printing none of them."
+>>>>>>> deleted typo in wp.ml debug spec
 
   let () = when_ready (fun {get=(!!)} ->
       let flags =


### PR DESCRIPTION
My code adds a debug flag with four options:

- `solver` : shows various stats for `solver` in the function `main` in `wp.ml`

- `global` : calls ` Z3.set_global_param "verbose" "10" `, also in the function `main`

- `constr.t` : gives statistics on `pre` in the function `main` by calling `Constr.get_stats`. One area for improvement with this function is that it is very slow to run. 

- `eval` : gives statistics on the list values `olds` and `news` in `eval_aux` when called in the function `eval` in `constraint.ml`. List includes the mean, max and standard deviation of the list sizes. 