### PR TITLE
Add set_to_eqs to compare_smtlib

### DIFF
--- a/wp/lib/bap_wp/src/compare.ml
+++ b/wp/lib/bap_wp/src/compare.ml
@@ -206,8 +206,10 @@ let compare_subs_smtlib
   let postcond ~original:(_, env1) ~modified:(_, env2) ~rename_set:_ =
     mk_smtlib2_compare env1 env2 smtlib_post, env1, env2
   in
-  let hyps ~original:(_, env1) ~modified:(_, env2) ~rename_set:_ =
-    mk_smtlib2_compare env1 env2 smtlib_hyp, env1, env2
+  let hyps ~original:(_, env1) ~modified:(_, env2) ~rename_set =
+    let smtlib = mk_smtlib2_compare env1 env2 smtlib_hyp in
+    let pre_eqs, env1, env2 = set_to_eqs env1 env2 rename_set in
+    Constr.mk_clause [] (smtlib :: pre_eqs), env1, env2
   in
   postcond, hyps
 

--- a/wp/plugin/tests/test_wp.ml
+++ b/wp/plugin/tests/test_wp.ml
@@ -186,6 +186,9 @@ let suite = [
 
   "ROP example"                    >:: test_skip fail_msg (test_plugin "rop_example" unsat);
 
+  "Same signs: post registers"     >: test_plugin "same_signs" unsat;
+  "Same signs: postcondition"      >: test_plugin "same_signs" unsat ~script:"run_wp_postcond.sh";
+
   "Switch case assignments"        >: test_plugin "switch_case_assignments" sat ~expected_regs:[("RDI", "0x0000000000000000")];
   "Switch Cases"                   >: test_plugin "switch_cases" sat ~expected_regs:[("RDI", "0x0000000000000003")];
   "Switch Cases: Diff Ret Val"     >: test_plugin "switch_cases_diff_ret" sat ~expected_regs:[("RDI", "0x0000000000000003")];

--- a/wp/resources/sample_binaries/same_signs/Makefile
+++ b/wp/resources/sample_binaries/same_signs/Makefile
@@ -1,0 +1,14 @@
+BASE=main
+PROG1=$(BASE)_1
+PROG2=$(BASE)_2
+
+all: $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj
+
+%: %.c
+	$(CC) -g -Wall -Wpedantic -fno-stack-protector -z execstack -o $@ $<
+
+%.bpj: %
+	bap $< --pass=save-project --save-project-filename=$@
+
+clean:
+	rm -f $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj

--- a/wp/resources/sample_binaries/same_signs/main_1.c
+++ b/wp/resources/sample_binaries/same_signs/main_1.c
@@ -1,0 +1,25 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+bool same_signs(int x, int y) {
+    // When x is negative
+    if(x < 0){
+        // They have the same sign if x is negative too
+        if (y < 0) { return true; }
+        else { return false; }
+    // When x is positive
+    } else{
+        // They have the same sign if y is positive too
+        if (y >= 0) { return true; }
+        else { return false; }
+    }
+}
+
+int main() {
+    // Try it out
+    int x = 10;
+    int y = -10;
+    fputs(same_signs(x, y) ? "true\n" : "false\n", stdout);
+    return 0;
+}

--- a/wp/resources/sample_binaries/same_signs/main_2.c
+++ b/wp/resources/sample_binaries/same_signs/main_2.c
@@ -1,0 +1,15 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+bool same_signs(int x, int y) {
+    return !((x ^ y) < 0);
+}
+
+int main() {
+    // Try it out
+    int x = 10;
+    int y = -10;
+    fputs(same_signs(x, y) ? "true\n" : "false\n", stdout);
+    return 0;
+}

--- a/wp/resources/sample_binaries/same_signs/run_wp.sh
+++ b/wp/resources/sample_binaries/same_signs/run_wp.sh
@@ -1,0 +1,29 @@
+# This tests a function that checks if two integers are of the same sign. The
+# original binary uses a series of if/then statements to determine this, while
+# the second binary determines this with an exclusive or operator. Both should
+# be functionally equivalent. The result of same_signs between the two binaries
+# should be equal to each other given that the inputs are the same.
+
+# This tests the use of the compare-post-reg-values flag to compare the final
+# values of RAX at the end of same_sign's execution.
+
+# Should return UNSAT.
+
+set -x
+
+dummy_dir=../dummy
+
+compile () {
+  make
+}
+
+run () {
+  bap $dummy_dir/hello_world.out --pass=wp \
+    --wp-compare \
+    --wp-compare-post-reg-values=RAX \
+    --wp-file1=main_1.bpj \
+    --wp-file2=main_2.bpj \
+    --wp-function=same_signs
+}
+
+compile && run

--- a/wp/resources/sample_binaries/same_signs/run_wp_postcond.sh
+++ b/wp/resources/sample_binaries/same_signs/run_wp_postcond.sh
@@ -1,0 +1,29 @@
+# This tests a function that checks if two integers are of the same sign. The
+# original binary uses a series of if/then statements to determine this, while
+# the second binary determines this with an exclusive or operator. Both should
+# be functionally equivalent. The result of same_signs between the two binaries
+# should be equal to each other given that the inputs are the same.
+
+# This tests the use of the postcond flag to compare the final values of RAX at
+# the end of same_sign's execution.
+
+# Should return UNSAT.
+
+set -x
+
+dummy_dir=../dummy
+
+compile () {
+  make
+}
+
+run () {
+  bap $dummy_dir/hello_world.out --pass=wp \
+    --wp-compare \
+    --wp-postcond="(assert (= RAX_orig RAX_mod))" \
+    --wp-file1=main_1.bpj \
+    --wp-file2=main_2.bpj \
+    --wp-function=same_signs
+}
+
+compile && run


### PR DESCRIPTION
Adds the hypothesis that registers are equal to each other at the beginning of a subroutine's execution.