### PR TITLE
Fortunac/stack range

### DIFF
--- a/wp/README.md
+++ b/wp/README.md
@@ -402,6 +402,13 @@ The various options are:
   subroutine that would cause an `__assert_fail` to `__VERIFIER_error` to be
   reached.
 
+- `--wp-stack-base=address`. If present, sets the base or top address of the stack.
+  By default, WP places the stack at a base address of 0x40000000.
+
+- `--wp-stack-size=size`. If present, sets the size of the stack. `size` should
+  be denoted in bytes. By default, the size of the stack is 0x800000, which is
+  8Mbs.
+
 ## C checking API
 
 There is a `cbat.h` file in the `api/c` folder which contains headers

--- a/wp/lib/bap_wp/src/environment.ml
+++ b/wp/lib/bap_wp/src/environment.ml
@@ -409,7 +409,7 @@ let in_stack (env : t) : Constr.z3_expr -> Constr.z3_expr =
   let min = BV.mk_sub ctx max size in
   fun addr ->
     assert (BV.is_bv addr);
-    Bool.mk_and ctx [BV.mk_ule ctx min addr; BV.mk_ult ctx addr max]
+    Bool.mk_and ctx [BV.mk_ult ctx min addr; BV.mk_ule ctx addr max]
 
 (* Returns a function that takes in a memory address as a z3_expr and outputs a
    z3_expr that checks if that address is within the heap. *)

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -79,6 +79,23 @@ type cond_type = Verify of cond | Assume of cond
     typically a correctness constraint, like no overflow or no null dereference. *)
 type exp_cond = t -> Bap.Std.Exp.t -> cond_type option
 
+(** Memory regions modelled during analysis. This allows the user to specify
+    different properties based off the location in memory. For example, in a
+    comparative analysis, the use can have the hypothesis that memory on the
+    stack is equal, but memory on the heap is only equal at an offset. *)
+type mem_region =
+  | Stack
+  | Heap
+
+(* The range of addresses for a modelled memory region. The base address is the
+   highest address on the stack, but the lowest address on the heap. The
+   memory size is represent in bytes. *)
+type mem_range = {
+  region : mem_region;
+  base_addr : int;
+  size : int
+}
+
 (** Creates a new environment with
     - a sequence of subroutines in the program used to initialize function specs
     - a list of {!fun_spec}s that each summarize the precondition for its mapped function
@@ -106,8 +123,8 @@ val mk_env
   -> arch:Bap.Std.Arch.t
   -> freshen_vars:bool
   -> use_fun_input_regs:bool
-  -> stack_range:int * int
-  -> heap_range:int * int
+  -> stack_range:mem_range
+  -> heap_range:mem_range
   -> Z3.context
   -> var_gen
   -> t

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -79,19 +79,10 @@ type cond_type = Verify of cond | Assume of cond
     typically a correctness constraint, like no overflow or no null dereference. *)
 type exp_cond = t -> Bap.Std.Exp.t -> cond_type option
 
-(** Memory regions modelled during analysis. This allows the user to specify
-    different properties based off the location in memory. For example, in a
-    comparative analysis, the use can have the hypothesis that memory on the
-    stack is equal, but memory on the heap is only equal at an offset. *)
-type mem_region =
-  | Stack
-  | Heap
-
 (* The range of addresses for a modelled memory region. The base address is the
    highest address on the stack, but the lowest address on the heap. The
    memory size is represent in bytes. *)
 type mem_range = {
-  region : mem_region;
   base_addr : int;
   size : int
 }
@@ -247,13 +238,25 @@ val is_x86 : Bap.Std.Arch.t -> bool
     when generating symbols in the function specs at a function call site. *)
 val use_input_regs : t -> bool
 
