### PR TITLE
Phil/smt compat

### DIFF
--- a/wp/lib/bap_wp/src/constraint.ml
+++ b/wp/lib/bap_wp/src/constraint.ml
@@ -246,12 +246,12 @@ let rec eval_aux ?stats:(stats = init_stats) (constr : t) (olds : z3_expr list)
       (eval_aux ~stats:stats c2 olds news ctx)
   | Clause (hyps, concs) ->
     let eval_conjunction conj =
-      if List.length conj = 1 then 
-        (* This is tail recursive. Avoids And node. *)
-        eval_aux ~stats:stats (List.hd_exn conj) olds news ctx 
-      else
+      (* This adds possible tail recursiion, avoids And node. *)
+      match conj with
+      | []  -> Bool.mk_true ctx
+      | [x] -> eval_aux ~stats:stats x olds news ctx
+      | _   -> Bool.mk_and ctx @@
         List.map conj ~f:(fun c -> eval_aux ~stats:stats c olds news ctx)
-        |> Bool.mk_and ctx
     in
     if List.is_empty hyps then
       eval_conjunction concs(* possibly tail recursive? *)

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -57,8 +57,8 @@ let binop (ctx : Z3.context) (b : binop) : Constr.z3_expr -> Constr.z3_expr -> C
   | AND -> BV.mk_and ctx
   | OR -> BV.mk_or ctx
   | XOR -> BV.mk_xor ctx
-  | EQ -> fun x y -> BV.mk_not ctx @@ BV.mk_redor ctx @@ BV.mk_xor ctx x y
-  | NEQ -> fun x y -> BV.mk_redor ctx @@ BV.mk_xor ctx x y
+  | EQ -> fun x y -> Bool.mk_ite ctx (Bool.mk_eq ctx x y) one zero
+  | NEQ -> fun x y -> Bool.mk_ite ctx (Bool.mk_eq ctx x y) zero one
   | LT -> fun x y -> Bool.mk_ite ctx (BV.mk_ult ctx x y) one zero
   | LE -> fun x y -> Bool.mk_ite ctx (BV.mk_ule ctx x y) one zero
   | SLT -> fun x y -> Bool.mk_ite ctx (BV.mk_slt ctx x y) one zero
@@ -1018,7 +1018,7 @@ let non_null_load_vc : Env.exp_cond = fun env exp ->
     None
   else
     Some (Verify (BeforeExec (Constr.mk_goal "verify non-null mem load"
-                                (Bool.mk_and ctx conds))))
+                                (Z3_utils.mk_and ctx conds))))
 
 let non_null_load_assert : Env.exp_cond = fun env exp ->
   let ctx = Env.get_context env in
@@ -1027,7 +1027,7 @@ let non_null_load_assert : Env.exp_cond = fun env exp ->
     None
   else
     Some (Assume (BeforeExec (Constr.mk_goal "assume non-null mem load"
-                                (Bool.mk_and ctx conds))))
+                                (Z3_utils.mk_and ctx conds))))
 
 (* This adds a non-null condition for every memory write in the term *)
 let non_null_store_vc : Env.exp_cond = fun env exp ->
@@ -1037,7 +1037,7 @@ let non_null_store_vc : Env.exp_cond = fun env exp ->
     None
   else
     Some (Verify (BeforeExec (Constr.mk_goal "verify non-null mem store"
-                                (Bool.mk_and ctx conds))))
+                                (Z3_utils.mk_and ctx conds))))
 
 let non_null_store_assert : Env.exp_cond = fun env exp ->
   let ctx = Env.get_context env in
@@ -1046,7 +1046,7 @@ let non_null_store_assert : Env.exp_cond = fun env exp ->
     None
   else
     Some (Assume (BeforeExec (Constr.mk_goal "assume non-null mem store"
-                                (Bool.mk_and ctx conds))))
+                                (Z3_utils.mk_and ctx conds))))
 
 (* At a memory read, add two assumptions of the form:
    Data(x)  => init_mem_orig[x] == init_mem_mod[x + d] and
@@ -1109,7 +1109,7 @@ let mem_read_offsets (env2 : Env.t) (offset : Constr.z3_expr -> Constr.z3_expr)
   if List.is_empty conds then
     None
   else
-    Some (Assume (AfterExec (Constr.mk_goal name (Bool.mk_and ctx conds))))
+    Some (Assume (AfterExec (Constr.mk_goal name (Z3_utils.mk_and ctx conds))))
 
 let check ?refute:(refute = true) ?(print_constr = []) ?(debug = false)
     (solver : Solver.solver) (ctx : Z3.context) (pre : Constr.t)  : Solver.status =

--- a/wp/lib/bap_wp/src/z3_utils.ml
+++ b/wp/lib/bap_wp/src/z3_utils.ml
@@ -111,3 +111,11 @@ let mk_smtlib2_single (env : Env.t) (smt_post : string) : Constr.t =
   let ctx = Env.get_context env in
   mk_smtlib2 ctx smt_post decl_syms
 
+(** [mk_and] is a slightly optimized version of [Bool.mk_and] that does not produce an 
+    [and] node if the number of operands is less than 2. This may improve sharing,
+    but also improves compatibility of smtlib2 expressions with other solvers  *)
+let mk_and ( ctx : Z3.context ) (xs : Constr.z3_expr list) : Constr.z3_expr = 
+  match xs with
+  | []  -> Bool.mk_true ctx
+  | [x] -> x
+  | _   -> Bool.mk_and ctx xs

--- a/wp/lib/bap_wp/src/z3_utils.mli
+++ b/wp/lib/bap_wp/src/z3_utils.mli
@@ -52,3 +52,9 @@ val mk_smtlib2_single : Env.t -> string -> Constr.t
     [get_decls_and_symbols] function. *)
 
 val mk_smtlib2 : Z3.context -> string -> ((Z3.FuncDecl.func_decl * Z3.Symbol.symbol) list)  -> Constr.t
+
+(** [mk_and] is a slightly optimized version of [Bool.mk_and] that does not produce an 
+    [and] node if the number of operands is less than 2. This may improve sharing,
+    but also improves compatibility of smtlib2 expressions with other solvers.  *)
+
+val mk_and : Z3.context -> Constr.z3_expr list -> Constr.z3_expr


### PR DESCRIPTION
In experimenting with other solvers, I've found that z3 has different conventions with respect to `and` nodes and possibly other operations. Other solvers do not parse zero or single argument ands. In addition, other solvers do not support the `bvredor` bitvector instruction.