### PR TITLE
Trip asserts and function spec flags

### DIFF
--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -537,6 +537,8 @@ let spec_arg_terms (sub : Sub.t) (_ : Arch.t) : Env.fun_spec option =
   else
     None
 
+(* If RAX is found on the left hand side of an assignment, this spec will
+   chaos RAX as an output from the target function. *)
 let spec_rax_out (sub : Sub.t) (arch : Arch.t) : Env.fun_spec option =
   (* Calling convention for x86 uses EAX as output register. x86_64 uses RAX. *)
   let defs sub =
@@ -563,6 +565,8 @@ let spec_rax_out (sub : Sub.t) (arch : Arch.t) : Env.fun_spec option =
   else
     None
 
+(* This spec will chaos RAX regardless if it has been used on the left hand side
+   of an assignment in the target function. This spec only works for x86_64. *)
 let spec_chaos_rax (sub : Sub.t) (arch : Arch.t) : Env.fun_spec option =
   match arch with
   | `x86_64 ->

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -647,8 +647,7 @@ let num_unroll : int ref = ref 5
 
 let default_fun_specs (to_inline : Sub.t Seq.t) :
   (Sub.t -> Arch.t -> Env.fun_spec option) list =
-  [ spec_verifier_error;
-    spec_verifier_assume;
+  [ spec_verifier_assume;
     spec_verifier_nondet;
     spec_afl_maybe_log;
     spec_inline to_inline;
@@ -663,8 +662,7 @@ let default_heap_range : int * int = 0x0000000000000000, 0x00000000ffffffff
 
 let mk_env
     ?subs:(subs = Seq.empty)
-    ?to_inline:(to_inline = Seq.empty)
-    ?specs:(specs = default_fun_specs to_inline)
+    ?specs:(specs = [])
     ?default_spec:(default_spec = spec_default)
     ?jmp_spec:(jmp_spec = jmp_spec_default)
     ?int_spec:(int_spec = int_spec_default)
@@ -1070,7 +1068,7 @@ let check ?refute:(refute = true) ?(print_constr = []) (solver : Solver.solver)
     (ctx : Z3.context) (pre : Constr.t)  : Solver.status =
   printf "Evaluating precondition.\n%!";
   if (List.mem print_constr "internal" ~equal:(String.equal)) then (
-     Printf.printf "Internal : %s \n %!" (Constr.to_string pre) ) ;
+    Printf.printf "Internal : %s \n %!" (Constr.to_string pre) ) ;
   let pre' = Constr.eval pre ctx in
   printf "Checking precondition with Z3.\n%!";
   let is_correct =

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -174,7 +174,7 @@ val spec_default : Bap.Std.Sub.t -> Bap.Std.Arch.t -> Env.fun_spec
 (** The default jmp spec for handling branches in a BIR program. *)
 val jmp_spec_default : Env.jmp_spec
 
-(** A list of fun_specs that to be used by default in order of precedence. A
+(** A list of fun_specs to be used by default in order of precedence. A
     subroutine will be mapped to a fun_spec if it matches the proper conditions.
     If the subroutine does not fulfill any of the fun_specs' conditions,
     {!spec_default} will be used. Current default fun_specs are:

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -174,6 +174,22 @@ val spec_default : Bap.Std.Sub.t -> Bap.Std.Arch.t -> Env.fun_spec
 (** The default jmp spec for handling branches in a BIR program. *)
 val jmp_spec_default : Env.jmp_spec
 
+(** A list of fun_specs that to be used by default in order of precedence. A
+    subroutine will be mapped to a fun_spec if it matches the proper conditions.
+    If the subroutine does not fulfill any of the fun_specs' conditions,
+    {!spec_default} will be used. Current default fun_specs are:
+    - spec_verifier_assume
+    - spec_verifier_nondet
+    - spec_afl_maybe_log
+    - spec_inline
+    - spec_arg_terms
+    - spec_chaos_caller_saved
+    - spec_rax_out.
+      Takes in a sequence of subroutines to inline for spec_inline as input. *)
+val default_fun_specs :
+  Bap.Std.Sub.t Bap.Std.Seq.t
+  -> (Bap.Std.Sub.t -> Bap.Std.Arch.t -> Env.fun_spec option) list
+
 (** A jump spec that generates constraints for reaching a program point,
     according to a map specifying whether a jump was taken or not. *)
 val jmp_spec_reach : Constr.path -> Env.jmp_spec
@@ -205,8 +221,7 @@ val num_unroll : int ref
 
 (** Creates an environment with
     - an empty sequence of subroutines to initialize function specs
-    - an empty sequence of subroutines to inline
-    - the default list of {!Environment.fun_spec}s that summarize the precondition for a
+    - an empty list of {!Environment.fun_spec}s that summarize the precondition for a
       function call
     - the default {!Environment.jmp_spec} that summarizes the precondition at a jump
     - the default {!Environment.int_spec} that summarizes the precondition for an
@@ -228,7 +243,6 @@ val num_unroll : int ref
     expressions and create fresh variables. *)
 val mk_env
   :  ?subs:Bap.Std.Sub.t Bap.Std.Seq.t
-  -> ?to_inline:Bap.Std.Sub.t Bap.Std.Seq.t
   -> ?specs:(Bap.Std.Sub.t -> Bap.Std.Arch.t -> Env.fun_spec option) list
   -> ?default_spec:(Bap.Std.Sub.t -> Bap.Std.Arch.t -> Env.fun_spec)
   -> ?jmp_spec:Env.jmp_spec

--- a/wp/lib/bap_wp/tests/performance/test_precondition.ml
+++ b/wp/lib/bap_wp/tests/performance/test_precondition.ml
@@ -122,7 +122,8 @@ let test_nested_ifs (threshold : float) (test_ctx : test_ctxt) : unit =
             else
               None)
     in
-    let env = Pre.mk_env ctx var_gen ~jmp_spec ~subs:(Seq.singleton sub) in
+    let specs = Pre.default_fun_specs Seq.empty in
+    let env = Pre.mk_env ctx var_gen ~specs ~jmp_spec ~subs:(Seq.singleton sub) in
     let post  = Bool.mk_true ctx
                 |> Constr.mk_goal "true"
                 |> Constr.mk_constr
@@ -136,7 +137,8 @@ let test_nested_ifs (threshold : float) (test_ctx : test_ctxt) : unit =
     let var_gen = Env.mk_var_gen () in
     let assert_sub, assert_expr = Bil_to_bir.mk_assert_fail () in
     let sub = nest_ifs var_gen depth [Bil.jmp assert_expr] |> bil_to_sub in
-    let env = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [sub; assert_sub]) in
+    let specs = Pre.spec_verifier_error :: Pre.default_fun_specs Seq.empty in
+    let env = Pre.mk_env ctx var_gen ~specs ~subs:(Seq.of_list [sub; assert_sub]) in
     let post  = Bool.mk_true ctx
                 |> Constr.mk_goal "true"
                 |> Constr.mk_constr

--- a/wp/lib/bap_wp/tests/unit/test_compare.ml
+++ b/wp/lib/bap_wp/tests/unit/test_compare.ml
@@ -520,8 +520,9 @@ let test_fun_outputs_2 (test_ctx : test_ctxt) : unit =
         rsi := i64 3;
         jmp (unknown (call_sub2 |> Term.tid |> Tid.to_string) reg64_t)  ]
     ) |> bil_to_sub in
-  let env1 = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [main_sub1; call_sub1]) in
-  let env2 = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [main_sub2; call_sub2]) in
+  let specs = Pre.default_fun_specs Seq.empty in
+  let env1 = Pre.mk_env ctx var_gen ~specs ~subs:(Seq.of_list [main_sub1; call_sub1]) in
+  let env2 = Pre.mk_env ctx var_gen ~specs ~subs:(Seq.of_list [main_sub2; call_sub2]) in
   let input_vars = Var.Set.of_list (ret_var :: x86_64_input_regs) in
   let output_vars = Var.Set.singleton ret_var in
   let post, hyps = Comp.compare_subs_eq ~input:input_vars ~output:output_vars in

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -40,6 +40,7 @@ type flags =
     mem_offset : bool;
     check_null_deref : bool;
     print_constr : string list;
+    fun_specs : string list;
     trip_asserts : bool
   }
 
@@ -128,14 +129,31 @@ let exp_conds_mod (flags : flags) : Env.exp_cond list =
   else
     []
 
+let spec_of_name (name : string) : Sub.t -> Arch.t -> Env.fun_spec option  =
+  match name with
+  | "verifier_error" -> Pre.spec_verifier_error
+  | "verifier_assume" -> Pre.spec_verifier_assume
+  | "verifier_nondet" -> Pre.spec_verifier_nondet
+  | "afl_maybe_log" -> Pre.spec_afl_maybe_log
+  | "arg_terms" -> Pre.spec_arg_terms
+  | "chaos_caller_saved" -> Pre.spec_chaos_caller_saved
+  | "chaos_rax" -> Pre.spec_chaos_rax
+  | "rax_out" -> Pre.spec_rax_out
+  | n -> Format.printf "Function spec: %s not found. Run `bap --wp-help` for \
+                        available specs." n; exit 1
+
 (* Determine which fun_specs to use based on the flags passed in from the CLI.
    Pass in a list of subroutines to inline for spec_inline. *)
 let fun_specs (f : flags) (to_inline : Sub.t Seq.t)
   : (Sub.t -> Arch.t -> Env.fun_spec option) list =
+  let specs = List.map f.fun_specs ~f:spec_of_name in
+  let specs = Pre.spec_inline to_inline :: specs in
+  (* --wp-trip-asserts is an alias to --wp-fun-specs=spec_verifier_error. This
+     gives it the most priority and should be in the front of the list. *)
   if f.trip_asserts then
-    Pre.spec_verifier_error :: Pre.default_fun_specs to_inline
+    Pre.spec_verifier_error :: specs
   else
-    Pre.default_fun_specs to_inline
+    specs
 
 let analyze_proj (ctx : Z3.context) (var_gen : Env.var_gen) (proj : project)
     (flags : flags) : Constr.t * Env.t * Env.t =
@@ -392,9 +410,18 @@ module Cmdline = struct
             also be called like --wp-print-constr=internal,smtlib. If the flag \
             is not called, it defaults to printing neither."
 
+  let fun_specs = param (list string) "fun-specs" ~default:[]
+      ~doc:"List of function summaries to be used at a call site in order of \
+            precedence. A target function will be mapped to a function spec if \
+            it fulfills the corresponding conditions. If no conditions are \
+            satisfied, a default spec will be used. The available specs are: \
+            verifier_error, verifier_assume, verifier_nondet, afl_maybe_log, \
+            arg_terms, chaos_caller_saved, and rax_out."
+
   let trip_asserts = param bool "trip-asserts" ~as_flag:true ~default:false
       ~doc:"If set, WP will look for inputs to the subroutine that would \
-            cause an __assert_fail or __VERIFIER_error to be reached."
+            cause an __assert_fail or __VERIFIER_error to be reached. This is \
+            an alias to `--wp-fun-specs=spec_verifier_error,...`"
 
   let () = when_ready (fun {get=(!!)} ->
       let flags =
@@ -416,6 +443,7 @@ module Cmdline = struct
           mem_offset = !!mem_offset;
           check_null_deref = !!check_null_deref;
           print_constr = !!print_constr;
+          fun_specs = !!fun_specs;
           trip_asserts = !!trip_asserts
         }
       in

--- a/wp/resources/sample_binaries/equiv_null_check/run_wp.sh
+++ b/wp/resources/sample_binaries/equiv_null_check/run_wp.sh
@@ -15,7 +15,8 @@ run () {
   bap $dummy_dir/hello_world.out --pass=wp \
     --wp-compare \
     --wp-file1=main_1.bpj \
-    --wp-file2=main_2.bpj
+    --wp-file2=main_2.bpj \
+    --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/equiv_null_check/run_wp.sh
+++ b/wp/resources/sample_binaries/equiv_null_check/run_wp.sh
@@ -16,7 +16,8 @@ run () {
     --wp-compare \
     --wp-file1=main_1.bpj \
     --wp-file2=main_2.bpj \
-    --wp-trip-asserts
+    --wp-trip-asserts \
+    --wp-fun-specs=verifier_nondet
 }
 
 compile && run

--- a/wp/resources/sample_binaries/function_call/run_wp_inline_all.sh
+++ b/wp/resources/sample_binaries/function_call/run_wp_inline_all.sh
@@ -12,7 +12,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-inline=.*
+  bap main --pass=wp --wp-inline=.* --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/function_call/run_wp_inline_foo.sh
+++ b/wp/resources/sample_binaries/function_call/run_wp_inline_foo.sh
@@ -13,7 +13,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-inline=foo
+  bap main --pass=wp --wp-inline=foo --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/function_spec/run_wp.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp.sh
@@ -15,7 +15,7 @@ compile () {
 }
 
 run () {
-    bap main --pass=wp --wp-trip-asserts
+    bap main --pass=wp --wp-trip-asserts --wp-fun-specs=chaos_caller_saved
 }
 
 compile && run

--- a/wp/resources/sample_binaries/function_spec/run_wp.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp.sh
@@ -15,7 +15,7 @@ compile () {
 }
 
 run () {
-    bap main --pass=wp
+    bap main --pass=wp --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/function_spec/run_wp_inline_all.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp_inline_all.sh
@@ -13,7 +13,7 @@ compile () {
 }
 
 run () {
-    bap main --pass=wp --wp-inline=.*
+    bap main --pass=wp --wp-inline=.* --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/function_spec/run_wp_inline_foo.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp_inline_foo.sh
@@ -14,7 +14,7 @@ compile () {
 }
 
 run () {
-    bap main --pass=wp --wp-inline=foo
+    bap main --pass=wp --wp-inline=foo --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/function_spec/run_wp_inline_garbage.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp_inline_garbage.sh
@@ -13,7 +13,7 @@ compile () {
 }
 
 run () {
-    bap main --pass=wp --wp-inline=NONEXISTENTGARBAGE
+    bap main --pass=wp --wp-inline=NONEXISTENTGARBAGE --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/function_spec/run_wp_inline_garbage.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp_inline_garbage.sh
@@ -13,7 +13,7 @@ compile () {
 }
 
 run () {
-    bap main --pass=wp --wp-inline=NONEXISTENTGARBAGE --wp-trip-asserts
+    bap main --pass=wp --wp-inline=NONEXISTENTGARBAGE --wp-trip-asserts --wp-fun-specs=chaos_caller_saved
 }
 
 compile && run

--- a/wp/resources/sample_binaries/goto_string/run_wp.sh
+++ b/wp/resources/sample_binaries/goto_string/run_wp.sh
@@ -16,7 +16,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-trip-asserts
+  bap main --pass=wp --wp-trip-asserts --wp-fun-specs=chaos_caller_saved
 }
 
 compile && run

--- a/wp/resources/sample_binaries/goto_string/run_wp.sh
+++ b/wp/resources/sample_binaries/goto_string/run_wp.sh
@@ -16,7 +16,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp
+  bap main --pass=wp --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/goto_string/run_wp_inline.sh
+++ b/wp/resources/sample_binaries/goto_string/run_wp_inline.sh
@@ -16,7 +16,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-inline=.*
+  bap main --pass=wp --wp-inline=.* --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/goto_string/run_wp_inline.sh
+++ b/wp/resources/sample_binaries/goto_string/run_wp_inline.sh
@@ -16,7 +16,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-inline=.* --wp-trip-asserts
+  bap main --pass=wp --wp-inline=my_string_alloc --wp-trip-asserts --wp-fun-specs=verifier_nondet
 }
 
 compile && run

--- a/wp/resources/sample_binaries/loop/run_wp.sh
+++ b/wp/resources/sample_binaries/loop/run_wp.sh
@@ -3,7 +3,7 @@ compile() {
 }
 
 run() {
-        bap main --pass=wp --wp-num-unroll=2
+        bap main --pass=wp --wp-num-unroll=2 --trip-asserts
 
 }
 

--- a/wp/resources/sample_binaries/nested_function_calls/run_wp.sh
+++ b/wp/resources/sample_binaries/nested_function_calls/run_wp.sh
@@ -12,7 +12,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp
+  bap main --pass=wp --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_all.sh
+++ b/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_all.sh
@@ -12,7 +12,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-inline=.*
+  bap main --pass=wp --wp-inline=.* --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_regex.sh
+++ b/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_regex.sh
@@ -12,7 +12,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-inline="foo|bar"
+  bap main --pass=wp --wp-inline="foo|bar" --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/nested_ifs/run_wp.sh
+++ b/wp/resources/sample_binaries/nested_ifs/run_wp.sh
@@ -16,7 +16,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-func=nestedIfExample
+  bap main --pass=wp --wp-func=nestedIfExample --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/nested_ifs/run_wp.sh
+++ b/wp/resources/sample_binaries/nested_ifs/run_wp.sh
@@ -16,7 +16,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-func=nestedIfExample --wp-trip-asserts
+  bap main --pass=wp --wp-func=nestedIfExample --wp-trip-asserts --wp-fun-specs=verifier_nondet
 }
 
 compile && run

--- a/wp/resources/sample_binaries/nested_ifs/run_wp_goto.sh
+++ b/wp/resources/sample_binaries/nested_ifs/run_wp_goto.sh
@@ -16,7 +16,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-func=gotoExample
+  bap main --pass=wp --wp-func=gotoExample --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/nested_ifs/run_wp_goto.sh
+++ b/wp/resources/sample_binaries/nested_ifs/run_wp_goto.sh
@@ -16,7 +16,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-func=gotoExample --wp-trip-asserts
+  bap main --pass=wp --wp-func=gotoExample --wp-trip-asserts --wp-fun-specs=verifier_nondet
 }
 
 compile && run

--- a/wp/resources/sample_binaries/nested_ifs/run_wp_inline.sh
+++ b/wp/resources/sample_binaries/nested_ifs/run_wp_inline.sh
@@ -12,7 +12,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-inline=.*
+  bap main --pass=wp --wp-inline=.* --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/no_stack_protection/run_wp.sh
+++ b/wp/resources/sample_binaries/no_stack_protection/run_wp.sh
@@ -15,7 +15,8 @@ run () {
     --wp-compare \
     --wp-file1=main_1.bpj \
     --wp-file2=main_2.bpj \
-    --wp-output-vars=RSI,RAX
+    --wp-output-vars=RSI,RAX \
+    --wp-fun-specs=chaos_caller_saved
 }
 
 compile && run

--- a/wp/resources/sample_binaries/retrowrite_stub/run_wp.sh
+++ b/wp/resources/sample_binaries/retrowrite_stub/run_wp.sh
@@ -19,7 +19,8 @@ run () {
   bap $dummy_dir/hello_world.out --pass=wp \
     --wp-compare \
     --wp-file1=main_1.bpj \
-    --wp-file2=main_2.bpj
+    --wp-file2=main_2.bpj \
+    --wp-fun-specs=afl_maybe_log
 }
 
 compile && run

--- a/wp/resources/sample_binaries/retrowrite_stub_no_ret/run_wp.sh
+++ b/wp/resources/sample_binaries/retrowrite_stub_no_ret/run_wp.sh
@@ -19,7 +19,8 @@ run () {
   bap $dummy_dir/hello_world.out --pass=wp \
     --wp-compare \
     --wp-file1=main_1.bpj \
-    --wp-file2=main_2.bpj
+    --wp-file2=main_2.bpj \
+    --wp-fun-specs=afl_maybe_log
 }
 
 compile && run

--- a/wp/resources/sample_binaries/simple_wp/run_wp.sh
+++ b/wp/resources/sample_binaries/simple_wp/run_wp.sh
@@ -12,7 +12,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp
+  bap main --pass=wp --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/simple_wp/run_wp_pre.sh
+++ b/wp/resources/sample_binaries/simple_wp/run_wp_pre.sh
@@ -12,7 +12,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-precond="(assert (= RDI #x0000000000000002))"
+  bap main --pass=wp --wp-precond="(assert (= RDI #x0000000000000002))" --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/switch_cases_diff_ret/run_wp.sh
+++ b/wp/resources/sample_binaries/switch_cases_diff_ret/run_wp.sh
@@ -23,7 +23,8 @@ run () {
     --wp-file1=main_1.bpj \
     --wp-file2=main_2.bpj \
     --wp-function=process_message \
-    --wp-check-calls
+    --wp-check-calls \
+    --wp-fun-specs=chaos_caller_saved
 }
 
 compile && run

--- a/wp/resources/sample_binaries/verifier_calls/run_wp_assume_sat.sh
+++ b/wp/resources/sample_binaries/verifier_calls/run_wp_assume_sat.sh
@@ -10,7 +10,7 @@ compile () {
 }
 
 run () {
-  bap verifier_assume_sat --pass=wp
+  bap verifier_assume_sat --pass=wp --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/verifier_calls/run_wp_assume_sat.sh
+++ b/wp/resources/sample_binaries/verifier_calls/run_wp_assume_sat.sh
@@ -10,7 +10,7 @@ compile () {
 }
 
 run () {
-  bap verifier_assume_sat --pass=wp --wp-trip-asserts
+  bap verifier_assume_sat --pass=wp --wp-trip-asserts --wp-fun-specs=verifier_assume
 }
 
 compile && run

--- a/wp/resources/sample_binaries/verifier_calls/run_wp_assume_unsat.sh
+++ b/wp/resources/sample_binaries/verifier_calls/run_wp_assume_unsat.sh
@@ -10,7 +10,7 @@ compile () {
 }
 
 run () {
-  bap verifier_assume_unsat --pass=wp --wp-trip-asserts
+  bap verifier_assume_unsat --pass=wp --wp-trip-asserts --wp-fun-specs=verifier_assume
 }
 
 compile && run

--- a/wp/resources/sample_binaries/verifier_calls/run_wp_assume_unsat.sh
+++ b/wp/resources/sample_binaries/verifier_calls/run_wp_assume_unsat.sh
@@ -10,7 +10,7 @@ compile () {
 }
 
 run () {
-  bap verifier_assume_unsat --pass=wp
+  bap verifier_assume_unsat --pass=wp --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/verifier_calls/run_wp_nondet.sh
+++ b/wp/resources/sample_binaries/verifier_calls/run_wp_nondet.sh
@@ -11,7 +11,7 @@ compile () {
 }
 
 run () {
-  bap verifier_nondet --pass=wp
+  bap verifier_nondet --pass=wp --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/verifier_calls/run_wp_nondet.sh
+++ b/wp/resources/sample_binaries/verifier_calls/run_wp_nondet.sh
@@ -11,7 +11,7 @@ compile () {
 }
 
 run () {
-  bap verifier_nondet --pass=wp --wp-trip-asserts
+  bap verifier_nondet --pass=wp --wp-trip-asserts --wp-fun-specs=verifier_nondet
 }
 
 compile && run


### PR DESCRIPTION
Fixes #167 and #176.

Adds two flags to the wp plugin:
1. `--wp-trip-asserts` which will look for inputs to the subroutine that would cause an `__assert_fail` or `__VERIFIER_error` to be reached
2. `--wp-fun-specs=<list>` that allows the user to pick which specs they want to be enabled for the analysis.
    - the user can specify `--wp-fun-specs=all` if they want to enable all of the specs, which is defined in `Pre.default_fun_specs`

Allowing the user to choose specs fixes #176, as the intended spec of `chaos_caller_saved` will be used in this case.
