### PR TITLE
Allow list of countermodels for tests

### DIFF
--- a/wp/plugin/tests/test_wp.ml
+++ b/wp/plugin/tests/test_wp.ml
@@ -102,7 +102,7 @@ let check_result (stream : char Stream.t) (expected : string)
         Buffer.add_char buff chr)
     stream;
   let matches_a_model = List.exists !acc
-      (fun ele -> ele = None) || (List.length expected_regs = 0)
+      ~f:(fun ele -> ele = None) || (List.length expected_regs = 0)
   in
   if not matches_a_model then
     List.foldi !acc ~init:("") ~f:(fun index a ele ->


### PR DESCRIPTION
This PR addresses issue #225 by allowing a list of countermodels to be passed into our test suite. If any one of those countermodels matches, the test will pass. If none of the models match, the mismatched registers in each model are printed. This will allow us to pass in all solutions to a sudoku puzzle or nqueens and thereby always pass even in the face of the varying solutions across machines. This should allow for #223 to be rebased on top of this commit.