### PR TITLE
Fortunac/trip asserts2

### DIFF
--- a/wp/README.md
+++ b/wp/README.md
@@ -398,6 +398,10 @@ The various options are:
   eval-constraint-stats respectively. If the flag is not called, it defaults to
   printing none of them.
 
+- `--wp-trip-asserts=[true|false]`. If set, WP will look for inputs to the
+  subroutine that would cause an `__assert_fail` to `__VERIFIER_error` to be
+  reached.
+
 ## C checking API
 
 There is a `cbat.h` file in the `api/c` folder which contains headers

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -645,26 +645,13 @@ let int_spec_default : Env.int_spec =
 
 let num_unroll : int ref = ref 5
 
-let default_fun_specs (to_inline : Sub.t Seq.t) :
-  (Sub.t -> Arch.t -> Env.fun_spec option) list =
-  [ spec_verifier_error;
-    spec_verifier_assume;
-    spec_verifier_nondet;
-    spec_afl_maybe_log;
-    spec_inline to_inline;
-    spec_arg_terms;
-    spec_chaos_caller_saved;
-    spec_rax_out
-  ]
-
 let default_stack_range : int * int = 0x00007fffffff0000, 0x00007fffffffffff
 
 let default_heap_range : int * int = 0x0000000000000000, 0x00000000ffffffff
 
 let mk_env
     ?subs:(subs = Seq.empty)
-    ?to_inline:(to_inline = Seq.empty)
-    ?specs:(specs = default_fun_specs to_inline)
+    ?specs:(specs = [])
     ?default_spec:(default_spec = spec_default)
     ?jmp_spec:(jmp_spec = jmp_spec_default)
     ?int_spec:(int_spec = int_spec_default)
@@ -1070,7 +1057,7 @@ let check ?refute:(refute = true) ?(print_constr = []) ?(debug = false)
     (solver : Solver.solver) (ctx : Z3.context) (pre : Constr.t)  : Solver.status =
   printf "Evaluating precondition.\n%!";
   if (List.mem print_constr "internal" ~equal:(String.equal)) then (
-     Printf.printf "Internal : %s \n %!" (Constr.to_string pre) ) ;
+    Printf.printf "Internal : %s \n %!" (Constr.to_string pre) ) ;
   let pre' = Constr.eval ~debug:debug pre ctx in
   printf "Checking precondition with Z3.\n%!";
   let is_correct =

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -205,9 +205,8 @@ val num_unroll : int ref
 
 (** Creates an environment with
     - an empty sequence of subroutines to initialize function specs
-    - an empty sequence of subroutines to inline
-    - the default list of {!Environment.fun_spec}s that summarize the precondition for a
-      function call
+    - an empty list of {!Environment.fun_spec}s that summarize the precondition
+      for a function call
     - the default {!Environment.jmp_spec} that summarizes the precondition at a jump
     - the default {!Environment.int_spec} that summarizes the precondition for an
       interrupt
@@ -228,7 +227,6 @@ val num_unroll : int ref
     expressions and create fresh variables. *)
 val mk_env
   :  ?subs:Bap.Std.Sub.t Bap.Std.Seq.t
-  -> ?to_inline:Bap.Std.Sub.t Bap.Std.Seq.t
   -> ?specs:(Bap.Std.Sub.t -> Bap.Std.Arch.t -> Env.fun_spec option) list
   -> ?default_spec:(Bap.Std.Sub.t -> Bap.Std.Arch.t -> Env.fun_spec)
   -> ?jmp_spec:Env.jmp_spec

--- a/wp/lib/bap_wp/tests/performance/test_precondition.ml
+++ b/wp/lib/bap_wp/tests/performance/test_precondition.ml
@@ -136,7 +136,8 @@ let test_nested_ifs (threshold : float) (test_ctx : test_ctxt) : unit =
     let var_gen = Env.mk_var_gen () in
     let assert_sub, assert_expr = Bil_to_bir.mk_assert_fail () in
     let sub = nest_ifs var_gen depth [Bil.jmp assert_expr] |> bil_to_sub in
-    let env = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [sub; assert_sub]) in
+    let env = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [sub; assert_sub])
+        ~specs:[Pre.spec_verifier_error] in
     let post  = Bool.mk_true ctx
                 |> Constr.mk_goal "true"
                 |> Constr.mk_constr

