### PR TITLE
Functional loop unrolling depth

### DIFF
--- a/wp/lib/bap_wp/src/environment.ml
+++ b/wp/lib/bap_wp/src/environment.ml
@@ -205,6 +205,12 @@ module Unfold_depth = Blk.Map
 
 type unfold_depth = int Unfold_depth.t
 
+(* This is the default handler for loops, which unfolds a loop by:
+   - Looking at the target node for a backjump
+   - If the node has been visited more than [num_unroll] times, use the [loop_exit_pre] precondition
+   - Otherwise, decrement the [depth] map which tracks the unfoldings for that node, and
+     recursively call [Precondition.visit_graph]. Because this function is defined in another
+     (later) module, we use open recursion via the [wp_rec_call] function reference. *)
 let rec loop_unfold (num_unroll : int) (depth : unfold_depth) : loop_handler =
   {
     handle =


### PR DESCRIPTION
Instead of using a mutable hashtable, we now pass around a functional map, _within_ the `loop_handler` thunk contained in the `env`.

This should reduce the usual risks associated with mutability, e.g. if we re-use an existing `env` for a second analysis, as we are prone to doing.

Tests pass and I don't see any significant performance regression, but someone might want to double check that.