### PR TITLE
Fortunac/print flags

### DIFF
--- a/wp/README.md
+++ b/wp/README.md
@@ -364,18 +364,6 @@ The various options are:
   follow the same execution trace. In the case the analysis returns UNSAT or
   UNKNOWN, no script will be outputted.
 
-- `--wp-print-refuted-goals[true|false]`. If set, in the case WP results in SAT,
-  prints a list of goals that have been refuted in the model. The list will show
-  the tagged name of the goal, the concrete values of the goal, and the Z3
-  expression representing the goal. For example, a refuted goal of
-  `(= RAX_orig RAX_mod)` can have concrete values of
-  `(= 0x0000000000000000 0x0000000000000001)`.
-
-- `--wp-print-path=[true|false]`. If present, will print out the path to a refuted
-  goal and the register values at each jump in the path. It also contains information
-  about whether a jump has been taken and the address of the jump if found. The path
-  will only be printed if refuted goals are printed with `--wp-print-refuted-goals`.
-
 - `--wp-use-fun-input-regs=[true|false].` If present, at a function call site, uses
   all possible input registers as arguments to a function symbol generated for
   an output register that represents the result of the function call. If set to
@@ -395,11 +383,21 @@ The various options are:
   original binary, then that same address is also non-null in the modified binary.
   Defaults to false.
 
-- `--wp-print-constr=[internal|smtlib] or both/neither`. If set, the preconditions
-  and Z3's SMT-LIB 2 are both printed. One or both outputs can be explicitly
-  called with the respective names `internal` and `smtlib`, which will print only
-  what is stated. Both can also be called like `--wp-print-constr=internal,smtlib`.
-  If the flag is not called, it defaults to printing neither.
+- `--wp-show=[bir|refuted-goals|paths|precond-internal|precond-smtlib]`. A list
+  of details to print out from the analysis. Multiple options as a list can be
+  passed into the flag to print out multiple details. For example:
+  `--wp-show=bir,refuted-goals`. The options are:
+   - `bir`: The code of the binary/binaries in BAP Immediate Representation.
+   - `refuted-goals`: In the case the analysis results in SAT, a list of goals
+      refuted in the model that contains their tagged names, the concrete values
+      of the goals, and the Z3 representation of the goal.
+   - `paths`: The execution path of the binary that results in a refuted goal.
+     The path contains information about the jumps taken, their addresses, and
+     the values of the registers at each jump. This option automatically prints
+     out the refuted-goals.
+   - `precond-internal`: The precondition printed out in WP's internal format
+     for the Constr.t type.
+   - `precond-smtlib`: The precondition printed out in Z3's SMT-LIB2 format.
 
 - `--wp-debug=[z3-solver-stats|z3-verbose|constraint-stats|eval-constraint-stats]
   or some comma delimited combination`. If set, debug will print the various

--- a/wp/lib/bap_wp/src/output.ml
+++ b/wp/lib/bap_wp/src/output.ml
@@ -150,8 +150,7 @@ let get_mem (m : Z3.Model.model) (env : Env.t) : mem_model option =
     None
 
 let print_result (solver : Solver.solver) (status : Solver.status) (goals: Constr.t)
-    ~print_path:(print_path : bool) ~print_refuted_goals:(print_refuted_goals : bool)
-    ~orig:(env1 : Env.t) ~modif:(env2 : Env.t) : unit =
+    ~show:(show : string list) ~orig:(env1 : Env.t) ~modif:(env2 : Env.t) : unit =
   match status with
   | Solver.UNSATISFIABLE -> Format.printf "\nUNSAT!\n%!"
   | Solver.UNKNOWN -> Format.printf "\nUNKNOWN!\n%!"
@@ -164,7 +163,10 @@ let print_result (solver : Solver.solver) (status : Solver.status) (goals: Const
     let mem2, _ = Env.get_var env2 Target.CPU.mem in
     Format.printf "\nSAT!\n%!";
     Format.printf "\nModel:\n%s\n%!" (format_model model env1 env2);
-    if print_refuted_goals then begin
+    let print_refuted_goals = List.mem show "refuted-goals" ~equal:String.equal in
+    let print_path = List.mem show "paths" ~equal:String.equal in
+    (* If 'paths' is specified, we assume we are also printing the refuted goals. *)
+    if print_refuted_goals || print_path then begin
       let refuted_goals =
         Constr.get_refuted_goals goals solver ctx ~filter_out:[mem1; mem2] in
       Format.printf "\nRefuted goals:\n%!";

--- a/wp/lib/bap_wp/src/output.mli
+++ b/wp/lib/bap_wp/src/output.mli
@@ -32,8 +32,8 @@ module Constr = Constraint
     a list of goals that have been refuted, and if specified, the paths that lead to
     the refuted goals. *)
 val print_result :
