### PR TITLE
Phil/slim save

### DIFF
--- a/wp/plugin/save_project/save_project.ml
+++ b/wp/plugin/save_project/save_project.ml
@@ -28,7 +28,10 @@ let main nm proj : unit =
   in
   let clear_mapper = object 
     inherit Term.mapper as super
-    method! map_term cls t = let t' = Term.with_attrs t Dict.empty in super#map_term cls t'
+    method! map_term cls t = 
+                 let new_dict = Option.value_map ~default:Dict.empty ~f:(fun a -> (Dict.set Dict.empty address a)) (Term.get_attr t address) in
+                 let t' = Term.with_attrs t new_dict in 
+                 super#map_term cls t'
     end 
   in
   let prog = clear_mapper#run prog in

--- a/wp/plugin/save_project/save_project.ml
+++ b/wp/plugin/save_project/save_project.ml
@@ -26,15 +26,18 @@ let main nm proj : unit =
     | ("", Some bnm) -> String.concat [bnm; ".bpj"]
     | (user_dest, _) -> user_dest
   in
-  (* Here we clear the attributes from terms because it was found to result in unnecessary bloat and slowdown.
-     We retain the address attribute for usage in --wp-print-paths *)
+  (* Here we clear the attributes from terms because it was found to result in unnecessary
+     bloat and slowdown. We retain the address attribute for usage in --wp-print-paths *)
   let clear_mapper = object 
     inherit Term.mapper as super
     method! map_term cls t = 
-                 let new_dict = Option.value_map ~default:Dict.empty ~f:(fun a -> (Dict.set Dict.empty address a)) (Term.get_attr t address) in
-                 let t' = Term.with_attrs t new_dict in 
-                 super#map_term cls t'
-    end 
+      let new_dict = Option.value_map 
+          ~default:Dict.empty 
+          ~f:(fun a -> (Dict.set Dict.empty address a)) (Term.get_attr t address) 
+      in
+      let t' = Term.with_attrs t new_dict in 
+      super#map_term cls t'
+  end 
   in
   let prog = clear_mapper#run prog in
   Program.Io.write ~fmt:"bin" dest prog

--- a/wp/plugin/save_project/save_project.ml
+++ b/wp/plugin/save_project/save_project.ml
@@ -26,6 +26,8 @@ let main nm proj : unit =
     | ("", Some bnm) -> String.concat [bnm; ".bpj"]
     | (user_dest, _) -> user_dest
   in
+  (* Here we clear the attributes from terms because it was found to result in unnecessary bloat and slowdown.
+     We retain the address attribute for usage in --wp-print-paths *)
   let clear_mapper = object 
     inherit Term.mapper as super
     method! map_term cls t = 

--- a/wp/plugin/save_project/save_project.ml
+++ b/wp/plugin/save_project/save_project.ml
@@ -26,6 +26,12 @@ let main nm proj : unit =
     | ("", Some bnm) -> String.concat [bnm; ".bpj"]
     | (user_dest, _) -> user_dest
   in
+  let clear_mapper = object 
+    inherit Term.mapper as super
+    method! map_term cls t = let t' = Term.with_attrs t Dict.empty in super#map_term cls t'
+    end 
+  in
+  let prog = clear_mapper#run prog in
   Program.Io.write ~fmt:"bin" dest prog
 
 module Cmdline = struct


### PR DESCRIPTION
In the save-project plugin, removes attributes of terms as per Ivan's suggestion. This significantly reduces the size of the project files which in turn reduces the loading time of these project files. Down from ~600mb to ~45mb on a `tar` example and ~40s loading to ~5s. 

These are the attributes that are removed:

- alloc-size
- c.data
- c.proto
- c.type
- entry-point
- format
- insn
- malloc
- nonnull
- noreturn
- pure
- returns-twice
- warn-unused

The `address` attribute was kept for` --wp-print-paths`
