### PR TITLE
mark pointer inputs with flag

### DIFF
--- a/docs/reference.html
+++ b/docs/reference.html
@@ -40,6 +40,8 @@ These options apply in most circumstances to adjust CBAT's behavior or output.
 
 <li><code>--inline=&lt;posix-regexp&gt;</code> &mdash; Functions specified by the provided POSIX regular expression will inlined. When functions are not inlined, heuristic function summaries are used at function call sites. For example, if you want to inline the functions <code>foo</code> and <code>bar</code>, you can write <code>--inline=foo|bar</code>. To inline everything, use <code>--inline=.*</code> (not generally recommended).</li>
 
+<li><code>--pointer-reg-list=&lt;reg-list&gt;</code> &mdash; This flag specifies a comma delimited list of input registers to be treated as pointers at the start of program execution. This means that these registers are restricted in value to point to memory known to be initialized at the start of the function. For example, <code>RSI,RDI</code> would specify that <code>RSI</code> and <code>RDI</code>'s values should be restricted to initialized memory at the start of execution. </li>
+
 <li><code>--num-unroll=&lt;num&gt;</code> &mdash; Specifies the number of times to unroll each loop. WP will unroll each loop 5 times by default.</code></li>
 
 <li><code>--gdb-output=&lt;filename.gdb&gt;</code> &mdash; When WP results in SAT, outputs a <code>gdb</code> script to file <code>filename.gdb</code>. From within <code>gdb</code>, run <code>source filename.gdb</code> to set a breakpoint at the function given by <code>--func</code> and fill the appropriate registers with the values found in the countermodel. In the case WP returns UNSAT or UNKNOWN, no script will be outputted.</li>

--- a/wp/lib/bap_wp/src/compare.ml
+++ b/wp/lib/bap_wp/src/compare.ml
@@ -72,7 +72,7 @@ let mk_smtlib2_compare (env1 : Env.t) (env2 : Env.t) (smtlib_str : string) : Con
   let names = List.zip_exn maps fmts in
   let to_z3_name token =
     List.find_map names ~f:(fun (map, fmt) -> Z3_utils.get_z3_name map token fmt)
-    |> Option.value ~default:token
+    |> Base.Option.map ~f:Expr.to_string |> Option.value ~default:token
   in
   let smtlib_str =
     smtlib_str

--- a/wp/lib/bap_wp/src/compare.ml
+++ b/wp/lib/bap_wp/src/compare.ml
@@ -227,6 +227,19 @@ let compare_subs_eq
   in
   postcond, hyps
 
+let compare_subs_constraints
+    ~pre_conds:(pre_conds : Constr.t)
+    ~post_conds:(post_conds : Constr.t)
+  : comparator * comparator =
+  let postcond ~original:(_, env1) ~modified:(_, env2) ~rename_set:_ =
+    Constr.mk_clause [] [post_conds], env1, env2
+  in
+  let hyps ~original:(_, env1) ~modified:(_, env2) ~rename_set:_ =
+    Constr.mk_clause [] [pre_conds], env1, env2
+  in
+  postcond, hyps
+
+
 let compare_subs_fun : comparator * comparator =
   let mk_is_fun_called env f =
     let ctx = Env.get_context env in

--- a/wp/lib/bap_wp/src/compare.mli
+++ b/wp/lib/bap_wp/src/compare.mli
@@ -104,15 +104,15 @@ val compare_subs_empty_post : comparator * comparator
     creation time. *)
 val compare_subs_sp : comparator * comparator
 
-(** Compare two subs by composition for restraints on a pointer.:
+(** Compare two subs by composition for custom preconditions and postconditions.
 
     Give two subroutines and environments, return a postcondition
     and hypothesis that, when passed to [compare_subs], will generate a
     precondition which is provable only if (modulo soundness bugs) the VCs generated
-    by the hooks provided by the environment are satisfied, given that the
-    architecture of the binary is x86_64. The hypothesis comparator generates
-    hypotheses that are the precondition; the post condition comparator
-    generates postconditions based on the input Constr.t. *)
+    by the hooks provided by the environment are satisfied, given that the.
+    The hypothesis comparator generates hypotheses that are the input
+    [pre_conds] argument. The post condition comparator generates postconditions
+    that are the input [post_conds] argument. *)
 val compare_subs_constraints
   :  pre_conds:Constr.t
   -> post_conds:Constr.t

--- a/wp/lib/bap_wp/src/compare.mli
+++ b/wp/lib/bap_wp/src/compare.mli
@@ -104,15 +104,10 @@ val compare_subs_empty_post : comparator * comparator
     creation time. *)
 val compare_subs_sp : comparator * comparator
 
-(** Compare two subs by composition for custom preconditions and postconditions.
-
-    Give two subroutines and environments, return a postcondition
-    and hypothesis that, when passed to [compare_subs], will generate a
-    precondition which is provable only if (modulo soundness bugs) the VCs generated
-    by the hooks provided by the environment are satisfied, given that the.
-    The hypothesis comparator generates hypotheses that are the input
-    [pre_conds] argument. The post condition comparator generates postconditions
-    that are the input [post_conds] argument. *)
+(** Given a constraint to use as the hypothesis (precondition) and a constraint
+    to use as the postcondition, returns a tuple of comparators. The first
+    comparator returns the input postcondition constraint when called. The
+    second comparator returns the input precondition constraint when called. *)
 val compare_subs_constraints
   :  pre_conds:Constr.t
   -> post_conds:Constr.t

--- a/wp/lib/bap_wp/src/compare.mli
+++ b/wp/lib/bap_wp/src/compare.mli
@@ -104,6 +104,19 @@ val compare_subs_empty_post : comparator * comparator
     creation time. *)
 val compare_subs_sp : comparator * comparator
 