-  Z3.Solver.solver -> Z3.Solver.status -> Constr.t -> print_path:bool ->
-  print_refuted_goals:bool -> orig:Env.t -> modif:Env.t -> unit
+  Z3.Solver.solver -> Z3.Solver.status -> Constr.t -> show:string list ->
+  orig:Env.t -> modif:Env.t -> unit
 
 (** Prints to file a gdb script that will fill the appropriate registers with the countermodel *)
 val output_gdb :

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -1088,7 +1088,7 @@ let mem_read_offsets (env2 : Env.t) (offset : Constr.z3_expr -> Constr.z3_expr)
 let check ?refute:(refute = true) ?(print_constr = []) ?(debug = false)
     (solver : Solver.solver) (ctx : Z3.context) (pre : Constr.t)  : Solver.status =
   printf "Evaluating precondition.\n%!";
-  if (List.mem print_constr "internal" ~equal:(String.equal)) then (
+  if (List.mem print_constr "precond-internal" ~equal:(String.equal)) then (
     Printf.printf "Internal : %s \n %!" (Constr.to_string pre) ) ;
   let pre' = Constr.eval ~debug:debug pre ctx in
   printf "Checking precondition with Z3.\n%!";
@@ -1099,7 +1099,7 @@ let check ?refute:(refute = true) ?(print_constr = []) ?(debug = false)
       pre'
   in
   Z3.Solver.add solver [is_correct];
-  if (List.mem print_constr "smtlib" ~equal:(String.equal)) then (
+  if (List.mem print_constr "precond-smtlib" ~equal:(String.equal)) then (
     Printf.printf "Z3 : \n %s \n %!" (Z3.Solver.to_string solver) );
   Z3.Solver.check solver []
 

--- a/wp/lib/bap_wp/tests/unit/test_utils.ml
+++ b/wp/lib/bap_wp/tests/unit/test_utils.ml
@@ -75,13 +75,11 @@ let mk_z3_var (env : Env.t) (v : Var.t) : Constr.z3_expr =
   fst (Env.get_var env v)
 
 let print_z3_model
-    ?print_path:(print_path = false) ?print_refuted_goals:(print_refuted_goals = false)
     ~orig:(env1 : Env.t) ~modif:(env2 : Env.t)
     (solver : Z3.Solver.solver) (exp : Z3.Solver.status)
     (real : Z3.Solver.status) (goals : Constr.t) : unit =
   if real = exp || real = Z3.Solver.UNSATISFIABLE then () else
-    Output.print_result solver real goals ~print_path ~print_refuted_goals
-      ~orig:env1 ~modif:env2
+    Output.print_result solver real goals ~show:[] ~orig:env1 ~modif:env2
 
 (* Finds a jump in a subroutine given its jump condition. *)
 let find_jump (sub : Sub.t) (cond : Exp.t) : Jmp.t =

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -304,6 +304,15 @@ let compare_projs (ctx : Z3.context) (var_gen : Env.var_gen) (proj : project)
 let should_compare (f : flags) : bool =
   f.compare || ((not @@ String.is_empty f.file1) && (not @@ String.is_empty f.file2))
 
+let check_show (show : string list) : unit =
+  let options = ["bir"; "refuted-goals"; "paths"; "precond-internal"; "precond-smtlib"] in
+  match List.find show ~f:(fun s -> not @@ List.mem options s ~equal:String.equal) with
+  | Some s ->
+    Printf.printf "'%s' is not a valid option for --wp-show. Available options \
+                   are: %s\n%!" s (List.to_string options ~f:String.to_string);
+    exit 1
+  | None -> ()
+
 let main (flags : flags) (proj : project) : unit =
   if (List.mem flags.debug "z3-verbose"  ~equal:(String.equal)) then
     Z3.set_global_param "verbose" "10";
@@ -490,6 +499,7 @@ module Cmdline = struct
           show = !!show
         }
       in
+      check_show flags.show;
       Project.register_pass' @@
       main flags
     )

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -447,7 +447,7 @@ module Cmdline = struct
             goal. The path contains information about the jumps taken, their \
             addresses, and the values of the registers at each jump. This option \
             automatically prints out the refuted-goals.\n \