--- a/wp/lib/bap_wp/tests/unit/test_compare.ml
+++ b/wp/lib/bap_wp/tests/unit/test_compare.ml
@@ -485,8 +485,10 @@ let test_fun_outputs_1 (test_ctx : test_ctxt) : unit =
   let main_sub2 = Bil.(
       [ jmp (unknown (call_sub2 |> Term.tid |> Tid.to_string) reg64_t)  ]
     ) |> bil_to_sub in
-  let env1 = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [main_sub1; call_sub1]) in
-  let env2 = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [main_sub2; call_sub2]) in
+  let env1 = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [main_sub1; call_sub1])
+      ~specs:[Pre.spec_chaos_caller_saved] in
+  let env2 = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [main_sub2; call_sub2])
+      ~specs:[Pre.spec_chaos_caller_saved] in
   let input_vars = Var.Set.of_list (ret_var :: x86_64_input_regs) in
   let output_vars = Var.Set.singleton ret_var in
   let post, hyps = Comp.compare_subs_eq ~input:input_vars ~output:output_vars in
@@ -520,8 +522,10 @@ let test_fun_outputs_2 (test_ctx : test_ctxt) : unit =
         rsi := i64 3;
         jmp (unknown (call_sub2 |> Term.tid |> Tid.to_string) reg64_t)  ]
     ) |> bil_to_sub in
-  let env1 = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [main_sub1; call_sub1]) in
-  let env2 = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [main_sub2; call_sub2]) in
+  let env1 = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [main_sub1; call_sub1])
+      ~specs:[Pre.spec_chaos_caller_saved] in
+  let env2 = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [main_sub2; call_sub2])
+      ~specs:[Pre.spec_chaos_caller_saved] in
   let input_vars = Var.Set.of_list (ret_var :: x86_64_input_regs) in
   let output_vars = Var.Set.singleton ret_var in
   let post, hyps = Comp.compare_subs_eq ~input:input_vars ~output:output_vars in

--- a/wp/lib/bap_wp/tests/unit/test_precondition.ml
+++ b/wp/lib/bap_wp/tests/unit/test_precondition.ml
@@ -521,7 +521,7 @@ let test_subroutine_6 (test_ctx : test_ctxt) : unit =
   let blk2 = blk2 |> mk_call (Label.direct (Term.tid blk3)) (Label.direct (Term.tid sub_assert)) in
   let sub = mk_sub [blk2; blk3] in
   let subs = Seq.of_list [sub; sub_assert] in
-  let env = Pre.mk_env ~subs ctx var_gen in
+  let env = Pre.mk_env ~subs ~specs:[Pre.spec_verifier_error] ctx var_gen in
   let post = true_constr ctx in
   let pre, _ = Pre.visit_sub env post sub in
   assert_z3_result test_ctx env (Sub.to_string sub) post pre Z3.Solver.SATISFIABLE
@@ -533,7 +533,7 @@ let test_subroutine_7 (test_ctx : test_ctxt) : unit =
   let assert_sub, assert_expr = Bil_to_bir.mk_assert_fail () in
   let sub = Bil_to_bir.bil_to_sub Bil.([jmp assert_expr])  in
   let subs = Seq.singleton assert_sub in
-  let env = Pre.mk_env ~subs ctx var_gen in
+  let env = Pre.mk_env ~subs ~specs:[Pre.spec_verifier_error] ctx var_gen in
   let post = true_constr ctx in
   let pre, _ = Pre.visit_sub env post sub in
   assert_z3_result test_ctx env (Sub.to_string sub) post pre Z3.Solver.SATISFIABLE
@@ -556,7 +556,8 @@ let test_call_1 (test_ctx : test_ctxt) : unit =
              |> mk_def ret_var zero
              |> mk_call (Label.direct (Term.tid blk3)) (Label.direct (Term.tid call_body)) in
   let main_sub = mk_sub [blk2; blk3] in
-  let env = Pre.mk_env ctx var_gen 
+  let env = Pre.mk_env ctx var_gen
+      ~specs:[Pre.spec_arg_terms]
       ~subs:(Seq.of_list [call_body; main_sub]) in
   let post = Bool.mk_eq ctx (mk_z3_expr env (Bil.var ret_var)) (mk_z3_expr env zero)
              |> Constr.mk_goal "ret = 0"
