### PR TITLE
handling for empty subroutines

### DIFF
--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -513,6 +513,14 @@ let spec_verifier_nondet (sub : Sub.t) (_ : Arch.t) : Env.fun_spec option =
   else
     None
 
+let spec_empty (sub : Sub.t) (_ : Arch.t) : Env.fun_spec option =
+  if (Seq.is_empty @@ Term.enum blk_t sub) then
+    Some {
+      spec_name = "spec_empty";
+      spec = Summary (fun env post _tid -> post, env)
+    }
+  else None
+
 let spec_arg_terms (sub : Sub.t) (_ : Arch.t) : Env.fun_spec option =
   let args = Term.enum arg_t sub in
   if not (Seq.is_empty args) then

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -872,12 +872,14 @@ let filter (env : Env.t) (calls : string list) (cfg : Graphs.Ir.t) : Graphs.Ir.t
 
 let visit_sub (env : Env.t) (post : Constr.t) (sub : Sub.t) : Constr.t * Env.t =
   debug "Visiting sub:\n%s%!" (Sub.to_string sub);
-  let cfg = sub |> Sub.to_cfg |> filter env ["exit"] in
-  let start = Term.first blk_t sub
-              |> Option.value_exn ?here:None ?error:None ?message:None
-              |> Graphs.Ir.Node.create in
-  let pre, env' = visit_graph ~start:start env post cfg in
-  (pre, Env.add_precond env' (Term.tid sub) pre)
+  if (Seq.is_empty @@ Term.enum blk_t sub) then (post, env)
+  else
+    let cfg = sub |> Sub.to_cfg |> filter env ["exit"] in
+    let start = Term.first blk_t sub
+                |> Option.value_exn ?here:None ?error:None ?message:None
+                |> Graphs.Ir.Node.create in
+    let pre, env' = visit_graph ~start:start env post cfg in
+    (pre, Env.add_precond env' (Term.tid sub) pre)
 
 (* Replace the [inline_func] placeholder with [visit_sub]. *)
 let _  = inline_func :=

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -871,9 +871,15 @@ let filter (env : Env.t) (calls : string list) (cfg : Graphs.Ir.t) : Graphs.Ir.t
   Graphlib.depth_first_search (module Graphs.Ir) ~enter_edge:enter_edge ~init:cfg cfg
 
 let visit_sub (env : Env.t) (post : Constr.t) (sub : Sub.t) : Constr.t * Env.t =
-  debug "Visiting sub:\n%s%!" (Sub.to_string sub);
+  let sub_name = (Sub.to_string sub) in
+  debug "Visiting sub:\n%s%!" sub_name;
   let pre, env' =
-    if (Seq.is_empty @@ Term.enum blk_t sub) then (post, env)
+    if (Seq.is_empty @@ Term.enum blk_t sub) 
+    then
+      (
+        warning "encountered empty subroutine %s%!" sub_name;
+        (post, env)
+      )
     else
       let cfg = sub |> Sub.to_cfg |> filter env ["exit"] in
       let start = Term.first blk_t sub

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -136,6 +136,10 @@ val spec_verifier_assume : Bap.Std.Sub.t -> Bap.Std.Arch.t -> Env.fun_spec optio
     the output value from the function call. *)
 val spec_verifier_nondet : Bap.Std.Sub.t -> Bap.Std.Arch.t -> Env.fun_spec option
 
+(** This spec is used for empty subroutines that have no blocks. This spec is a
+    nop, returning the postcondition as the precondition. *)
+val spec_empty : Bap.Std.Sub.t -> Bap.Std.Arch.t -> Env.fun_spec option
+
 (** This spec is used when BAP is able to generate [arg term]s for the subroutine
     in the case when an API is specified. It creates a function symbol for
     each output register given the input registers in the form

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -138,8 +138,8 @@ let fun_specs (f : flags) (to_inline : Sub.t Seq.t)
     [ Pre.spec_verifier_assume;
       Pre.spec_verifier_nondet;
       Pre.spec_afl_maybe_log;
-      Pre.spec_inline to_inline;
       Pre.spec_empty;
+      Pre.spec_inline to_inline;
       Pre.spec_arg_terms;
       Pre.spec_chaos_caller_saved;
       Pre.spec_rax_out

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -138,8 +138,8 @@ let fun_specs (f : flags) (to_inline : Sub.t Seq.t)
     [ Pre.spec_verifier_assume;
       Pre.spec_verifier_nondet;
       Pre.spec_afl_maybe_log;
-      Pre.spec_empty;
       Pre.spec_inline to_inline;
+      Pre.spec_empty;
       Pre.spec_arg_terms;
       Pre.spec_chaos_caller_saved;
       Pre.spec_rax_out

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -139,6 +139,7 @@ let fun_specs (f : flags) (to_inline : Sub.t Seq.t)
       Pre.spec_verifier_nondet;
       Pre.spec_afl_maybe_log;
       Pre.spec_inline to_inline;
+      Pre.spec_empty;
       Pre.spec_arg_terms;
       Pre.spec_chaos_caller_saved;
       Pre.spec_rax_out


### PR DESCRIPTION
This PR addresses issue #186 by adding in an empty function spec. 

This passes all but the switch statement test (which is benign) in our test suite. When run on the grammatech examples, this turns 19 out of 23 SATs to UNSATs (the remainder take over 15 minutes on my computer and thus timeout). 