### PR TITLE
Phil eval speedup2

### DIFF
--- a/wp/lib/bap_wp/src/constraint.ml
+++ b/wp/lib/bap_wp/src/constraint.ml
@@ -359,15 +359,9 @@ let get_refuted_goals ?filter_out:(filter_out = []) (constr : t)
         worker c2 current_path current_registers olds news
       else
         failwith (Format.sprintf "get_refuted_goals: Unable to resolve branch \
-<<<<<<< HEAD
                                     condition %s at %s"
                                     (Z3.Expr.to_string cond_res)
                                     (jmp |> Term.tid |> Tid.to_string))
-=======
-                                  condition %s at %s" 
-                    (Z3.Expr.to_string cond_res)
-                    (jmp |> Term.tid |> Tid.to_string))
->>>>>>> ed3b7c6... Changed indenting and added fast path to get_refuted_goals subst
     | Clause (hyps, concs) ->
       let hyps_false =
         let hyp_vals =

--- a/wp/lib/bap_wp/src/constraint.ml
+++ b/wp/lib/bap_wp/src/constraint.ml
@@ -235,9 +235,7 @@ let rec eval_aux ?stats:(stats = init_stats) (constr : t) (olds : z3_expr list)
       let hyps_expr = eval_conjunction hyps in
       Bool.mk_implies ctx hyps_expr concs_expr
   | Subst (c, o, n) ->
-    let n' = List.map n ~f:(fun x -> 
-                                   let[@landmark "oldsnews" ] olds, news = get_vars' x olds news |> List.unzip in
-                                   Expr.substitute x olds news) in
+    let n' = List.map n ~f:(fun x -> Expr.substitute x olds news) in
     if (List.length n') = 1 (* It appears we generate overwhelmingly size 1 lists *)
       then 
       begin
@@ -252,7 +250,7 @@ let rec eval_aux ?stats:(stats = init_stats) (constr : t) (olds : z3_expr list)
         let rec removen_exn n l = match l with | x :: xs ->  if (n = 0) then xs else x :: (removen_exn (n - 1) xs) |  [] -> failwith "Improper removen use" in
         let oind = findn o olds in
         match oind with
-          | None -> eval_aux c (o :: olds) (n' :: news) ctx
+          | None -> eval_aux ~stats:stats c (o :: olds) (n' :: news) ctx
           | Some ind -> let news' = n' :: (removen_exn ind news) in
                         let olds  = o  :: (removen_exn ind olds) in 
                         eval_aux ~stats:stats c olds news' ctx


### PR DESCRIPTION
The size of the olds/news list occurring in the Constr.eval function seems to be a major source of slowdown. One step towards correcting this is to use a map data structure. Because without looking deeper under the hood the Z3 ocaml api only accepts lists, It appears to be most efficient to still maintain olds/news as lists for the moment, but we can prune multiple occurrences of the same keys in the olds list. In addition, it appears that moving the most recently changed variables to the head of the olds list speeds things up by making it faster to find commonly used variables. One problem is that bap is generating virtual memory addresses which increase the sizes of the lists but cannot be easily garbage collected, despite being accessed very rarely (often only once or twice). 
I believe every time Expr.substitute is called the olds/news list are traversed and unpacked into an array for z3 internal use.
The list processing and `Expr.substitute` functions are still the bottleneck in the slow examples I've looked at.

Possibilities for further improvements:
- The `new` expression being processed in `Subst(c, old, new)` rarely contains more than a few variables. It is possible to traverse the expression and fill olds/news only with the variables needed for. This allows the use of efficient Map data structures. Doing this naively was found to be more complicated, of questionable correctness, and not much faster. Now instead of lots of time being spent in Expr.substititue a lot of time was spent in the variable collection pass. I think this could be made more efficient by peeking under the z3 api to the z3native module. The Map structures were not all that fast either compared to the simple most recently accessed element of list strategy discussed above as Expr.compare is not super cheap or too often used.