@@ -717,7 +718,7 @@ let test_call_7 (test_ctx : test_ctxt) : unit =
   let main_sub = mk_sub [blk2; blk3] in
   let env = Pre.mk_env ctx var_gen
       ~subs:(Seq.of_list [main_sub; call_sub])
-      ~to_inline:(Seq.singleton call_sub)
+      ~specs:[Pre.spec_inline @@ Seq.singleton call_sub]
   in
   let sub_called = Option.value_exn (call_tid |> Env.get_called env) in
   let post = Bool.mk_and ctx [
@@ -794,7 +795,7 @@ let test_call_9 (test_ctx : test_ctxt) : unit =
   let main_sub = mk_sub [blk_main; blk_main'] in
   let env = Pre.mk_env ctx var_gen
       ~subs:(Seq.of_list [main_sub; call1_sub; call2_sub])
-      ~to_inline:(Seq.of_list [call1_sub; call2_sub])
+      ~specs:[Pre.spec_inline @@ Seq.of_list [call1_sub; call2_sub]]
   in
   let sub1_called = Option.value_exn (call1_tid |> Env.get_called env) in
   let sub2_called = Option.value_exn (call2_tid |> Env.get_called env) in
@@ -838,7 +839,7 @@ let test_call_10 (test_ctx : test_ctxt) : unit =
   let main_sub = mk_sub [blk_main; blk_main'] in
   let env = Pre.mk_env ctx var_gen
       ~subs:(Seq.of_list [main_sub; call1_sub; call2_sub])
-      ~to_inline:(Seq.of_list [call1_sub])
+      ~specs:[Pre.spec_inline @@ Seq.singleton call1_sub]
   in
   let sub1_called = Option.value_exn (call1_tid |> Env.get_called env) in
   let sub2_called = Option.value_exn (call2_tid |> Env.get_called env) in
@@ -864,7 +865,7 @@ let test_int_1 (test_ctx : test_ctxt) : unit =
              |> mk_int 0x0 blk2
   in
   let main_sub = mk_sub [blk1; blk2] in
-  let env = Pre.mk_env ctx var_gen ~to_inline:(Seq.empty) ~subs:(Seq.of_list [main_sub]) in
+  let env = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [main_sub]) in
   let post = Bool.mk_eq ctx (mk_z3_expr env (Bil.var ret_var)) (mk_z3_expr env zero)
              |> Constr.mk_goal "ret = 0"
              |> Constr.mk_constr
@@ -1355,7 +1356,8 @@ let test_get_vars_inline_1 (test_ctx : test_ctxt) : unit =
   let ctx = Env.mk_ctx () in
   let var_gen = Env.mk_var_gen () in
   let env = Pre.mk_env ctx var_gen ~use_fun_input_regs:false
-      ~to_inline:(Seq.singleton call_sub) ~subs:(Seq.of_list [sub; call_sub]) in
+      ~specs:[Pre.spec_inline @@ Seq.singleton call_sub]
+      ~subs:(Seq.of_list [sub; call_sub]) in
   let vars = Pre.get_vars env sub in
   assert_equal ~ctxt:test_ctx ~cmp:Var.Set.equal
     ~printer:(fun v -> v |> Var.Set.to_list |> List.to_string ~f:Var.to_string)

--- a/wp/resources/sample_binaries/equiv_null_check/run_wp.sh
+++ b/wp/resources/sample_binaries/equiv_null_check/run_wp.sh
@@ -14,6 +14,7 @@ compile () {
 run () {
   bap $dummy_dir/hello_world.out --pass=wp \
     --wp-compare \
+    --wp-trip-asserts \
     --wp-file1=main_1.bpj \
     --wp-file2=main_2.bpj
 }

--- a/wp/resources/sample_binaries/function_call/run_wp_inline_all.sh
+++ b/wp/resources/sample_binaries/function_call/run_wp_inline_all.sh
@@ -12,7 +12,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-inline=.*
+  bap main --pass=wp --wp-inline=.* --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/function_call/run_wp_inline_foo.sh
+++ b/wp/resources/sample_binaries/function_call/run_wp_inline_foo.sh
@@ -13,7 +13,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-inline=foo
+  bap main --pass=wp --wp-inline=foo --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/function_spec/run_wp.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp.sh
@@ -15,7 +15,7 @@ compile () {
 }
 
 run () {
-    bap main --pass=wp
+    bap main --pass=wp --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/function_spec/run_wp_inline_all.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp_inline_all.sh
@@ -13,7 +13,7 @@ compile () {
 }
 
 run () {
-    bap main --pass=wp --wp-inline=.*
+    bap main --pass=wp --wp-inline=.* --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/function_spec/run_wp_inline_foo.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp_inline_foo.sh
@@ -14,7 +14,7 @@ compile () {
 }
 
 run () {
-    bap main --pass=wp --wp-inline=foo
+    bap main --pass=wp --wp-inline=foo --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/function_spec/run_wp_inline_garbage.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp_inline_garbage.sh
@@ -13,7 +13,7 @@ compile () {
 }
 
 run () {
-    bap main --pass=wp --wp-inline=NONEXISTENTGARBAGE
+    bap main --pass=wp --wp-inline=NONEXISTENTGARBAGE --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/goto_string/run_wp.sh
+++ b/wp/resources/sample_binaries/goto_string/run_wp.sh
@@ -16,7 +16,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp
+  bap main --pass=wp --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/goto_string/run_wp_inline.sh
+++ b/wp/resources/sample_binaries/goto_string/run_wp_inline.sh
@@ -16,7 +16,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-inline=.*
+  bap main --pass=wp --wp-inline=.* --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/loop/run_wp.sh
+++ b/wp/resources/sample_binaries/loop/run_wp.sh
@@ -3,7 +3,7 @@ compile() {
 }
 
 run() {
-        bap main --pass=wp --wp-num-unroll=2
+        bap main --pass=wp --wp-num-unroll=2 --wp-trip-asserts
 
 }
 

--- a/wp/resources/sample_binaries/nested_function_calls/run_wp.sh
+++ b/wp/resources/sample_binaries/nested_function_calls/run_wp.sh
@@ -12,7 +12,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp
+  bap main --pass=wp --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_all.sh
+++ b/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_all.sh
@@ -12,7 +12,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-inline=.*
+  bap main --pass=wp --wp-inline=.* --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_regex.sh
+++ b/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_regex.sh
@@ -12,7 +12,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-inline="foo|bar"
+  bap main --pass=wp --wp-inline="foo|bar" --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/nested_ifs/run_wp.sh
+++ b/wp/resources/sample_binaries/nested_ifs/run_wp.sh
@@ -16,7 +16,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-func=nestedIfExample
+  bap main --pass=wp --wp-func=nestedIfExample --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/nested_ifs/run_wp_goto.sh
+++ b/wp/resources/sample_binaries/nested_ifs/run_wp_goto.sh
@@ -16,7 +16,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-func=gotoExample
+  bap main --pass=wp --wp-func=gotoExample --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/nested_ifs/run_wp_inline.sh
+++ b/wp/resources/sample_binaries/nested_ifs/run_wp_inline.sh
@@ -12,7 +12,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp --wp-inline=.*
+  bap main --pass=wp --wp-inline=.* --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/simple_wp/run_wp.sh
+++ b/wp/resources/sample_binaries/simple_wp/run_wp.sh
@@ -12,7 +12,7 @@ compile () {
 }
 
 run () {
-  bap main --pass=wp
+  bap main --pass=wp --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/verifier_calls/run_wp_assume_sat.sh
+++ b/wp/resources/sample_binaries/verifier_calls/run_wp_assume_sat.sh
@@ -10,7 +10,7 @@ compile () {
 }
 
 run () {
-  bap verifier_assume_sat --pass=wp
+  bap verifier_assume_sat --pass=wp --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/verifier_calls/run_wp_assume_unsat.sh
+++ b/wp/resources/sample_binaries/verifier_calls/run_wp_assume_unsat.sh
@@ -10,7 +10,7 @@ compile () {
 }
 
 run () {
-  bap verifier_assume_unsat --pass=wp
+  bap verifier_assume_unsat --pass=wp --wp-trip-asserts
 }
 
 compile && run

--- a/wp/resources/sample_binaries/verifier_calls/run_wp_nondet.sh
+++ b/wp/resources/sample_binaries/verifier_calls/run_wp_nondet.sh
@@ -11,7 +11,7 @@ compile () {
 }
 
 run () {
-  bap verifier_nondet --pass=wp
+  bap verifier_nondet --pass=wp --wp-trip-asserts
 }
 
 compile && run


### PR DESCRIPTION
Fixes #167. The user needs to specify `--wp-trip-asserts` in order to find inputs that would reach an assert false.