-(** [in_stack env addr] is the constraint [STACK_MIN <= addr <= STACK_MAX] as
+(** [in_stack env addr] is the constraint [STACK_MIN <= addr < STACK_MAX] as
     defined by the concrete range of the stack in the env. *)
 val in_stack : t -> Constr.z3_expr -> Constr.z3_expr
 
-(** [in_heap env addr] is the constraint [HEAP_MIN <= addr <= HEAP_MAX] as
+(** [in_heap env addr] is the constraint [HEAP_MIN <= addr < HEAP_MAX] as
     defined by the concrete range of the heap in the env. *)
 val in_heap : t -> Constr.z3_expr -> Constr.z3_expr
+
+(** [get_stack_base env] obtains a z3_expr which represents the top address
+    of the stack. *)
+val get_stack_base : t -> Constr.z3_expr
+
+(** [update_stack_base range base] updates the highest address address of the
+    stack to be the same value as base. *)
+val update_stack_base : mem_range -> int -> mem_range
+
+(** [update_stack_size range size] updates the size of the stack to be the
+    same value as size. *)
+val update_stack_size : mem_range -> int -> mem_range
 
 (** [mk_init_var env var] creates a fresh Z3 variable that represents the
     initial state of variable [var]. Adds a new binding to [env] for the bap

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -238,7 +238,7 @@ val is_x86 : Bap.Std.Arch.t -> bool
     when generating symbols in the function specs at a function call site. *)
 val use_input_regs : t -> bool
 
-(** [in_stack env addr] is the constraint [STACK_MIN <= addr < STACK_MAX] as
+(** [in_stack env addr] is the constraint [STACK_MIN < addr <= STACK_MAX] as
     defined by the concrete range of the stack in the env. *)
 val in_stack : t -> Constr.z3_expr -> Constr.z3_expr
 

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -80,7 +80,7 @@ type cond_type = Verify of cond | Assume of cond
 type exp_cond = t -> Bap.Std.Exp.t -> cond_type option
 
 (* The range of addresses for a modelled memory region. The base address is the
-   highest address on the stack, but the lowest address on the heap. The
+   highest address on the stack, but the lowest address in the data section. The
    memory size is represented in bytes. *)
 type mem_range = {
   base_addr : int;
@@ -100,7 +100,7 @@ type mem_range = {
     - the option to freshen variable names
     - the option to use all input registers when generating function symbols at a call site
     - the concrete range of addresses of the stack
-    - the concrete range of addresses of the heap
+    - the concrete range of addresses of the data section
     - a Z3 context
     - and a variable generator. *)
 val mk_env
@@ -115,7 +115,7 @@ val mk_env
   -> freshen_vars:bool
   -> use_fun_input_regs:bool
   -> stack_range:mem_range
-  -> heap_range:mem_range
+  -> data_section_range:mem_range
   -> Z3.context
   -> var_gen
   -> t
@@ -242,9 +242,9 @@ val use_input_regs : t -> bool
     defined by the concrete range of the stack in the env. *)
 val in_stack : t -> Constr.z3_expr -> Constr.z3_expr
 
-(** [in_heap env addr] is the constraint [HEAP_MIN <= addr < HEAP_MAX] as
-    defined by the concrete range of the heap in the env. *)
-val in_heap : t -> Constr.z3_expr -> Constr.z3_expr
+(** [in_data_section env addr] is the constraint [DATA_MIN <= addr < DATA_MAX] as
+    defined by the concrete range of the data section in the env. *)
+val in_data_section : t -> Constr.z3_expr -> Constr.z3_expr
 
 (** [get_stack_base env] obtains a z3_expr which represents the top address
     of the stack. *)

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -81,7 +81,7 @@ type exp_cond = t -> Bap.Std.Exp.t -> cond_type option
 
 (* The range of addresses for a modelled memory region. The base address is the
    highest address on the stack, but the lowest address on the heap. The
-   memory size is represent in bytes. *)
+   memory size is represented in bytes. *)
 type mem_range = {
   base_addr : int;
   size : int
@@ -250,8 +250,8 @@ val in_heap : t -> Constr.z3_expr -> Constr.z3_expr
     of the stack. *)
 val get_stack_base : t -> Constr.z3_expr
 
-(** [update_stack_base range base] updates the highest address address of the
-    stack to be the same value as base. *)
+(** [update_stack_base range base] updates the highest address of the stack to
+    be the same value as base. *)
 val update_stack_base : mem_range -> int -> mem_range
 
 (** [update_stack_size range size] updates the size of the stack to be the

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -645,9 +645,19 @@ let int_spec_default : Env.int_spec =
 
 let num_unroll : int ref = ref 5
 
-let default_stack_range : int * int = 0x00007fffffff0000, 0x00007fffffffffff
+let default_stack_range : Env.mem_range =
+  {
+    region = Stack;
+    base_addr = 0x40000000;
+    size = 0x800000
+  }
 
-let default_heap_range : int * int = 0x0000000000000000, 0x00000000ffffffff
+let default_heap_range : Env.mem_range =
+  {
+    region = Heap;
+    base_addr = 0x00000000;
+    size = 0x800000
+  }
 
 let mk_env
     ?subs:(subs = Seq.empty)

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -654,7 +654,7 @@ let default_stack_range : Env.mem_range = {
    The heap starts at the program break which is initially set to the end of
    the program data segment. See [man brk] for details. *)
 let default_heap_range : Env.mem_range = {
-  base_addr = 0x00000000;
+  base_addr = 0x000000;
   size = 0x800000
 }
 

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -207,9 +207,9 @@ val num_unroll : int ref
     0x800000. The stack grows downward. *)
 val default_stack_range : Env.mem_range
 
-(* The default heap range has a base address at 0x00000000 and a size of
+(* The default data section range has a base address at 0x00000000 and a size of
    0x800000. *)
-val default_heap_range : Env.mem_range
+val default_data_section_range : Env.mem_range
 
 (** Creates an environment with
     - an empty sequence of subroutines to initialize function specs
@@ -227,9 +227,9 @@ val default_heap_range : Env.mem_range
     - the option to use all function input registers when generating function symbols
       at a call site set to true
     - the default concrete range of addresses of the stack for constraints about
-      the stack: [0x00007fffffff0000, 0x00007fffffffffff]
-    - the default concreate range of addresses of the heap for constraints about
-      the heap: [0x0000000000000000, 0x00000000ffffffff]
+      the stack with a base of 0x40000000 and size of 8Mbs
+    - the default concreate range of addresses of the data section for constraints about
+      the data section with a base of 0x000000 and size of 8Mbs
 
     unless specified. A Z3 context and var_gen are required to generate Z3
     expressions and create fresh variables. *)
@@ -245,7 +245,7 @@ val mk_env
   -> ?freshen_vars:bool
   -> ?use_fun_input_regs:bool
   -> ?stack_range:Env.mem_range
-  -> ?heap_range:Env.mem_range
+  -> ?data_section_range:Env.mem_range
   -> Z3.context
   -> Env.var_gen
   -> Env.t

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -236,8 +236,8 @@ val mk_env
   -> ?arch:Bap.Std.Arch.t
   -> ?freshen_vars:bool
   -> ?use_fun_input_regs:bool
-  -> ?stack_range:int * int
-  -> ?heap_range:int * int
+  -> ?stack_range:Env.mem_range
+  -> ?heap_range:Env.mem_range
   -> Z3.context
   -> Env.var_gen
   -> Env.t

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -203,6 +203,14 @@ val mem_read_offsets : Env.t -> (Constr.z3_expr -> Constr.z3_expr) -> Env.exp_co
     We use the default value [!num_unroll = 5]. *)
 val num_unroll : int ref
 
+(** The default stack range has a base address at 0x40000000 and size of
+    0x800000. The stack grows downward. *)
+val default_stack_range : Env.mem_range
+
+(* The default heap range has a base address at 0x00000000 and a size of
+   0x800000. *)
+val default_heap_range : Env.mem_range
+
 (** Creates an environment with
     - an empty sequence of subroutines to initialize function specs
     - an empty list of {!Environment.fun_spec}s that summarize the precondition


### PR DESCRIPTION
- Adds functionality for the user to change the stack base and size with `--wp-stack-base=address` and `--wp-stack-size=size_in_bytes`.
- Changes the default stack base to 0x40000000 and size to 0x800000.
- Changes the initial hypothesis to SP is at the top of the stack. Initially, we said that SP was anywhere on the stack, and Z3 was giving us countermodels where RSP is at the bottom of the stack, and during the analysis, RSP was not actually within the stack we defined.
- Our initial memory model was modelling the stack and data section, but data was incorrectly labeled as heap. Changed the labels to data_section.
- On the implementation side, the environment initially held the range of valid addresses for a memory region. Changed this to a data type that can be represented with the base address and size.
- Even though the stack matches the defaults of Primus, we still cannot assume that the model that Z3 gives us will give us memory locations that are valid in Primus. We need to address this in the future.