+(** Compare two subs by composition for restraints on a pointer.:
+
+    Give two subroutines and environments, return a postcondition
+    and hypothesis that, when passed to [compare_subs], will generate a
+    precondition which is provable only if (modulo soundness bugs) the VCs generated
+    by the hooks provided by the environment are satisfied, given that the
+    architecture of the binary is x86_64. The hypothesis comparator generates a
+    constraint which states whichever TODO *)
+val compare_subs_constraints
+  :  pre_conds:Constr.t
+  -> post_conds:Constr.t
+  -> comparator * comparator
+
 (** Compare two subroutines by composition for conservation of function calls:
 
     Given two subroutines and environments, return a postcondition

--- a/wp/lib/bap_wp/src/compare.mli
+++ b/wp/lib/bap_wp/src/compare.mli
@@ -110,8 +110,9 @@ val compare_subs_sp : comparator * comparator
     and hypothesis that, when passed to [compare_subs], will generate a
     precondition which is provable only if (modulo soundness bugs) the VCs generated
     by the hooks provided by the environment are satisfied, given that the
-    architecture of the binary is x86_64. The hypothesis comparator generates a
-    constraint which states whichever TODO *)
+    architecture of the binary is x86_64. The hypothesis comparator generates
+    hypotheses that are the precondition; the post condition comparator
+    generates postconditions based on the input Constr.t. *)
 val compare_subs_constraints
   :  pre_conds:Constr.t
   -> post_conds:Constr.t

--- a/wp/lib/bap_wp/src/environment.ml
+++ b/wp/lib/bap_wp/src/environment.ml
@@ -404,7 +404,7 @@ let get_consts (env : t) : ExprSet.t =
 let get_arch (env : t) : Arch.t =
   env.arch
 
-let get_rsp_name (env : t) : string =
+let get_sp_name (env : t) : string =
   let module Target = (val target_of_arch (get_arch env)) in
   Var.name Target.CPU.sp
 

--- a/wp/lib/bap_wp/src/environment.ml
+++ b/wp/lib/bap_wp/src/environment.ml
@@ -443,6 +443,9 @@ let in_stack (env : t) : Constr.z3_expr -> Constr.z3_expr =
     assert (BV.is_bv addr);
     Bool.mk_and ctx [BV.mk_ult ctx min addr; BV.mk_ule ctx addr max]
 
+let get_stack_bottom (env : t) : int =
+  env.stack.base_addr - env.stack.size
+
 (* Returns a function that takes in a memory address as a z3_expr and outputs a
    z3_expr that checks if that address is within the data section. *)
 let in_data_section (env : t) : Constr.z3_expr -> Constr.z3_expr =

--- a/wp/lib/bap_wp/src/environment.ml
+++ b/wp/lib/bap_wp/src/environment.ml
@@ -404,6 +404,10 @@ let get_consts (env : t) : ExprSet.t =
 let get_arch (env : t) : Arch.t =
   env.arch
 
