### PR TITLE
Add flag for printing refuted goals

### DIFF
--- a/wp/README.md
+++ b/wp/README.md
@@ -361,9 +361,17 @@ The various options are:
   follow the same execution trace. In the case the analysis returns UNSAT or
   UNKNOWN, no script will be outputted.
 
+- `--wp-print-refuted-goals[true|false]`. If set, in the case WP results in SAT,
+  prints a list of goals that have been refuted in the model. The list will show
+  the tagged name of the goal, the concrete values of the goal, and the Z3
+  expression representing the goal. For example, a refuted goal of
+  `(= RAX_orig RAX_mod)` can have concrete values of
+  `(= 0x0000000000000000 0x0000000000000001)`.
+
 - `--wp-print-path=[true|false]`. If present, will print out the path to a refuted
   goal and the register values at each jump in the path. It also contains information
-  about whehter a jump has been taken and the address of the jump if found.
+  about whether a jump has been taken and the address of the jump if found. The path
+  will only be printed if refuted goals are printed with `--wp-print-refuted-goals`.
 
 - `--wp-use-fun-input-regs=[true|false].` If present, at a function call site, uses
   all possible input registers as arguments to a function symbol generated for

--- a/wp/lib/bap_wp/src/output.ml
+++ b/wp/lib/bap_wp/src/output.ml
@@ -149,7 +149,8 @@ let get_mem (m : Z3.Model.model) (env : Env.t) : mem_model option =
     None
 
 let print_result (solver : Solver.solver) (status : Solver.status) (goals: Constr.t)
-    ~print_path:(print_path : bool) ~orig:(env1 : Env.t) ~modif:(env2 : Env.t) : unit =
+    ~print_path:(print_path : bool) ~print_refuted_goals:(print_refuted_goals : bool)
+    ~orig:(env1 : Env.t) ~modif:(env2 : Env.t) : unit =
   match status with
   | Solver.UNSATISFIABLE -> Format.printf "\nUNSAT!\n%!"
   | Solver.UNKNOWN -> Format.printf "\nUNKNOWN!\n%!"
@@ -162,12 +163,14 @@ let print_result (solver : Solver.solver) (status : Solver.status) (goals: Const
     let mem2, _ = Env.get_var env2 Target.CPU.mem in
     Format.printf "\nSAT!\n%!";
     Format.printf "\nModel:\n%s\n%!" (format_model model env1 env2);
-    let refuted_goals =
-      Constr.get_refuted_goals goals solver ctx ~filter_out:[mem1; mem2] in
-    Format.printf "\nRefuted goals:\n%!";
-    Seq.iter refuted_goals ~f:(fun goal ->
-        Format.printf "%s\n%!"
-          (Constr.format_refuted_goal goal model var_map ~print_path))
+    if print_refuted_goals then begin
+      let refuted_goals =
+        Constr.get_refuted_goals goals solver ctx ~filter_out:[mem1; mem2] in
+      Format.printf "\nRefuted goals:\n%!";
+      Seq.iter refuted_goals ~f:(fun goal ->
+          Format.printf "%s\n%!"
+            (Constr.format_refuted_goal goal model var_map ~print_path))
+    end
 
 (** [output_gdb] is similar to [print_result] except chews on the model and outputs a gdb script with a
     breakpoint at the subroutine and fills the appropriate registers *)

--- a/wp/lib/bap_wp/src/output.mli
+++ b/wp/lib/bap_wp/src/output.mli
@@ -33,7 +33,7 @@ module Constr = Constraint
     the refuted goals. *)
 val print_result :
   Z3.Solver.solver -> Z3.Solver.status -> Constr.t -> print_path:bool ->
-  orig:Env.t -> modif:Env.t -> unit
+  print_refuted_goals:bool -> orig:Env.t -> modif:Env.t -> unit
 
 (** Prints to file a gdb script that will fill the appropriate registers with the countermodel *)
 val output_gdb :