-            `precond-internal': The precondition printed out in WP's interal \
+            `precond-internal': The precondition printed out in WP's internal \
             format for the Constr.t type.\n \
            `precond-smtlib': The precondition printed out in Z3's SMT-LIB2 \
             format."

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -38,7 +38,6 @@ type flags =
     use_fun_input_regs : bool;
     mem_offset : bool;
     check_null_deref : bool;
-    print_constr : string list;
     debug : string list;
     trip_asserts : bool;
     stack_base : int option;
@@ -322,7 +321,7 @@ let main (flags : flags) (proj : project) : unit =
     Constr.print_stats (pre);
   let debug_eval =
     (List.mem flags.debug "eval-constraint-stats" ~equal:(String.equal)) in
-  let result = Pre.check ~print_constr:flags.print_constr ~debug:debug_eval
+  let result = Pre.check ~print_constr:flags.show ~debug:debug_eval
       solver ctx pre in
   if (List.mem flags.debug "z3-solver-stats" ~equal:(String.equal)) then
     Printf.printf "Showing solver statistics : \n %s \n %!" (
@@ -425,13 +424,6 @@ module Cmdline = struct
             not dereference a NULL, then that same read or write in the modified \
             binary also does not dereference a NULL. Defaults to false."
 
-  let print_constr = param (list string) "print-constr" ~as_flag:["internal";"smtlib"] ~default:[]
-      ~doc:"If set, the preconditions and Z3's SMT-LIB 2 are both printed. \
-            One or both outputs can be explicitly called with the respective names \
-            internal and smtlib, which will print only what is stated. Both can \
-            also be called like --wp-print-constr=internal,smtlib. If the flag \
-            is not called, it defaults to printing neither."
-
   let debug = param (list string) "debug" ~default:[]
       ~as_flag:["z3-solver-stats"; "z3-verbose"; "constraint-stats"; "eval-constraint-stats"]
       ~doc:"If set, debug will print the various debugging statistics, including \
@@ -442,7 +434,10 @@ module Cmdline = struct
             defaults to printing none of them."
 
   let show = param (list string) "show" ~default:[]
-      ~doc:"A list of details to print out from the analysis. The options are:\n \
+      ~doc:"A list of details to print out from the analysis. Multiple options \
+            as a list can be passed into the flag to print out multiple details. \
+            For example: `--wp-show=bir,refuted-goals'. \
+            The options are:\n \
             `bir': The code of the binary/binaries in BAP Immediate \
             Representation.\n \
             `refuted-goals': In the case the analysis results in SAT, a list \
@@ -451,7 +446,11 @@ module Cmdline = struct
             `paths': The execution path of the binary that results in a refuted \
             goal. The path contains information about the jumps taken, their \
             addresses, and the values of the registers at each jump. This option \
-            automatically prints out the refuted-goals."
+            automatically prints out the refuted-goals.\n \
+            `precond-internal': The precondition printed out in WP's interal \
+            format for the Constr.t type.\n \
+           `precond-smtlib': The precondition printed out in Z3's SMT-LIB2 \
+            format."
 
   let trip_asserts = param bool "trip-asserts" ~as_flag:true ~default:false
       ~doc:"If set, WP will look for inputs to the subroutine that would cause \
@@ -484,7 +483,6 @@ module Cmdline = struct
           use_fun_input_regs = !!use_fun_input_regs;
           mem_offset = !!mem_offset;
           check_null_deref = !!check_null_deref;
-          print_constr = !!print_constr;
           debug = !!debug;
           trip_asserts = !!trip_asserts;
           stack_base = !!stack_base;


### PR DESCRIPTION
Fixes #202. Consolidated the different printing options into a single flag: `--wp-show=[bir|refuted-goals|paths|precond-internal|precond-smtlib]`. Passing in the option(s) to the flag will print to STDOUT the respective item(s).

- I did prepend `precond-` to `internal` and `smtlib` to specify that it is printing out the precondition since we no longer have the `print-constr` flag.
- If we pass in `paths`, we are assuming we are also printing out the refuted goals, because each path is for a refuted goal.
- I'm currently not too big on the magic strings we have for this flag, but that is a fix I want to leave for when we have a module for handling all of our flags.