+let get_rsp_name (env : t) : string =
+  let module Target = (val target_of_arch (get_arch env)) in
+  Var.name Target.CPU.sp
+
 let fold_fun_tids (env : t) ~init:(init : 'a)
     ~f:(f : key:string -> data:Tid.t -> 'a -> 'a) : 'a =
   StringMap.fold env.fun_name_tid ~init:init ~f:f
@@ -443,7 +447,7 @@ let in_stack (env : t) : Constr.z3_expr -> Constr.z3_expr =
     assert (BV.is_bv addr);
     Bool.mk_and ctx [BV.mk_ult ctx min addr; BV.mk_ule ctx addr max]
 
-let get_stack_bottom (env : t) : int =
+let get_stack_end (env : t) : int =
   env.stack.base_addr - env.stack.size
 
 (* Returns a function that takes in a memory address as a z3_expr and outputs a

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -251,6 +251,9 @@ val use_input_regs : t -> bool
     defined by the concrete range of the stack in the env. *)
 val in_stack : t -> Constr.z3_expr -> Constr.z3_expr
 
+(** [get_stack_bottom] retrieves the address of the bottom of the stack *)
+val get_stack_bottom : t -> int
+
 (** [in_data_section env addr] is the constraint [DATA_MIN <= addr < DATA_MAX] as
     defined by the concrete range of the data section in the env. *)
 val in_data_section : t -> Constr.z3_expr -> Constr.z3_expr

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -231,6 +231,9 @@ val get_loop_handler :
 (** Obtains the architecture of the program. *)
 val get_arch : t -> Bap.Std.Arch.t
 
+(** Obtains the name of the program's stack pointer *)
+val get_rsp_name : t -> string
+
 (** Obtains a list of all the {!Constr.z3_expr}s that represents constants that
     were generated during analysis. *)
 val get_consts : t -> ExprSet.t
@@ -251,8 +254,13 @@ val use_input_regs : t -> bool
     defined by the concrete range of the stack in the env. *)
 val in_stack : t -> Constr.z3_expr -> Constr.z3_expr
 
-(** [get_stack_bottom] retrieves the address of the bottom of the stack *)
-val get_stack_bottom : t -> int
+(** [get_stack_end] retrieves the address of the largest address that the top
+     of the stack can take. It is assumed the stack grows downwards, from
+     high addresss to low address. The top and start of the stack is defined as
+     stack_base and is the largest address in the stack. The stack end
+     (retrieved by this function) is the smallest value that the stack pointer
+     can take. *)
+val get_stack_end: t -> int
 
 (** [in_data_section env addr] is the constraint [DATA_MIN <= addr < DATA_MAX] as
     defined by the concrete range of the data section in the env. *)

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -232,7 +232,7 @@ val get_loop_handler :
 val get_arch : t -> Bap.Std.Arch.t
 
 (** Obtains the name of the program's stack pointer *)
-val get_rsp_name : t -> string
+val get_sp_name : t -> string
 
 (** Obtains a list of all the {!Constr.z3_expr}s that represents constants that
     were generated during analysis. *)

--- a/wp/lib/bap_wp/src/z3_utils.ml
+++ b/wp/lib/bap_wp/src/z3_utils.ml
@@ -111,8 +111,9 @@ let mk_smtlib2_single (env : Env.t) (smt_post : string) : Constr.t =
   let ctx = Env.get_context env in
   mk_smtlib2 ctx smt_post decl_syms
 
-let construct_pointer_constraint (l: string list) (stack_bottom: int)
-    (env1 : Env.t) (env2: Env.t option): Constr.t =
+let construct_pointer_constraint (l: string list) (env1 : Env.t)
+    (env2: Env.t option): Constr.t =
+  let stack_bottom = Env.get_stack_bottom env1 in
   let ctx = Env.get_context env1 in
   let arch = match Env.get_arch env1 |> Bap.Std.Arch.addr_size with
     | `r32 -> 32

--- a/wp/lib/bap_wp/src/z3_utils.ml
+++ b/wp/lib/bap_wp/src/z3_utils.ml
@@ -126,17 +126,17 @@ let construct_pointer_constraint (l: string list) (env1 : Env.t)
     | Some env2 ->
       let init_var_map_orig = Env.get_init_var_map env1 in
       let init_var_map_mod = Env.get_init_var_map env2 in
-      let rsp_orig = Option.value_exn ~message:"original " ^ err_msg_rsp
-                       (get_z3_name init_var_map_orig rsp Var.name) in
-      let rsp_mod = Option.value_exn ~message:"modified " ^ err_msg_rsp
-                      (get_z3_name init_var_map_mod rsp Var.name) in
+      let rsp_orig = Option.value_exn ~message:("original " ^ err_msg_rsp)
+          (get_z3_name init_var_map_orig rsp Var.name) in
+      let rsp_mod = Option.value_exn ~message:("modified " ^ err_msg_rsp)
+          (get_z3_name init_var_map_mod rsp Var.name) in
       (* Encode constraint for each register and wrap them up in a massive and *)
       (fun acc reg ->
          (* we do want exceptions here if the register names are invalid
           *  or RSP doesn't exist *)
-         let reg_name_orig = Option.value_exn ~message:err_msg
+         let reg_name_orig = Option.value_exn ~message:err_msg_input
              (get_z3_name init_var_map_orig reg Var.name) in
-         let reg_name_mod = Option.value_exn ~message:err_msg
+         let reg_name_mod = Option.value_exn ~message:err_msg_input
              (get_z3_name init_var_map_mod reg Var.name) in
          (* the pointer register must be above RSP
           *  NOTE: we are assuming stack grows down *)
@@ -153,10 +153,10 @@ let construct_pointer_constraint (l: string list) (env1 : Env.t)
       )
     | None ->
       let init_var_map = Env.get_init_var_map env1 in
-      let stack_pointer = Option.value_exn ~message:"stack pointer not found"
+      let stack_pointer = Option.value_exn ~message:err_msg_rsp
           (get_z3_name init_var_map rsp Var.name) in
       (fun acc reg ->
-         let reg_name = Option.value_exn ~message:err_msg
+         let reg_name = Option.value_exn ~message:err_msg_input
              (get_z3_name init_var_map reg Var.name)in
          let uge = Z3.BitVector.mk_ugt ctx reg_name stack_pointer in
          let ule = Z3.BitVector.mk_ult ctx reg_name sb_bv in

--- a/wp/lib/bap_wp/src/z3_utils.ml
+++ b/wp/lib/bap_wp/src/z3_utils.ml
@@ -112,25 +112,27 @@ let mk_smtlib2_single (env : Env.t) (smt_post : string) : Constr.t =
   mk_smtlib2 ctx smt_post decl_syms
 
 let construct_pointer_constraint (l: string list) (env1 : Env.t)
-    (env2: Env.t option): Constr.t =
+    (env2: Env.t option) : Constr.t =
   let stack_end = Env.get_stack_end env1 in
   let ctx = Env.get_context env1 in
   let arch = match Env.get_arch env1 |> Bap.Std.Arch.addr_size with
     | `r32 -> 32
     | `r64 -> 64 in
-  let rsp = Env.get_rsp_name env1 in
+  let rsp = Env.get_sp_name env1 in
+  let function_name = "construct_pointer_constraint" in
   let err_msg_input = "invalid register name in pointer register list" in
   let err_msg_rsp = "stack pointer not found" in
   let sb_bv = Z3.BitVector.mk_numeral ctx (stack_end |> Int.to_string) arch in
   let gen_constr = match env2 with
+    (* comparative case *)
     | Some env2 ->
       let init_var_map_orig = Env.get_init_var_map env1 in
       let init_var_map_mod = Env.get_init_var_map env2 in
       (* we do want exceptions here if the register names are invalid
        *  or RSP doesn't exist *)
-      let rsp_orig = Option.value_exn ~message:("original " ^ err_msg_rsp)
+      let rsp_orig = Option.value_exn ~message:(function_name ^ ": original " ^ err_msg_rsp)
           (get_z3_name init_var_map_orig rsp Var.name) in
-      let rsp_mod = Option.value_exn ~message:("modified " ^ err_msg_rsp)
+      let rsp_mod = Option.value_exn ~message:(function_name ^ ": modified " ^ err_msg_rsp)
           (get_z3_name init_var_map_mod rsp Var.name) in
       (* Encode constraint that each register is not within stack*)
       (fun acc reg ->
@@ -138,20 +140,25 @@ let construct_pointer_constraint (l: string list) (env1 : Env.t)
              (get_z3_name init_var_map_orig reg Var.name) in
          let reg_name_mod = Option.value_exn ~message:err_msg_input
              (get_z3_name init_var_map_mod reg Var.name) in
-         (* the pointer register must be above RSP
-          *  NOTE: we are assuming stack grows down *)
+         (* NOTE: we are assuming stack grows down.*)
+         (* R_orig >= RSP_orig *)
          let uge_1 = Z3.BitVector.mk_uge ctx reg_name_orig rsp_orig in
+         (* R_mod >= RSP_mod *)
          let uge_2 = Z3.BitVector.mk_uge ctx reg_name_mod rsp_mod in
-         (* the pointer must be below the end of the stack *)
+         (*  R_orig <= stack_bottom *)
          let ule_1 =  Z3.BitVector.mk_ule ctx reg_name_orig sb_bv in
+         (* R_mod <= stack_bottom *)
          let ule_2 =  Z3.BitVector.mk_ule ctx reg_name_mod sb_bv in
-         (* encode that the pointer is either above RSP or below the stack
-          *  end and thereby outside the uninitialized stack region *)
+         (* R_orig >= RSP \/ R_orig <= stack_bottom *)
          let or_c_1 = Z3.Boolean.mk_or ctx [uge_1; ule_1] in
+         (* R_mod >= RSP \/ R_mod <= stack_bottom *)
          let or_c_2 = Z3.Boolean.mk_or ctx [uge_2; ule_2] in
+         (* (R_orig >= RSP \/ R_orig <= stack_bottom) /\
+            (R_mod >= RSP \/ R_mod <= stack_bottom)     *)
          let and_c = Z3.Boolean.mk_and ctx [or_c_1; or_c_2;] in
          Z3.Boolean.mk_and ctx [and_c; acc]
       )
+    (* single binary case *)
     | None ->
       let init_var_map = Env.get_init_var_map env1 in
       let stack_pointer = Option.value_exn ~message:err_msg_rsp

--- a/wp/lib/bap_wp/src/z3_utils.mli
+++ b/wp/lib/bap_wp/src/z3_utils.mli
@@ -32,7 +32,7 @@ val build_str : string list -> string
     [fmt] is used to add prefixes and suffixes to a variable name. For example,
     init_RDI_orig. *)
 val get_z3_name :
-  Constr.z3_expr Bap.Std.Var.Map.t -> string -> (Bap.Std.Var.t -> string) -> string option
+  Constr.z3_expr Bap.Std.Var.Map.t -> string -> (Bap.Std.Var.t -> string) -> (Z3.Expr.expr option)
 
 (** [get_decls_and_symbols] builds from a the var_map in an environment
     a mapping of all Z3 func_decl to their symbol. This is a helper function for
@@ -50,5 +50,11 @@ val mk_smtlib2_single : Env.t -> string -> Constr.t
     to symbols and returns a constraint [Constr.t] corresponding to the smtlib2 string.
     The [func_decl * symbol] mapping can be constructed from an [Env.t] using the
     [get_decls_and_symbols] function. *)
-
 val mk_smtlib2 : Z3.context -> string -> ((Z3.FuncDecl.func_decl * Z3.Symbol.symbol) list)  -> Constr.t
+
+(** [construct_pointer_constraint] generates a precondition that asserts that
+    the register names provided in `l` are treated as pointers. That means
+    all of these registers cannot point to the uninitalized stack region. This
+    means, they must be either below the bottom of the stack or above the initial
+    stack pointer. *)
+val construct_pointer_constraint : string list -> int -> Z3.context -> Env.t -> Env.t option -> string

--- a/wp/lib/bap_wp/src/z3_utils.mli
+++ b/wp/lib/bap_wp/src/z3_utils.mli
@@ -52,9 +52,9 @@ val mk_smtlib2_single : Env.t -> string -> Constr.t
     [get_decls_and_symbols] function. *)
 val mk_smtlib2 : Z3.context -> string -> ((Z3.FuncDecl.func_decl * Z3.Symbol.symbol) list)  -> Constr.t
 
-(** [construct_pointer_constraint] generates a precondition that asserts that
+(** [construct_pointer_constraint] generates a constraint that
     the register names provided in `l` are treated as pointers. That means
-    all of these registers cannot point to the uninitalized stack region. This
-    means, they must be either below the bottom of the stack or above the initial
+    all of these registers cannot point to the uninitalized stack region. That
+    is, they must be either below the bottom of the stack or above the initial
     stack pointer. *)
-val construct_pointer_constraint : string list -> int -> Z3.context -> Env.t -> Env.t option -> string
+val construct_pointer_constraint : string list -> int -> Env.t -> Env.t option -> Constr.t

--- a/wp/lib/bap_wp/src/z3_utils.mli
+++ b/wp/lib/bap_wp/src/z3_utils.mli
@@ -57,4 +57,4 @@ val mk_smtlib2 : Z3.context -> string -> ((Z3.FuncDecl.func_decl * Z3.Symbol.sym
     all of these registers cannot point to the uninitalized stack region. That
     is, they must be either below the bottom of the stack or above the initial
     stack pointer. *)
-val construct_pointer_constraint : string list -> int -> Env.t -> Env.t option -> Constr.t
+val construct_pointer_constraint : string list -> Env.t -> Env.t option -> Constr.t

--- a/wp/lib/bap_wp/src/z3_utils.mli
+++ b/wp/lib/bap_wp/src/z3_utils.mli
@@ -53,8 +53,8 @@ val mk_smtlib2_single : Env.t -> string -> Constr.t
 val mk_smtlib2 : Z3.context -> string -> ((Z3.FuncDecl.func_decl * Z3.Symbol.symbol) list)  -> Constr.t
 
 (** [construct_pointer_constraint] generates a constraint that
-    the register names provided in `l` are treated as pointers. That means
-    all of these registers cannot point to the uninitalized stack region. That
-    is, they must be either below the bottom of the stack or above the initial
+    the register names provided in [l] are treated as pointers. That is,
+    all registers in [l] cannot point to the uninitalized stack region.
+    They must be either below the bottom of the stack or above the initial
     stack pointer. *)
 val construct_pointer_constraint : string list -> Env.t -> Env.t option -> Constr.t

--- a/wp/lib/bap_wp/src/z3_utils.mli
+++ b/wp/lib/bap_wp/src/z3_utils.mli
@@ -32,7 +32,7 @@ val build_str : string list -> string
     [fmt] is used to add prefixes and suffixes to a variable name. For example,
     init_RDI_orig. *)
 val get_z3_name :
-  Constr.z3_expr Bap.Std.Var.Map.t -> string -> (Bap.Std.Var.t -> string) -> (Z3.Expr.expr option)
+  Constr.z3_expr Bap.Std.Var.Map.t -> string -> (Bap.Std.Var.t -> string) -> (Constr.z3_expr option)
 
 (** [get_decls_and_symbols] builds from a the var_map in an environment
     a mapping of all Z3 func_decl to their symbol. This is a helper function for

--- a/wp/plugin/lib/analysis.ml
+++ b/wp/plugin/lib/analysis.ml
@@ -185,7 +185,12 @@ let single (bap_ctx : ctxt) (z3_ctx : Z3.context) (var_gen : Env.var_gen)
       Z3_utils.mk_smtlib2_single env p.postcond
   in
   let pre, env = Pre.visit_sub env post main_sub in
-  let pre = Constr.mk_clause [Z3_utils.mk_smtlib2_single env p.precond] [pre] in
+  let precond_from_flag = Z3_utils.mk_smtlib2_single env p.precond in
+  let stack_bottom = Env.get_stack_bottom env in
+  let pointer_constr = Z3_utils.mk_smtlib2_single env
+      (Z3_utils.construct_pointer_constraint p.pointer_reg_list
+         stack_bottom z3_ctx env None) in
+  let pre = Constr.mk_clause [precond_from_flag; pointer_constr;] [pre] in
   let pre = Constr.mk_clause hyps [pre] in
   if List.mem p.show "bir" ~equal:String.equal then
     Printf.printf "\nSub:\n%s\n%!" (Sub.to_string main_sub);

--- a/wp/plugin/lib/analysis.ml
+++ b/wp/plugin/lib/analysis.ml
@@ -187,9 +187,8 @@ let single (bap_ctx : ctxt) (z3_ctx : Z3.context) (var_gen : Env.var_gen)
   let pre, env = Pre.visit_sub env post main_sub in
   let precond_from_flag = Z3_utils.mk_smtlib2_single env p.precond in
   let stack_bottom = Env.get_stack_bottom env in
-  let pointer_constr = Z3_utils.mk_smtlib2_single env
-      (Z3_utils.construct_pointer_constraint p.pointer_reg_list
-         stack_bottom z3_ctx env None) in
+  let pointer_constr = Z3_utils.construct_pointer_constraint p.pointer_reg_list
+      stack_bottom env None in
   let pre = Constr.mk_clause [precond_from_flag; pointer_constr;] [pre] in
   let pre = Constr.mk_clause hyps [pre] in
   if List.mem p.show "bir" ~equal:String.equal then

--- a/wp/plugin/lib/analysis.ml
+++ b/wp/plugin/lib/analysis.ml
@@ -138,8 +138,10 @@ let sp (arch : Arch.t) : (Comp.comparator * Comp.comparator) option =
            memory for the x86_64 architecture.\n%!";
     None
 
-(* TODO document *)
-let gen_pointer_comparators
+
+(* Returns a set of comparators that provide the constraint that
+   the pointer registers are treated as pointers. *)
+let gen_pointer_flag_comparators
     (l: string list) (env1: Env.t) (env2: Env.t option)
   : (Comp.comparator * Comp.comparator) option =
   if List.length l = 0 then None
@@ -163,7 +165,7 @@ let comparators_of_flags
       ~orig:(sub1, env1) ~modif:(sub2, env2);
     smtlib ~precond:p.precond ~postcond:p.postcond;
     sp arch;
-    gen_pointer_comparators p.pointer_reg_list env1 (Some env2);
+    gen_pointer_flag_comparators p.pointer_reg_list env1 (Some env2);
   ] |> List.filter_opt
   in
   let comps =

--- a/wp/plugin/lib/parameters.ml
+++ b/wp/plugin/lib/parameters.ml
@@ -50,8 +50,6 @@ type t = {
   show : string list
 }
 
-(* TODO add in validate pointer_reg_list *)
-
 (* Ensures the user inputted a function for analysis. *)
 let validate_func (func : string) : (unit, error) result =
   let err = Printf.sprintf "Function is not provided for analysis. Usage: \

--- a/wp/plugin/lib/parameters.ml
+++ b/wp/plugin/lib/parameters.ml
@@ -37,6 +37,7 @@ type t = {
   check_null_derefs : bool;
   compare_func_calls : bool;
   compare_post_reg_values : string list;
+  pointer_reg_list : string list;
   inline : string option;
   num_unroll : int option;
   gdb_output : string option;
@@ -48,6 +49,8 @@ type t = {
   stack_size : int option;
   show : string list
 }
+
+(* TODO add in validate pointer_reg_list *)
 
 (* Ensures the user inputted a function for analysis. *)
 let validate_func (func : string) : (unit, error) result =

--- a/wp/plugin/lib/parameters.mli
+++ b/wp/plugin/lib/parameters.mli
@@ -40,6 +40,7 @@ type t = {
   check_null_derefs : bool;
   compare_func_calls : bool;
   compare_post_reg_values : string list;
+  pointer_reg_list : string list;
   inline : string option;
   num_unroll : int option;
   gdb_output : string option;

--- a/wp/plugin/tests/test_wp.ml
+++ b/wp/plugin/tests/test_wp.ml
@@ -216,6 +216,9 @@ let suite = [
   "Indirect call with return"      >: test_plugin "indirect_call_return" unsat;
   "Indirect call with no return"   >: test_plugin "indirect_call_no_return" unsat;
 
+  "Test without pointer flag"      >: test_plugin "pointer_flag" sat ~script:"run_wp_sat.sh";
+  "Test with pointer flag"         >: test_plugin "pointer_flag" unsat ~script:"run_wp_unsat.sh";
+
   (* Test single elf *)
 
   "Function call"                  >: test_plugin "function_call" sat ~script:"run_wp_inline_foo.sh"

--- a/wp/plugin/tests/test_wp.ml
+++ b/wp/plugin/tests/test_wp.ml
@@ -261,6 +261,10 @@ let suite = [
     ~expected_regs:[ [("RDI", "0x0000000000000003")]; ];
   "Simple WP: precondition"        >: test_plugin "simple_wp" unsat ~script:"run_wp_pre.sh";
 
+  "Single test without pointer flag" >: test_plugin "pointer_flag_single" sat ~script:"run_wp_sat.sh";
+  "Single test with pointer flag"    >: test_plugin "pointer_flag_single" unsat ~script:"run_wp_unsat.sh";
+
+
   "Verifier assume SAT"            >: test_plugin "verifier_calls" sat ~script:"run_wp_assume_sat.sh";
   "Verifier assume UNSAT"          >: test_plugin "verifier_calls" unsat ~script:"run_wp_assume_unsat.sh";
   "Verifier nondent"               >: test_plugin "verifier_calls" sat ~script:"run_wp_nondet.sh";

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -82,8 +82,12 @@ let compare_post_reg_values = Cmd.parameter Typ.(list string) "compare-post-reg-
            output in RAX, and ARM architectures place their output in R0.|}
 
 let pointer_reg_list = Cmd.parameter Typ.(list string) "pointer-reg-list"
-    ~doc:"flag that contains a list of input registers to be treated as \
-          pointers at the start of program execution."
+    ~doc:"{|This flag specifies a comma delimited list of input registers to be
+          treated as pointers at the start of program execution. This means
+          that these registers are restricted in value to point to memory
+          known to be initialized at the start of the function. For example,
+          `RSI,RDI` would specify that `RSI` and `RDI`'s values should be
+          restricted to initialized memory at the start of execution.|}"
 
 (* Options. *)
 

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -81,6 +81,10 @@ let compare_post_reg_values = Cmd.parameter Typ.(list string) "compare-post-reg-
            check the architecture's ABI. x86_64 architectures place their
            output in RAX, and ARM architectures place their output in R0.|}
 
+let pointer_reg_list = Cmd.parameter Typ.(list string) "pointer-reg-list"
+    ~doc:"flag that contains a list of input registers to be treated as \
+          pointers at the start of program execution."
+
 (* Options. *)
 
 let inline = Cmd.parameter Typ.(some string) "inline"
@@ -174,24 +178,25 @@ let stack_size = Cmd.parameter Typ.(some int) "stack-size"
 
 let grammar = Cmd.(
     args
-      $ func
-      $ precond
-      $ postcond
-      $ trip_asserts
-      $ check_null_derefs
-      $ compare_func_calls
-      $ compare_post_reg_values
-      $ inline
-      $ num_unroll
-      $ gdb_output
-      $ bildb_output
-      $ use_fun_input_regs
-      $ mem_offset
-      $ debug
-      $ show
-      $ stack_base
-      $ stack_size
-      $ files)
+    $ func
+    $ precond
+    $ postcond
+    $ trip_asserts
+    $ check_null_derefs
+    $ compare_func_calls
+    $ compare_post_reg_values
+    $ pointer_reg_list
+    $ inline
+    $ num_unroll
+    $ gdb_output
+    $ bildb_output
+    $ use_fun_input_regs
+    $ mem_offset
+    $ debug
+    $ show
+    $ stack_base
+    $ stack_size
+    $ files)
 
 (* The callback run when the command is invoked from the command line. *)
 let callback
@@ -202,6 +207,7 @@ let callback
     (check_null_derefs : bool)
     (compare_func_calls : bool)
     (compare_post_reg_values : string list)
+    (pointer_reg_list : string list)
     (inline : string option)
     (num_unroll : int option)
     (gdb_output : string option)
@@ -222,6 +228,7 @@ let callback
       check_null_derefs = check_null_derefs;
       compare_func_calls = compare_func_calls;
       compare_post_reg_values = compare_post_reg_values;
+      pointer_reg_list = pointer_reg_list;
       inline = inline;
       num_unroll = num_unroll;
       gdb_output = gdb_output;

--- a/wp/resources/sample_binaries/pointer_flag/Makefile
+++ b/wp/resources/sample_binaries/pointer_flag/Makefile
@@ -2,10 +2,10 @@ BASE=main
 PROG_1=$(BASE)_1
 PROG_2=$(BASE)_2
 
-all: $(PROG1) $(PROG_2)
+all: $(PROG_1) $(PROG_2)
 
 %: %.c
 	$(CC) -Wall -g -o $@ $<
 
 clean:
-	rm -f $(PROG1)
+	rm -f $(PROG_1) $(PROG_2)

--- a/wp/resources/sample_binaries/pointer_flag/Makefile
+++ b/wp/resources/sample_binaries/pointer_flag/Makefile
@@ -1,11 +1,11 @@
 BASE=main
-PROG1=$(BASE)_1
-PROG2=$(BASE)_2
+PROG_1=$(BASE)_1
+PROG_2=$(BASE)_2
 
-all: $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj
+all: $(PROG1) $(PROG_2)
 
 %: %.c
 	$(CC) -Wall -g -o $@ $<
 
 clean:
-	rm -f $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj
+	rm -f $(PROG1)

--- a/wp/resources/sample_binaries/pointer_flag/Makefile
+++ b/wp/resources/sample_binaries/pointer_flag/Makefile
@@ -1,0 +1,11 @@
+BASE=main
+PROG1=$(BASE)_1
+PROG2=$(BASE)_2
+
+all: $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj
+
+%: %.c
+	$(CC) -Wall -g -o $@ $<
+
+clean:
+	rm -f $(PROG1) $(PROG1).bpj $(PROG2) $(PROG2).bpj

--- a/wp/resources/sample_binaries/pointer_flag/main_1.c
+++ b/wp/resources/sample_binaries/pointer_flag/main_1.c
@@ -1,10 +1,6 @@
-int f(){
-    return 1;
-}
-// Type your code here, or load an example.
-int deref(int *num1) {
-    int num2 = f();
-    if(*num1 >= num2){
+int deref(int *num_1) {
+    int num_2 = 12;
+    if(*num_1 > num_2){
         return -1;
     }
     return 0;

--- a/wp/resources/sample_binaries/pointer_flag/main_1.c
+++ b/wp/resources/sample_binaries/pointer_flag/main_1.c
@@ -1,0 +1,15 @@
+int f(){
+    return 1;
+}
+// Type your code here, or load an example.
+int deref(int *num1) {
+    int num2 = f();
+    if(*num1 >= num2){
+        return -1;
+    }
+    return 0;
+}
+
+int main(int argc, char** argv){
+        return 0;
+}

--- a/wp/resources/sample_binaries/pointer_flag/main_2.c
+++ b/wp/resources/sample_binaries/pointer_flag/main_2.c
@@ -1,0 +1,20 @@
+int f(){
+    return 1;
+}
+
+int g() {
+    return 10;
+}
+
+// Type your code here, or load an example.
+int deref(int *num1) {
+    int num2 = f();
+    if(*num1 >= num2){
+        return -1;
+    }
+    return 0;
+}
+
+int main(int argc, char** argv){
+        return 0;
+}

--- a/wp/resources/sample_binaries/pointer_flag/main_2.c
+++ b/wp/resources/sample_binaries/pointer_flag/main_2.c
@@ -1,15 +1,7 @@
-int f(){
-    return 1;
-}
-
-int g() {
-    return 10;
-}
-
-// Type your code here, or load an example.
-int deref(int *num1) {
-    int num2 = f();
-    if(*num1 >= num2){
+int deref(int *num_1) {
+    int num_2 = 12;
+    int local = 42;
+    if(*num_1 > num_2){
         return -1;
     }
     return 0;

--- a/wp/resources/sample_binaries/pointer_flag/run_wp_sat.sh
+++ b/wp/resources/sample_binaries/pointer_flag/run_wp_sat.sh
@@ -1,0 +1,19 @@
+# This is a test that tests that the wp-pointer-reg-list flag works as expected
+# specifically, it calls a function, then tries to use the differing return address that 
+# is thereby pushed onto the stack to cause a different return value between functions.
+# Should return SAT
+
+set -x
+
+run_sat () {
+  bap wp \
+          --func=deref \
+          --num-unroll=0 \
+          --no-byteweight \
+          --mem-offset \
+          --show=bir,refuted-goals,paths \
+          --compare-post-reg-values=R12,R13,R14,R15,RBX,RSP,RBP,RAX \
+          -- main_1 main_2
+  }
+
+run_sat

--- a/wp/resources/sample_binaries/pointer_flag/run_wp_sat.sh
+++ b/wp/resources/sample_binaries/pointer_flag/run_wp_sat.sh
@@ -1,9 +1,8 @@
-# This is a test that tests that the wp-pointer-reg-list flag works as expected.
-# Specifically, the function foo tries to use differing
-# return addresses that are pushed onto the stack to cause a different return
-# value between functions. The abscence of the flag should allow the pointer
-# argument in RDI to be used to point to this return address, as it lives
-# on the uninitialized portion of the stack at the start of the function.
+# This tests that the absence wp-pointer-reg-list flag works as expected.
+# Specifically, differing return value should be found between programs because
+# in main_1, num_1 cannot be greater than 12. In main_2, num1 can point to local
+# and become 42, which is greater than 12. This results in main_1 returning 
+# 0 and main_2 returning -1.
 
 # Should return SAT
 
@@ -17,6 +16,7 @@ run_sat () {
     --mem-offset \
     --show=bir,refuted-goals,paths \
     --compare-post-reg-values=R12,R13,R14,R15,RBX,RSP,RBP,RAX \
+    --precond="(assert (= mem_orig mem_mod))" \
     -- main_1 main_2
 }
 

--- a/wp/resources/sample_binaries/pointer_flag/run_wp_sat.sh
+++ b/wp/resources/sample_binaries/pointer_flag/run_wp_sat.sh
@@ -4,20 +4,20 @@
 # value between functions. The abscence of the flag should allow the pointer
 # argument in RDI to be used to point to this return address, as it lives
 # on the uninitialized portion of the stack at the start of the function.
- 
+
 # Should return SAT
 
 set -x
 
 run_sat () {
   bap wp \
-          --func=deref \
-          --num-unroll=0 \
-          --no-byteweight \
-          --mem-offset \
-          --show=bir,refuted-goals,paths \
-          --compare-post-reg-values=R12,R13,R14,R15,RBX,RSP,RBP,RAX \
-          -- main_1 main_2
-  }
+    --func=deref \
+    --num-unroll=0 \
+    --no-byteweight \
+    --mem-offset \
+    --show=bir,refuted-goals,paths \
+    --compare-post-reg-values=R12,R13,R14,R15,RBX,RSP,RBP,RAX \
+    -- main_1 main_2
+}
 
 run_sat

--- a/wp/resources/sample_binaries/pointer_flag/run_wp_sat.sh
+++ b/wp/resources/sample_binaries/pointer_flag/run_wp_sat.sh
@@ -1,6 +1,10 @@
-# This is a test that tests that the wp-pointer-reg-list flag works as expected
-# specifically, it calls a function, then tries to use the differing return address that 
-# is thereby pushed onto the stack to cause a different return value between functions.
+# This is a test that tests that the wp-pointer-reg-list flag works as expected.
+# Specifically, the function foo tries to use differing
+# return addresses that are pushed onto the stack to cause a different return
+# value between functions. The abscence of the flag should allow the pointer
+# argument in RDI to be used to point to this return address, as it lives
+# on the uninitialized portion of the stack at the start of the function.
+ 
 # Should return SAT
 
 set -x

--- a/wp/resources/sample_binaries/pointer_flag/run_wp_unsat.sh
+++ b/wp/resources/sample_binaries/pointer_flag/run_wp_unsat.sh
@@ -1,0 +1,24 @@
+# This is a test that tests that the wp-pointer-reg-list flag works as expected
+# specifically, it calls a function, then tries to use the differing return address that 
+# is thereby pushed onto the stack to cause a different return value between functions.
+# Should return SAT
+
+# Should return UNSAT
+
+set -x
+
+run_unsat () {
+  bap wp \
+          --func=deref \
+          --num-unroll=0 \
+          --no-byteweight \
+          --mem-offset \
+          --show=bir,refuted-goals,paths \
+          --compare-post-reg-values=R12,R13,R14,R15,RBX,RSP,RBP,RAX \
+          --pointer-reg-list=RDI \
+          -- main_1 main_2
+
+  
+  }
+
+run_unsat

--- a/wp/resources/sample_binaries/pointer_flag/run_wp_unsat.sh
+++ b/wp/resources/sample_binaries/pointer_flag/run_wp_unsat.sh
@@ -11,16 +11,14 @@ set -x
 
 run_unsat () {
   bap wp \
-          --func=deref \
-          --num-unroll=0 \
-          --no-byteweight \
-          --mem-offset \
-          --show=bir,refuted-goals,paths \
-          --compare-post-reg-values=R12,R13,R14,R15,RBX,RSP,RBP,RAX \
-          --pointer-reg-list=RDI \
-          -- main_1 main_2
-
-  
-  }
+    --func=deref \
+    --num-unroll=0 \
+    --no-byteweight \
+    --mem-offset \
+    --show=bir,refuted-goals,paths \
+    --compare-post-reg-values=R12,R13,R14,R15,RBX,RSP,RBP,RAX \
+    --pointer-reg-list=RDI \
+    -- main_1 main_2
+}
 
 run_unsat

--- a/wp/resources/sample_binaries/pointer_flag/run_wp_unsat.sh
+++ b/wp/resources/sample_binaries/pointer_flag/run_wp_unsat.sh
@@ -1,7 +1,9 @@
-# This is a test that tests that the wp-pointer-reg-list flag works as expected
-# specifically, it calls a function, then tries to use the differing return address that 
-# is thereby pushed onto the stack to cause a different return value between functions.
-# Should return SAT
+# This is a test that tests that the wp-pointer-reg-list flag works as expected.
+# Specifically, the function foo tries to use differing
+# return addresses that are pushed onto the stack to cause a different return
+# value between functions. The inclusion of the flag should prevent the pointer
+# argument in RDI from being used to point to this return address, as it lives
+# on the uninitialized portion of the stack at the start of the function.
 
 # Should return UNSAT
 

--- a/wp/resources/sample_binaries/pointer_flag/run_wp_unsat.sh
+++ b/wp/resources/sample_binaries/pointer_flag/run_wp_unsat.sh
@@ -1,10 +1,7 @@
-# This is a test that tests that the wp-pointer-reg-list flag works as expected.
-# Specifically, the function foo tries to use differing
-# return addresses that are pushed onto the stack to cause a different return
-# value between functions. The inclusion of the flag should prevent the pointer
-# argument in RDI from being used to point to this return address, as it lives
-# on the uninitialized portion of the stack at the start of the function.
-
+# This tests that the wp-pointer-reg-list flag works as expected.
+# Specifically, when num_1 is treated as a pointer, it cannot point to local,
+# as local is uninitialized at the start of the function.
+ 
 # Should return UNSAT
 
 set -x
@@ -18,6 +15,7 @@ run_unsat () {
     --show=bir,refuted-goals,paths \
     --compare-post-reg-values=R12,R13,R14,R15,RBX,RSP,RBP,RAX \
     --pointer-reg-list=RDI \
+    --precond="(assert (= mem_orig mem_mod))" \
     -- main_1 main_2
 }
 

--- a/wp/resources/sample_binaries/pointer_flag_single/Makefile
+++ b/wp/resources/sample_binaries/pointer_flag_single/Makefile
@@ -7,9 +7,5 @@ x86-64: $(BASE)
 $(BASE): $(BASE).c
 	gcc -O0 -g -Wall -o $(BASE) $(BASE).c
 
-$(BASE).s : $(BASE).c
-	gcc -O0 -S -o $(BASE).s $(BASE).c
-
-
 clean:
 	rm -f $(BASE)

--- a/wp/resources/sample_binaries/pointer_flag_single/Makefile
+++ b/wp/resources/sample_binaries/pointer_flag_single/Makefile
@@ -1,0 +1,15 @@
+BASE=main
+
+all: x86-64
+
+x86-64: $(BASE)
+
+$(BASE): $(BASE).c
+	gcc -O0 -g -Wall -o $(BASE) $(BASE).c
+
+$(BASE).s : $(BASE).c
+	gcc -O0 -S -o $(BASE).s $(BASE).c
+
+
+clean:
+	rm -f $(BASE)

--- a/wp/resources/sample_binaries/pointer_flag_single/main.c
+++ b/wp/resources/sample_binaries/pointer_flag_single/main.c
@@ -1,0 +1,10 @@
+int foo(int * x){
+    int y = 3;
+    *x = 0xdeadbeef;
+    return y;
+}
+
+int main(int argc, char* argv[])
+{
+    return 0;
+}

--- a/wp/resources/sample_binaries/pointer_flag_single/run_wp_sat.sh
+++ b/wp/resources/sample_binaries/pointer_flag_single/run_wp_sat.sh
@@ -1,0 +1,16 @@
+# This tests the single binary case of the --wp-poitner-reg-list flag. In this
+# case, we ensure that the program cannot take input that points to an
+# uninitialized region on the stack. Without the flag, this is possible.
+
+# Should return SAT
+
+set -x
+
+run () {
+  bap wp \
+    --func=foo \
+    --postcond="(assert (not (= RAX #x00000000deadbeef)))" \
+    -- main
+}
+
+run

--- a/wp/resources/sample_binaries/pointer_flag_single/run_wp_unsat.sh
+++ b/wp/resources/sample_binaries/pointer_flag_single/run_wp_unsat.sh
@@ -1,0 +1,18 @@
+# This tests the single binary case of the --wp-pointer-reg-list flag. In this
+# case, we ensure that the program cannot take input that points to an
+# uninitialized region on the stack. With the flag, this is not possible.
+
+# Should return UNSAT
+
+set -x
+
+run () {
+  bap wp \
+    --func=foo \
+    --postcond="(assert (not (= RAX #x00000000deadbeef)))" \
+    --pointer-reg-list=RDI  \
+    -- main
+
+}
+
+run


### PR DESCRIPTION
This PR introduces a flag, `--wp-pointer-reg-list` and closes the second half of #216 . The purpose of this flag is to, at the start of a function, mark registers as pointers. These specially marked registers are then used to generate a precondition that restricts their value to anywhere that is not uninitialized stack. That is to say, these "pointer" register values are either above the initial value of `RSP` or below the bottom of the stack. A sample invocation is included with the example, [here](https://github.com/DieracDelta/cbat_tools/blob/jrestivo/precond_flag/wp/resources/sample_binaries/pointer_flag/run_wp_unsat.sh).

I've tested this on the grammatech examples from #213 , and the simple toy example included in this commit.
- The toy example: CBAT is unable to use differing return addresses to obtain differing return values with the flag (the inspiration for this PR), but comes back SAT without the flag.
- `is_dumpdir` remains SAT when `RDI` is marked as a pointer. This is because in execution, there are accesses at an offset, which result in `wp` choosing a particular `RSP` such that `RDI + $OFFSET == pushed return address`.
- `safe_hasher` and `mb_copy` suffer from the same issue as `is_dumpdir`, though they're more subtle.

Note that I've only included a test for the comparative case (and double checked that the single analysis case doesn't break things). It's not obvious to me how to obtain different results (SAT vs UNSAT) with and without this flag in a single binary analysis.