--- a/wp/lib/bap_wp/tests/unit/test_utils.ml
+++ b/wp/lib/bap_wp/tests/unit/test_utils.ml
@@ -74,11 +74,14 @@ let mk_z3_expr (env : Env.t) (e : Exp.t) : Constr.z3_expr =
 let mk_z3_var (env : Env.t) (v : Var.t) : Constr.z3_expr =
   fst (Env.get_var env v)
 
-let print_z3_model ?print_path:(print_path = false) ~orig:(env1 : Env.t)
-    ~modif:(env2 : Env.t) (solver : Z3.Solver.solver) (exp : Z3.Solver.status)
+let print_z3_model
+    ?print_path:(print_path = false) ?print_refuted_goals:(print_refuted_goals = false)
+    ~orig:(env1 : Env.t) ~modif:(env2 : Env.t)
+    (solver : Z3.Solver.solver) (exp : Z3.Solver.status)
     (real : Z3.Solver.status) (goals : Constr.t) : unit =
   if real = exp || real = Z3.Solver.UNSATISFIABLE then () else
-    Output.print_result solver real goals ~print_path ~orig:env1 ~modif:env2
+    Output.print_result solver real goals ~print_path ~print_refuted_goals
+      ~orig:env1 ~modif:env2
 
 (* Finds a jump in a subroutine given its jump condition. *)
 let find_jump (sub : Sub.t) (cond : Exp.t) : Jmp.t =

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -35,6 +35,7 @@ type flags =
     output_vars : string list;
     gdb_filename : string option;
     bildb_output : string option;
+    print_refuted_goals : bool;
     print_path : bool;
     use_fun_input_regs : bool;
     mem_offset : bool;
@@ -330,8 +331,8 @@ let main (flags : flags) (proj : project) : unit =
   let () = match flags.bildb_output with
     | None -> ()
     | Some f -> Output.output_bildb solver result env2 f in
-  Output.print_result solver result pre ~print_path:flags.print_path
-    ~orig:env1 ~modif:env2
+  Output.print_result solver result pre ~orig:env1 ~modif:env2
+    ~print_refuted_goals:flags.print_refuted_goals ~print_path:flags.print_path
 
 
 module Cmdline = struct
@@ -399,10 +400,19 @@ module Cmdline = struct
             countermodel found during WP analysis, allowing BilDB to follow the \
             same execution trace."
 
+  let print_refuted_goals = param bool "print-refuted-goals" ~as_flag:true ~default:false
+      ~doc:"If set, in the case WP results in SAT, prints a list of goals that \
+            have been refuted in the model. The list will show the tagged name \
+            of the goal, the concrete values of the goal, and the Z3 expression \
+            representing the goal. For example, a refuted goal of \
+            (= RAX_orig RAX_mod) can have concrete values of \
+            (= 0x0000000000000000 0x0000000000000001)."
+
   let print_path = param bool "print-path" ~as_flag:true ~default:false
-      ~doc:"If set, prints out the path to a refuted goal and the register values \
+      ~doc:"If set, prints out the path to each refuted goal and the register values \
             at each jump in the path. The path contains information about whether \
-            a jump has been taken and the address of the jump if found."
+            a jump has been taken and the address of the jump if found. The path \
+            will only be printed if refuted goals are printed with --wp-print-refuted-goals."
 
   let use_fun_input_regs = param bool "use-fun-input-regs" ~as_flag:true  ~default:true
       ~doc:"If set, at a function call site, uses all possible input registers \
@@ -467,6 +477,7 @@ module Cmdline = struct
           output_vars = !!output_vars;
           gdb_filename = !!gdb_filename;
           bildb_output = !!bildb_output;
+          print_refuted_goals = !!print_refuted_goals;
           print_path = !!print_path;
           use_fun_input_regs = !!use_fun_input_regs;
           mem_offset = !!mem_offset;


### PR DESCRIPTION
Addresses part of #193. Adds a flag, `--wp-print-refuted-goals`. Refuted goals won't be calculated or printed out if the flag isn't set.