### PR TITLE
revamp makefiles

### DIFF
--- a/wp/Makefile
+++ b/wp/Makefile
@@ -5,7 +5,7 @@ SAMPLE_BINS := resources/sample_binaries
 
 .PHONY: test.integration test.lib test.plugin
 
-install: build.lib uninstall.plugin uninstall.lib install.lib build.plugin install.plugin
+install: uninstall.plugin install.lib build.plugin install.plugin
 
 uninstall.lib:
 	@printf "\n\u001b[31mUNINSTALLING LIB\u001b[0m\n"
@@ -22,7 +22,7 @@ build.lib:
 	$(MAKE) -C $(LIB) $*
 
 build.plugin: install.lib
-	$(MAKE) -C $(PLUGIN) $*
+	$(MAKE) -C $(PLUGIN) build
 
 doc:
 	$(MAKE) -C $(LIB) $@
@@ -50,4 +50,7 @@ install.plugin:
 
 # lib must be installed BEFORE building plugin
 install.lib:
+	$(MAKE) -C $(LIB) install
+
+reinstall.lib:
 	$(MAKE) -C $(LIB) $*

--- a/wp/Makefile
+++ b/wp/Makefile
@@ -4,7 +4,7 @@ PLUGIN := plugin
 SAMPLE_BINS := resources/sample_binaries
 FMT_STR := "\u001b[31m%s\u001b[0m\n"
 
-.PHONY: test.lib test.plugin test all
+.PHONY: test.lib test.plugin test all clean
 
 all: install
 
@@ -40,14 +40,9 @@ test.lib:
 
 test.plugin:
 	@printf $(FMT_STR) "TESTING PLUGIN"
-	$(MAKE) -C $(SAMPLE_BINS)
 	$(MAKE) -C $(PLUGIN) test
 
-test.clean:
-	@printf $(FMT_STR) "CLEANING SAMPLE BINS"
-	$(MAKE) -C $(SAMPLE_BINS) clean
-
-clean: test.clean
+clean:
 	@printf $(FMT_STR) "CLEANING LIB"
 	$(MAKE) -C $(LIB) clean
 	@printf $(FMT_STR) "CLEANING PLUGIN"

--- a/wp/Makefile
+++ b/wp/Makefile
@@ -1,14 +1,17 @@
-SHELL=/bin/bash
+SHELL := /bin/bash
 LIB := lib/bap_wp
 PLUGIN := plugin
 SAMPLE_BINS := resources/sample_binaries
 FMT_STR := "\u001b[31m%s\u001b[0m\n"
 
-.PHONY: test.lib test.plugin test all clean
+.PHONY: all uninstall.lib uninstall.plugin uninstall build build.lib build.plugin doc test test.lib test.plugin clean reinstall install install.plugin install.lib
+
+
+# test.lib test.plugin test all clean uninstall uninstall.lib uninstall.plugin reinstall
 
 all: install
 
-install: uninstall.plugin install.lib build.plugin install.plugin
+install: uninstall.plugin install.plugin
 
 uninstall.lib:
 	@printf $(FMT_STR) "UNINSTALLING LIB"
@@ -18,6 +21,7 @@ uninstall.plugin:
 	@printf $(FMT_STR) "UNINSTALLING PLUGIN"
 	$(MAKE) -C $(PLUGIN) uninstall
 
+uninstall: uninstall.lib uninstall.plugin
 
 build: build.lib build.plugin
 
@@ -25,7 +29,7 @@ build.lib:
 	@printf $(FMT_STR) "BUILDING LIB"
 	$(MAKE) -C $(LIB) $*
 
-build.plugin: install.lib
+build.plugin: build.lib install.lib
 	@printf $(FMT_STR) "BUILDING PLUGIN"
 	$(MAKE) -C $(PLUGIN) build
 
@@ -48,9 +52,10 @@ clean:
 	@printf $(FMT_STR) "CLEANING PLUGIN"
 	$(MAKE) -C $(PLUGIN) clean
 
-reinstall: clean install
 
-install.plugin:
+reinstall: uninstall install
+
+install.plugin: install.lib
 	@printf $(FMT_STR) "INSTALLING PLUGIN"
 	$(MAKE) -C $(PLUGIN) $*
 
@@ -58,6 +63,3 @@ install.plugin:
 install.lib:
 	@printf $(FMT_STR) "INSTALLING LIB"
 	$(MAKE) -C $(LIB) install
-
-reinstall.lib:
-	$(MAKE) -C $(LIB) $*

--- a/wp/Makefile
+++ b/wp/Makefile
@@ -4,62 +4,98 @@ PLUGIN := plugin
 SAMPLE_BINS := resources/sample_binaries
 FMT_STR := "\u001b[31m%s\u001b[0m\n"
 
-.PHONY: all uninstall.lib uninstall.plugin uninstall build build.lib build.plugin doc test test.lib test.plugin clean reinstall install install.plugin install.lib
+#####################################################
+# DEFAULT
+#####################################################
+.DEFAULT_GOAL = all
 
-
-# test.lib test.plugin test all clean uninstall uninstall.lib uninstall.plugin reinstall
-
+.PHONY: all
 all: install
 
-install: uninstall.plugin install.plugin
+#####################################################
+# CLEAN
+#####################################################
 
-uninstall.lib:
-	@printf $(FMT_STR) "UNINSTALLING LIB"
-	$(MAKE) -C $(LIB) uninstall
-
-uninstall.plugin:
-	@printf $(FMT_STR) "UNINSTALLING PLUGIN"
-	$(MAKE) -C $(PLUGIN) uninstall
-
-uninstall: uninstall.lib uninstall.plugin
-
-build: build.lib build.plugin
-
-build.lib:
-	@printf $(FMT_STR) "BUILDING LIB"
-	$(MAKE) -C $(LIB) $*
-
-build.plugin: build.lib install.lib
-	@printf $(FMT_STR) "BUILDING PLUGIN"
-	$(MAKE) -C $(PLUGIN) build
-
-doc:
-	$(MAKE) -C $(LIB) $@
-
-test: install test.lib test.plugin
-
-test.lib:
-	@printf $(FMT_STR) "TESTING LIB"
-	$(MAKE) -C $(LIB) test
-
-test.plugin:
-	@printf $(FMT_STR) "TESTING PLUGIN"
-	$(MAKE) -C $(PLUGIN) test
-
+.PHONY: clean
 clean:
 	@printf $(FMT_STR) "CLEANING LIB"
 	$(MAKE) -C $(LIB) clean
 	@printf $(FMT_STR) "CLEANING PLUGIN"
 	$(MAKE) -C $(PLUGIN) clean
 
+#####################################################
+# BUILD
+#####################################################
 
+.PHONY: build
+build: build.lib build.plugin
+
+.PHONY: build.lib
+build.lib:
+	@printf $(FMT_STR) "BUILDING LIB"
+	$(MAKE) -C $(LIB) $*
+
+.PHONY: build.plugin
+build.plugin: build.lib install.lib
+	@printf $(FMT_STR) "BUILDING PLUGIN"
+	$(MAKE) -C $(PLUGIN) build
+
+
+#####################################################
+# INSTALL
+#####################################################
+
+.PHONY: install
+install: uninstall.plugin install.plugin
+
+.PHONY: uninstall
+uninstall: uninstall.lib uninstall.plugin
+
+.PHONY: uninstall.lib
+uninstall.lib:
+	@printf $(FMT_STR) "UNINSTALLING LIB"
+	$(MAKE) -C $(LIB) uninstall
+
+.PHONY: uninstall.plugin
+uninstall.plugin:
+	@printf $(FMT_STR) "UNINSTALLING PLUGIN"
+	$(MAKE) -C $(PLUGIN) uninstall
+
+.PHONY: reinstall
 reinstall: uninstall install
 
+.PHONY: install.plugin
 install.plugin: install.lib
 	@printf $(FMT_STR) "INSTALLING PLUGIN"
 	$(MAKE) -C $(PLUGIN) $*
 
 # lib must be installed BEFORE building plugin
+.PHONY: install.lib
 install.lib:
 	@printf $(FMT_STR) "INSTALLING LIB"
 	$(MAKE) -C $(LIB) install
+
+#####################################################
+# TEST
+#####################################################
+
+.PHONY: test
+test: install test.lib test.plugin
+
+.PHONY: test.lib
+test.lib:
+	@printf $(FMT_STR) "TESTING LIB"
+	$(MAKE) -C $(LIB) test
+
+.PHONY: test.plugin
+test.plugin:
+	@printf $(FMT_STR) "TESTING PLUGIN"
+	$(MAKE) -C $(PLUGIN) test
+
+#####################################################
+# DOCS
+#####################################################
+
+.PHONY: doc
+doc:
+	$(MAKE) -C $(LIB) $@

--- a/wp/Makefile
+++ b/wp/Makefile
@@ -2,54 +2,66 @@ SHELL=/bin/bash
 LIB := lib/bap_wp
 PLUGIN := plugin
 SAMPLE_BINS := resources/sample_binaries
+FMT_STR := "\u001b[31m%s\u001b[0m\n"
 
-.PHONY: test.integration test.lib test.plugin
+.PHONY: test.lib test.plugin test all
+
+all: install
 
 install: uninstall.plugin install.lib build.plugin install.plugin
 
 uninstall.lib:
-	@printf "\n\u001b[31mUNINSTALLING LIB\u001b[0m\n"
+	@printf $(FMT_STR) "UNINSTALLING LIB"
 	$(MAKE) -C $(LIB) uninstall
 
 uninstall.plugin:
-	@printf "\n\u001b[31mUNINSTALLING PLUGIN\u001b[0m\n"
+	@printf $(FMT_STR) "UNINSTALLING PLUGIN"
 	$(MAKE) -C $(PLUGIN) uninstall
 
 
 build: build.lib build.plugin
 
 build.lib:
+	@printf $(FMT_STR) "BUILDING LIB"
 	$(MAKE) -C $(LIB) $*
 
 build.plugin: install.lib
+	@printf $(FMT_STR) "BUILDING PLUGIN"
 	$(MAKE) -C $(PLUGIN) build
 
 doc:
 	$(MAKE) -C $(LIB) $@
 
-test: install test.lib test.plugin test.integration
+test: install test.lib test.plugin
 
 test.lib:
-	$(MAKE) -C $(LIB) $*
+	@printf $(FMT_STR) "TESTING LIB"
+	$(MAKE) -C $(LIB) test
 
 test.plugin:
-	$(MAKE) -C $(SAMPLE_BINS) $*
-	$(MAKE) -C $(PLUGIN) $*
+	@printf $(FMT_STR) "TESTING PLUGIN"
+	$(MAKE) -C $(SAMPLE_BINS)
+	$(MAKE) -C $(PLUGIN) test
 
 test.clean:
+	@printf $(FMT_STR) "CLEANING SAMPLE BINS"
 	$(MAKE) -C $(SAMPLE_BINS) clean
 
 clean: test.clean
-	$(MAKE) -C $(PLUGIN) $@
-	$(MAKE) -C $(LIB) $@
+	@printf $(FMT_STR) "CLEANING LIB"
+	$(MAKE) -C $(LIB) clean
+	@printf $(FMT_STR) "CLEANING PLUGIN"
+	$(MAKE) -C $(PLUGIN) clean
 
 reinstall: clean install
 
 install.plugin:
+	@printf $(FMT_STR) "INSTALLING PLUGIN"
 	$(MAKE) -C $(PLUGIN) $*
 
 # lib must be installed BEFORE building plugin
 install.lib:
+	@printf $(FMT_STR) "INSTALLING LIB"
 	$(MAKE) -C $(LIB) install
 
 reinstall.lib:

--- a/wp/Makefile
+++ b/wp/Makefile
@@ -1,25 +1,53 @@
-BAP_WP = lib/bap_wp
-WP = plugin
-SAMPLE_BINS = resources/sample_binaries
+SHELL=/bin/bash
+LIB := lib/bap_wp
+PLUGIN := plugin
+SAMPLE_BINS := resources/sample_binaries
 
-.PHONY: install doc test clean reinstall
+.PHONY: test.integration test.lib test.plugin
 
-install:
-	$(MAKE) -C $(BAP_WP) $@.local
-	$(MAKE) -C $(WP) $@
+install: build.lib uninstall.plugin uninstall.lib install.lib build.plugin install.plugin
+
+uninstall.lib:
+	@printf "\n\u001b[31mUNINSTALLING LIB\u001b[0m\n"
+	$(MAKE) -C $(LIB) uninstall
+
+uninstall.plugin:
+	@printf "\n\u001b[31mUNINSTALLING PLUGIN\u001b[0m\n"
+	$(MAKE) -C $(PLUGIN) uninstall
+
+
+build: build.lib build.plugin
+
+build.lib:
+	$(MAKE) -C $(LIB) $*
+
+build.plugin: install.lib
+	$(MAKE) -C $(PLUGIN) $*
 
 doc:
-	$(MAKE) -C $(BAP_WP) $@
+	$(MAKE) -C $(LIB) $@
 
-test: install
-	$(MAKE) -C $(BAP_WP) $@
-	$(MAKE) -C $(WP) $@
+test: install test.lib test.plugin test.integration
+
+test.lib:
+	$(MAKE) -C $(LIB) $*
+
+test.plugin:
+	$(MAKE) -C $(SAMPLE_BINS) $*
+	$(MAKE) -C $(PLUGIN) $*
 
 test.clean:
 	$(MAKE) -C $(SAMPLE_BINS) clean
 
-clean:
-	$(MAKE) -C $(WP) $@
-	$(MAKE) -C $(BAP_WP) $@.local
+clean: test.clean
+	$(MAKE) -C $(PLUGIN) $@
+	$(MAKE) -C $(LIB) $@
 
 reinstall: clean install
+
+install.plugin:
+	$(MAKE) -C $(PLUGIN) $*
+
+# lib must be installed BEFORE building plugin
+install.lib:
+	$(MAKE) -C $(LIB) $*

--- a/wp/lib/bap_wp/Makefile
+++ b/wp/lib/bap_wp/Makefile
@@ -1,26 +1,41 @@
-project = bap_wp
+project := bap_wp
+SHELL=/bin/bash
+
+ifeq ($(shell opam pin list | grep "bap_wp" | grep -oE "file://.*" | cut -c 8-), $(shell pwd))
+IS_INSTALLED := true
+else
+IS_INSTALLED := false
+endif
+
+ML_FILES = $(wildcard src/*.ml)
+MLI_FILES = $(wildcard src/*.mli)
 
 all: build
 
+clean: uninstall clean.local
+	rm build
+
 clean.local:
-	opam pin remove -y .
-	dune uninstall
 	dune clean
 
-build:
-	dune build -p $(project)
+$(ML_FILES): ;
+$(MLI_FILES): ;
 
-install.local: build
-	dune install
-	opam pin add -y .
+build: $(ML_FILES) $(MLI_FILES)
+	@printf "\n\u001b[31mBUILDING LIB\u001b[0m\n"
+	dune build -p $(project)
+	touch build
+	echo $?
 
 test: test.unit test.performance
 
 test.unit:
 	dune runtest tests/unit
+	@echo "skipping for now"
 
 test.performance:
 	dune runtest tests/performance
+	@echo "skipping for now"
 
 doc:
 	dune build @doc
@@ -30,3 +45,16 @@ check.installed.findlib:
 
 check.installed.opam:
 	opam show $(project)
+
+install: build
+	@printf "\n\u001b[31mINSTALLING LIB\u001b[0m\n"
+	dune install
+	opam pin add -y .
+
+reinstall: clean install
+
+uninstall:
+ifeq ($(IS_INSTALLED),true)
+	opam pin remove -y .
+	dune uninstall
+endif

--- a/wp/lib/bap_wp/Makefile
+++ b/wp/lib/bap_wp/Makefile
@@ -3,13 +3,13 @@ SHELL := /bin/bash
 
 .PHONY: test test.unit test.performance all install uninstall clean build
 
-ifeq ($PROJECT, $(shell dune installed-libraries | grep "bap_wp"))
+ifeq (1, $(shell dune installed-libraries | grep "bap_wp" | wc -l))
 IS_INSTALLED := 1
 else
 IS_INSTALLED := 0
 endif
 
-BUILD := _build/build_unique_id
+BUILD := _build/install/default/lib/bap_wp/bap_wp.cmxa
 
 SRC_FILES := $(wildcard **/*.ml) $(wildcard **/*.mli)
 
@@ -43,8 +43,7 @@ install: $(BUILD)
 reinstall: clean uninstall install
 
 uninstall:
-	@printf "uninstalling..."
+# eq is needed otherwise errors if not installed
 ifeq ($(IS_INSTALLED),1)
-	@printf "more uninstallation"
 	dune uninstall
 endif

--- a/wp/lib/bap_wp/Makefile
+++ b/wp/lib/bap_wp/Makefile
@@ -9,6 +9,8 @@ else
 IS_INSTALLED := false
 endif
 
+BUILD := _build/build_unique_id
+
 ML_FILES = $(wildcard src/*.ml)
 MLI_FILES = $(wildcard src/*.mli)
 
@@ -16,13 +18,16 @@ all: install
 
 clean: uninstall clean.local
 	rm -f build install
-	rm -f _build/build
+	rm -f $(BUILD)
 
 clean.local:
 	dune clean
 
-build: $(ML_FILES) $(MLI_FILES)
+$(BUILD): $(ML_FILES) $(MLI_FILES)
 	dune build -p $(PROJECT)
+	touch $(BUILD)
+
+build: $(BUILD)
 
 test: test.unit test.performance
 
@@ -41,7 +46,7 @@ check.installed.findlib:
 check.installed.opam:
 	opam show $(PROJECT)
 
-install: build
+install: $(BUILD)
 	dune install
 # only needs to be added if does not already exist
 ifeq ($(IS_INSTALLED),false)

--- a/wp/lib/bap_wp/Makefile
+++ b/wp/lib/bap_wp/Makefile
@@ -1,8 +1,6 @@
 PROJECT := bap_wp
 SHELL := /bin/bash
 
-.PHONY: test test.unit test.performance all install uninstall clean build
-
 ifeq (1, $(shell dune installed-libraries | grep "bap_wp" | wc -l))
 IS_INSTALLED := 1
 else
@@ -13,37 +11,72 @@ BUILD := _build/install/default/lib/bap_wp/bap_wp.cmxa
 
 SRC_FILES := $(wildcard **/*.ml) $(wildcard **/*.mli)
 
+#####################################################
+# DEFAULT
+#####################################################
+.DEFAULT_GOAL = all
+
+.PHONY: all
 all: install
 
+#####################################################
+# CLEAN
+#####################################################
+
+.PHONY: clean
 clean: uninstall clean.local
 
+.PHONY: clean.local
 clean.local:
 	dune clean
+
+#####################################################
+# BUILD
+#####################################################
 
 $(BUILD): $(SRC_FILES)
 	dune build -p $(PROJECT)
 	touch $(BUILD)
 
+.PHONY: build
 build: $(BUILD)
 
-test: test.unit test.performance
+#####################################################
+# INSTALL
+#####################################################
 
-test.unit:
-	dune runtest tests/unit
-
-test.performance:
-	dune runtest tests/performance
-
-doc:
-	dune build @doc
-
+.PHONY: install
 install: $(BUILD)
 	dune install
 
-reinstall: clean uninstall install
+.PHONY:reinstall
+reinstall: uninstall install
 
+.PHONY: uninstall
 uninstall:
 # eq is needed otherwise errors if not installed
 ifeq ($(IS_INSTALLED),1)
 	dune uninstall
 endif
+
+#####################################################
+# TEST
+#####################################################
+
+.PHONY: test
+test: test.unit test.performance
+
+.PHONY: test.unit
+test.unit:
+	dune runtest tests/unit
+
+.PHONY: test.performance
+test.performance:
+	dune runtest tests/performance
+
+#####################################################
+# DOCS
+#####################################################
+
+doc:
+	dune build @doc

--- a/wp/lib/bap_wp/Makefile
+++ b/wp/lib/bap_wp/Makefile
@@ -10,10 +10,10 @@ endif
 ML_FILES = $(wildcard src/*.ml)
 MLI_FILES = $(wildcard src/*.mli)
 
-all: build
+all: install
 
 clean: uninstall clean.local
-	rm build
+	rm -f build install
 
 clean.local:
 	dune clean
@@ -46,15 +46,25 @@ check.installed.findlib:
 check.installed.opam:
 	opam show $(project)
 
-install: build
+install: hack
 	@printf "\n\u001b[31mINSTALLING LIB\u001b[0m\n"
 	dune install
 	opam pin add -y .
+	touch install
+
+hack: build
+ifeq ($(IS_INSTALLED),true)
+	@printf "\n\u001b[31mUNINSTALLING LIB\u001b[0m\n"
+	opam pin remove -y .
+	dune uninstall
+endif
+	touch hack
 
 reinstall: clean install
 
 uninstall:
 ifeq ($(IS_INSTALLED),true)
+	@printf "\n\u001b[31mUNINSTALLING LIB\u001b[0m\n"
 	opam pin remove -y .
 	dune uninstall
 endif

--- a/wp/lib/bap_wp/Makefile
+++ b/wp/lib/bap_wp/Makefile
@@ -1,5 +1,7 @@
-project := bap_wp
+PROJECT := bap_wp
 SHELL=/bin/bash
+
+.PHONY: test all install
 
 ifeq ($(shell opam pin list | grep "bap_wp" | grep -oE "file://.*" | cut -c 8-), $(shell pwd))
 IS_INSTALLED := true
@@ -14,57 +16,42 @@ all: install
 
 clean: uninstall clean.local
 	rm -f build install
+	rm -f _build/build
 
 clean.local:
 	dune clean
 
-$(ML_FILES): ;
-$(MLI_FILES): ;
-
 build: $(ML_FILES) $(MLI_FILES)
-	@printf "\n\u001b[31mBUILDING LIB\u001b[0m\n"
-	dune build -p $(project)
-	touch build
-	echo $?
+	dune build -p $(PROJECT)
 
 test: test.unit test.performance
 
 test.unit:
 	dune runtest tests/unit
-	@echo "skipping for now"
 
 test.performance:
 	dune runtest tests/performance
-	@echo "skipping for now"
 
 doc:
 	dune build @doc
 
 check.installed.findlib:
-	ocamlfind query $(project)
+	ocamlfind query $(PROJECT)
 
 check.installed.opam:
-	opam show $(project)
+	opam show $(PROJECT)
 
-install: hack
-	@printf "\n\u001b[31mINSTALLING LIB\u001b[0m\n"
+install: build
 	dune install
+# only needs to be added if does not already exist
+ifeq ($(IS_INSTALLED),false)
 	opam pin add -y .
-	touch install
-
-hack: build
-ifeq ($(IS_INSTALLED),true)
-	@printf "\n\u001b[31mUNINSTALLING LIB\u001b[0m\n"
-	opam pin remove -y .
-	dune uninstall
 endif
-	touch hack
 
 reinstall: clean install
 
 uninstall:
 ifeq ($(IS_INSTALLED),true)
-	@printf "\n\u001b[31mUNINSTALLING LIB\u001b[0m\n"
 	opam pin remove -y .
 	dune uninstall
 endif

--- a/wp/lib/bap_wp/Makefile
+++ b/wp/lib/bap_wp/Makefile
@@ -1,23 +1,21 @@
 PROJECT := bap_wp
-SHELL=/bin/bash
+SHELL := /bin/bash
 
-.PHONY: test all install
+.PHONY: test test.unit test.performance all install uninstall clean build
 
-ifeq ($(shell opam pin list | grep "bap_wp" | grep -oE "file://.*" | cut -c 8-), $(shell pwd))
-IS_INSTALLED := true
+ifeq ($PROJECT, $(shell dune installed-libraries | grep "bap_wp"))
+IS_INSTALLED := 1
 else
-IS_INSTALLED := false
+IS_INSTALLED := 0
 endif
 
 BUILD := _build/build_unique_id
 
-SRC_FILES = $(wildcard src/*.ml) $(wildcard src/*.mli)
+SRC_FILES := $(wildcard **/*.ml) $(wildcard **/*.mli)
 
 all: install
 
 clean: uninstall clean.local
-	rm -f build install
-	rm -f $(BUILD)
 
 clean.local:
 	dune clean
@@ -39,23 +37,14 @@ test.performance:
 doc:
 	dune build @doc
 
-check.installed.findlib:
-	ocamlfind query $(PROJECT)
-
-check.installed.opam:
-	opam show $(PROJECT)
-
 install: $(BUILD)
 	dune install
-# only needs to be added if does not already exist
-ifeq ($(IS_INSTALLED),false)
-	opam pin add -y .
-endif
 
-reinstall: clean install
+reinstall: clean uninstall install
 
 uninstall:
-ifeq ($(IS_INSTALLED),true)
-	opam pin remove -y .
+	@printf "uninstalling..."
+ifeq ($(IS_INSTALLED),1)
+	@printf "more uninstallation"
 	dune uninstall
 endif

--- a/wp/lib/bap_wp/Makefile
+++ b/wp/lib/bap_wp/Makefile
@@ -11,8 +11,7 @@ endif
 
 BUILD := _build/build_unique_id
 
-ML_FILES = $(wildcard src/*.ml)
-MLI_FILES = $(wildcard src/*.mli)
+SRC_FILES = $(wildcard src/*.ml) $(wildcard src/*.mli)
 
 all: install
 
@@ -23,7 +22,7 @@ clean: uninstall clean.local
 clean.local:
 	dune clean
 
-$(BUILD): $(ML_FILES) $(MLI_FILES)
+$(BUILD): $(SRC_FILES)
 	dune build -p $(PROJECT)
 	touch $(BUILD)
 

--- a/wp/plugin/Makefile
+++ b/wp/plugin/Makefile
@@ -5,14 +5,15 @@ SAMPLE_BIN_DIR = ../resources/sample_binaries
 API_PATH = $(shell bap --api-list-paths)
 
 # .PHONY: all install clean verifier save_project uninstall test
+.PHONY: all verifier save_project test
 
-install: build verifier save_project
+all: install
+
+install: verifier save_project build
 	@printf "\n\u001b[31mINSTALLING PLUGINs\u001b[0m\n"
 	bapbundle update -desc 'Computes the weakest precondition of a subroutine given a postcondition.' $(PASS_NAME).plugin
 	bapbundle install $(PASS_NAME).plugin
 
-
-wp.ml: ;
 
 build: wp.ml
 	@printf "\n\u001b[31mBUILDING PLUGIN\u001b[0m\n"
@@ -43,4 +44,4 @@ clean: uninstall
 	bapbuild -clean
 	rm -f *.plugin 
 	rm -rf _build
-	rm build
+	rm -f build

--- a/wp/plugin/Makefile
+++ b/wp/plugin/Makefile
@@ -1,28 +1,46 @@
 PASS_NAME = wp
+SHELL=/bin/bash
 
 SAMPLE_BIN_DIR = ../resources/sample_binaries
 API_PATH = $(shell bap --api-list-paths)
 
-.PHONY: all build install clean verifier
+# .PHONY: all install clean verifier save_project uninstall test
 
-all: install
-
-build:
-	bapbuild -use-ocamlfind -pkgs 'z3,bap_wp,re' -tag 'warn(A-48-44)' -I lib $(PASS_NAME).plugin
-
-install: build verifier
+install: build verifier save_project
+	@printf "\n\u001b[31mINSTALLING PLUGINs\u001b[0m\n"
 	bapbundle update -desc 'Computes the weakest precondition of a subroutine given a postcondition.' $(PASS_NAME).plugin
 	bapbundle install $(PASS_NAME).plugin
 
-test: install
+
+wp.ml: ;
+
+build: wp.ml
+	@printf "\n\u001b[31mBUILDING PLUGIN\u001b[0m\n"
+	bapbuild -use-ocamlfind -pkgs 'z3,bap_wp,re' -tag 'warn(A-48-44)' -I lib $(PASS_NAME).plugin
+	touch build
+
+test: install save_project dummy
 	ocamlbuild -r -use-ocamlfind -pkgs 'bap,z3,bap_wp,oUnit,re' -tag 'warn(A-48-44),debug,thread' -Is "lib,tests" test.native
 	./test.native
 
 verifier:
 	cp api/c/cbat.h $(API_PATH)/c/cbat.h
 
-clean:
+save_project:
+	$(MAKE) -C $(SAVE_PROJECT_DIR)
+
+dummy:
+	$(MAKE) -C $(SAMPLE_BIN_DIR)/dummy
+
+uninstall.save_project:
+	$(MAKE) -C $(SAVE_PROJECT_DIR) uninstall
+
+uninstall: uninstall.save_project
 	bapbundle remove $(PASS_NAME).plugin
+
+clean: uninstall
+	$(MAKE) -C $(SAVE_PROJECT_DIR) $@
 	bapbuild -clean
-	rm -f *.plugin
+	rm -f *.plugin 
 	rm -rf _build
+	rm build

--- a/wp/plugin/Makefile
+++ b/wp/plugin/Makefile
@@ -1,27 +1,30 @@
-PASS_NAME = wp
+PASS_NAME := wp
 SHELL=/bin/bash
 
 SAMPLE_BIN_DIR = ../resources/sample_binaries
 API_PATH = $(shell bap --api-list-paths)
 
-# .PHONY: all install clean verifier save_project uninstall test
+BUILD := _build/build_unique_id
+
 .PHONY: all verifier save_project test
 
 all: install
 
-install: verifier save_project build
-	@printf "\n\u001b[31mINSTALLING PLUGINs\u001b[0m\n"
+install: verifier save_project $(BUILD)
 	bapbundle update -desc 'Computes the weakest precondition of a subroutine given a postcondition.' $(PASS_NAME).plugin
 	bapbundle install $(PASS_NAME).plugin
 
+build: $(BUILD)
 
-build: wp.ml
-	@printf "\n\u001b[31mBUILDING PLUGIN\u001b[0m\n"
+$(BUILD): wp.ml
 	bapbuild -use-ocamlfind -pkgs 'z3,bap_wp,re' -tag 'warn(A-48-44)' -I lib $(PASS_NAME).plugin
-	touch build
+	# hack but no easy way around it
+	touch $(BUILD)
 
 test: install save_project dummy
-	ocamlbuild -r -use-ocamlfind -pkgs 'bap,z3,bap_wp,oUnit,re' -tag 'warn(A-48-44),debug,thread' -Is "lib,tests" test.native
+	ocamlbuild -r -use-ocamlfind
+		-pkgs 'bap,z3,bap_wp,oUnit,re'
+		-tag 'warn(A-48-44),debug,thread' -Is "lib,tests" test.native
 	./test.native
 
 verifier:

--- a/wp/plugin/Makefile
+++ b/wp/plugin/Makefile
@@ -6,21 +6,68 @@ API_PATH := $(shell bap --api-list-paths)
 VERIFIER_LOCAL := api/c/cbat.h
 VERIFIER_INSTALL_PATH := $(API_PATH)/c/cbat.h
 
+PKGS := 'z3,bap_wp,re'
+TAG := 'warn(A-48-44)'
+Is := 'lib'
+
+TEST_PKGS := 'bap,z3,bap_wp,oUnit,re'
+TEST_TAG := 'warn(A-48-44),debug,thread'
+TEST_Is := 'lib,tests'
+
 BUILD := $(PASS_NAME).plugin
 SRC_FILES := $(wildcard **/*.ml) $(wildcard **/*.mli)
 
-.PHONY: all test uninstall uninstall.verifier
+#####################################################
+# DEFAULT
+#####################################################
 
+.DEFAULT_GOAL = all
+
+.PHONY: all
 all: install
+
+#####################################################
+# CLEAN
+#####################################################
+
+clean: uninstall test.clean
+	bapbuild -clean
+
+#####################################################
+# BUILD
+#####################################################
+
+build: $(BUILD)
+
+$(BUILD): $(SRC_FILES)
+	bapbuild -use-ocamlfind -pkgs $(PKGS) -tag $(TAG) -I $(Is) $(PASS_NAME).plugin
+
+#####################################################
+# INSTALL
+#####################################################
 
 install: $(BUILD) $(VERIFIER_INSTALL_PATH)
 	bapbundle update -desc 'Computes the weakest precondition of a subroutine given a postcondition.' $(PASS_NAME).plugin
 	bapbundle install $(PASS_NAME).plugin
 
-build: $(BUILD)
+$(VERIFIER_INSTALL_PATH): $(VERIFIER_LOCAL)
+	cp $(VERIFIER_LOCAL) $(VERIFIER_INSTALL_PATH)
 
-$(BUILD): $(SRC_FILES)
-	bapbuild -use-ocamlfind -pkgs 'z3,bap_wp,re' -tag 'warn(A-48-44)' -I lib $(PASS_NAME).plugin
+.PHONY: uninstall.verifier
+uninstall.verifier:
+	rm -f $(VERIFIER_INSTALL_PATH)
+
+.PHONY: uninstall
+uninstall: uninstall.verifier
+	bapbundle remove $(PASS_NAME).plugin
+
+.PHONY: reinstall
+reinstall: uninstall reinstall
+
+
+#####################################################
+# TEST
+#####################################################
 
 test.build:
 	$(MAKE) -C $(SAMPLE_BIN_DIR)
@@ -28,20 +75,9 @@ test.build:
 test.clean:
 	$(MAKE) -C $(SAMPLE_BIN_DIR) clean
 
+.PHONY: test
 test: install test.build
 	ocamlbuild -r -use-ocamlfind \
-		-pkgs 'bap,z3,bap_wp,oUnit,re' \
-		-tag 'warn(A-48-44),debug,thread' -Is "lib,tests" test.native
+		-pkgs $(TEST_PKGS) \
+		-tag $(TEST_TAG) -Is $(TEST_Is) test.native
 	./test.native
-
-$(VERIFIER_INSTALL_PATH): $(VERIFIER_LOCAL)
-	cp $(VERIFIER_LOCAL) $(VERIFIER_INSTALL_PATH)
-
-uninstall.verifier:
-	rm -f $(VERIFIER_INSTALL_PATH)
-
-uninstall: uninstall.verifier
-	bapbundle remove $(PASS_NAME).plugin
-
-clean: uninstall test.clean
-	bapbuild -clean

--- a/wp/plugin/Makefile
+++ b/wp/plugin/Makefile
@@ -6,22 +6,32 @@ API_PATH = $(shell bap --api-list-paths)
 
 BUILD := _build/build_unique_id
 
-.PHONY: all verifier save_project test
+.PHONY: all verifier save_project test uninstall uninstall.save_project uninstall.verifier
 
 all: install
 
-install: verifier save_project $(BUILD)
+install: save_project $(BUILD) | verifier
 	bapbundle update -desc 'Computes the weakest precondition of a subroutine given a postcondition.' $(PASS_NAME).plugin
 	bapbundle install $(PASS_NAME).plugin
 
 build: $(BUILD)
 
 $(BUILD): wp.ml
+# exactly one version of bap_wp installed
+ifneq ($(shell opam pin list | grep "bap_wp" | wc -l), 1)
+	$(error "bap_wp lib is not installed. Please install using relevant makefile.")
+endif
 	bapbuild -use-ocamlfind -pkgs 'z3,bap_wp,re' -tag 'warn(A-48-44)' -I lib $(PASS_NAME).plugin
 	# hack but no easy way around it
 	touch $(BUILD)
 
-test: install save_project dummy
+test.build:
+	$(MAKE) -C $(SAMPLE_BIN_DIR)
+
+test.clean:
+	$(MAKE) -C $(SAMPLE_BIN_DIR) clean
+
+test: install save_project dummy test.build
 	ocamlbuild -r -use-ocamlfind \
 		-pkgs 'bap,z3,bap_wp,oUnit,re' \
 		-tag 'warn(A-48-44),debug,thread' -Is "lib,tests" test.native
@@ -39,10 +49,13 @@ dummy:
 uninstall.save_project:
 	$(MAKE) -C $(SAVE_PROJECT_DIR) uninstall
 
-uninstall: uninstall.save_project
+uninstall.verifier:
+	rm -f $(API_PATH)/c/cbat.h
+
+uninstall: uninstall.save_project uninstall.verifier
 	bapbundle remove $(PASS_NAME).plugin
 
-clean: uninstall
+clean: uninstall test.clean
 	$(MAKE) -C $(SAVE_PROJECT_DIR) $@
 	bapbuild -clean
 	rm -f *.plugin 

--- a/wp/plugin/Makefile
+++ b/wp/plugin/Makefile
@@ -5,22 +5,24 @@ SAMPLE_BIN_DIR = ../resources/sample_binaries
 API_PATH = $(shell bap --api-list-paths)
 
 BUILD := _build/build_unique_id
+SRC_FILES = $(wildcard */*.ml) $(wildcard */*.mli)
 
-.PHONY: all verifier save_project test uninstall uninstall.save_project uninstall.verifier
+.PHONY: all verifier test uninstall uninstall.verifier
 
 all: install
 
-install: save_project $(BUILD) | verifier
+install: $(BUILD) | verifier
 	bapbundle update -desc 'Computes the weakest precondition of a subroutine given a postcondition.' $(PASS_NAME).plugin
 	bapbundle install $(PASS_NAME).plugin
 
 build: $(BUILD)
 
-$(BUILD): wp.ml
+$(BUILD): $(SRC_FILES)
 # exactly one version of bap_wp installed
 ifneq ($(shell opam pin list | grep "bap_wp" | wc -l), 1)
 	$(error "bap_wp lib is not installed. Please install using relevant makefile.")
 endif
+	printf "SO YA MESSED WITH: " $(SRC_FILES)
 	bapbuild -use-ocamlfind -pkgs 'z3,bap_wp,re' -tag 'warn(A-48-44)' -I lib $(PASS_NAME).plugin
 	# hack but no easy way around it
 	touch $(BUILD)
@@ -31,7 +33,7 @@ test.build:
 test.clean:
 	$(MAKE) -C $(SAMPLE_BIN_DIR) clean
 
-test: install save_project dummy test.build
+test: install test.build
 	ocamlbuild -r -use-ocamlfind \
 		-pkgs 'bap,z3,bap_wp,oUnit,re' \
 		-tag 'warn(A-48-44),debug,thread' -Is "lib,tests" test.native
@@ -40,23 +42,13 @@ test: install save_project dummy test.build
 verifier:
 	cp api/c/cbat.h $(API_PATH)/c/cbat.h
 
-save_project:
-	$(MAKE) -C $(SAVE_PROJECT_DIR)
-
-dummy:
-	$(MAKE) -C $(SAMPLE_BIN_DIR)/dummy
-
-uninstall.save_project:
-	$(MAKE) -C $(SAVE_PROJECT_DIR) uninstall
-
 uninstall.verifier:
 	rm -f $(API_PATH)/c/cbat.h
 
-uninstall: uninstall.save_project uninstall.verifier
+uninstall: uninstall.verifier
 	bapbundle remove $(PASS_NAME).plugin
 
 clean: uninstall test.clean
-	$(MAKE) -C $(SAVE_PROJECT_DIR) $@
 	bapbuild -clean
 	rm -f *.plugin 
 	rm -rf _build

--- a/wp/plugin/Makefile
+++ b/wp/plugin/Makefile
@@ -22,8 +22,8 @@ $(BUILD): wp.ml
 	touch $(BUILD)
 
 test: install save_project dummy
-	ocamlbuild -r -use-ocamlfind
-		-pkgs 'bap,z3,bap_wp,oUnit,re'
+	ocamlbuild -r -use-ocamlfind \
+		-pkgs 'bap,z3,bap_wp,oUnit,re' \
 		-tag 'warn(A-48-44),debug,thread' -Is "lib,tests" test.native
 	./test.native
 

--- a/wp/plugin/Makefile
+++ b/wp/plugin/Makefile
@@ -1,31 +1,26 @@
 PASS_NAME := wp
-SHELL=/bin/bash
+SHELL := /bin/bash
 
-SAMPLE_BIN_DIR = ../resources/sample_binaries
-API_PATH = $(shell bap --api-list-paths)
+SAMPLE_BIN_DIR := ../resources/sample_binaries
+API_PATH := $(shell bap --api-list-paths)
+VERIFIER_LOCAL := api/c/cbat.h
+VERIFIER_INSTALL_PATH := $(API_PATH)/c/cbat.h
 
-BUILD := _build/build_unique_id
-SRC_FILES = $(wildcard */*.ml) $(wildcard */*.mli)
+BUILD := $(PASS_NAME).plugin
+SRC_FILES := $(wildcard **/*.ml) $(wildcard **/*.mli)
 
-.PHONY: all verifier test uninstall uninstall.verifier
+.PHONY: all test uninstall uninstall.verifier
 
 all: install
 
-install: $(BUILD) | verifier
+install: $(BUILD) $(VERIFIER_INSTALL_PATH)
 	bapbundle update -desc 'Computes the weakest precondition of a subroutine given a postcondition.' $(PASS_NAME).plugin
 	bapbundle install $(PASS_NAME).plugin
 
 build: $(BUILD)
 
 $(BUILD): $(SRC_FILES)
-# exactly one version of bap_wp installed
-ifneq ($(shell opam pin list | grep "bap_wp" | wc -l), 1)
-	$(error "bap_wp lib is not installed. Please install using relevant makefile.")
-endif
-	printf "SO YA MESSED WITH: " $(SRC_FILES)
 	bapbuild -use-ocamlfind -pkgs 'z3,bap_wp,re' -tag 'warn(A-48-44)' -I lib $(PASS_NAME).plugin
-	# hack but no easy way around it
-	touch $(BUILD)
 
 test.build:
 	$(MAKE) -C $(SAMPLE_BIN_DIR)
@@ -39,17 +34,14 @@ test: install test.build
 		-tag 'warn(A-48-44),debug,thread' -Is "lib,tests" test.native
 	./test.native
 
-verifier:
-	cp api/c/cbat.h $(API_PATH)/c/cbat.h
+$(VERIFIER_INSTALL_PATH): $(VERIFIER_LOCAL)
+	cp $(VERIFIER_LOCAL) $(VERIFIER_INSTALL_PATH)
 
 uninstall.verifier:
-	rm -f $(API_PATH)/c/cbat.h
+	rm -f $(VERIFIER_INSTALL_PATH)
 
 uninstall: uninstall.verifier
 	bapbundle remove $(PASS_NAME).plugin
 
 clean: uninstall test.clean
 	bapbuild -clean
-	rm -f *.plugin 
-	rm -rf _build
-	rm -f build

--- a/wp/resources/sample_binaries/Makefile
+++ b/wp/resources/sample_binaries/Makefile
@@ -1,6 +1,7 @@
 SAMPLE_DIRS = $(wildcard */)
 BUILD_DIRS = $(SAMPLE_DIRS:%=build-%)
 CLEAN_DIRS = $(SAMPLE_DIRS:%=clean-%)
+MAKEFLAGS += -j$(shell nproc)
 
 .PHONY: all subdirs $(BUILD_DIRS)
 all: $(BUILD_DIRS)

--- a/wp/resources/sample_binaries/Makefile
+++ b/wp/resources/sample_binaries/Makefile
@@ -3,12 +3,10 @@ BUILD_DIRS = $(SAMPLE_DIRS:%=build-%)
 CLEAN_DIRS = $(SAMPLE_DIRS:%=clean-%)
 MAKEFLAGS += -j$(shell nproc)
 
-.PHONY: all subdirs $(BUILD_DIRS)
 all: $(BUILD_DIRS)
 $(BUILD_DIRS):
 	$(MAKE) -C $(@:build-%=%)
 
-.PHONY: clean subdirs $(CLEAN_DIRS)
 clean: $(CLEAN_DIRS)
 $(CLEAN_DIRS):
 	$(MAKE) -C $(@:clean-%=%) clean

--- a/wp/resources/sample_binaries/cbat-multicompiler-samples/csmith/run_wp.sh
+++ b/wp/resources/sample_binaries/cbat-multicompiler-samples/csmith/run_wp.sh
@@ -2,8 +2,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/cbat-multicompiler-samples/csmith/run_wp_inline.sh
+++ b/wp/resources/sample_binaries/cbat-multicompiler-samples/csmith/run_wp_inline.sh
@@ -4,8 +4,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/cbat-multicompiler-samples/equiv_argc/run_wp.sh
+++ b/wp/resources/sample_binaries/cbat-multicompiler-samples/equiv_argc/run_wp.sh
@@ -2,8 +2,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/cbat-multicompiler-samples/switch_case_assignments/run_wp.sh
+++ b/wp/resources/sample_binaries/cbat-multicompiler-samples/switch_case_assignments/run_wp.sh
@@ -3,8 +3,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --compare-post-reg-values=RAX \

--- a/wp/resources/sample_binaries/debruijn/run_wp_16bit.sh
+++ b/wp/resources/sample_binaries/debruijn/run_wp_16bit.sh
@@ -5,8 +5,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=rightmost_index_16 \

--- a/wp/resources/sample_binaries/debruijn/run_wp_16bit.sh
+++ b/wp/resources/sample_binaries/debruijn/run_wp_16bit.sh
@@ -7,10 +7,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=rightmost_index_16 \
@@ -19,4 +15,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/debruijn/run_wp_32bit.sh
+++ b/wp/resources/sample_binaries/debruijn/run_wp_32bit.sh
@@ -5,8 +5,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=rightmost_index_32 \

--- a/wp/resources/sample_binaries/debruijn/run_wp_32bit.sh
+++ b/wp/resources/sample_binaries/debruijn/run_wp_32bit.sh
@@ -7,10 +7,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=rightmost_index_32 \
@@ -19,4 +15,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/debruijn/run_wp_8bit.sh
+++ b/wp/resources/sample_binaries/debruijn/run_wp_8bit.sh
@@ -5,8 +5,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=rightmost_index_8 \

--- a/wp/resources/sample_binaries/debruijn/run_wp_8bit.sh
+++ b/wp/resources/sample_binaries/debruijn/run_wp_8bit.sh
@@ -7,10 +7,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=rightmost_index_8 \
@@ -19,4 +15,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/diff_pointer_val/run_wp.sh
+++ b/wp/resources/sample_binaries/diff_pointer_val/run_wp.sh
@@ -17,4 +17,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/diff_pointer_val/run_wp.sh
+++ b/wp/resources/sample_binaries/diff_pointer_val/run_wp.sh
@@ -4,8 +4,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/diff_pointer_val/run_wp.sh
+++ b/wp/resources/sample_binaries/diff_pointer_val/run_wp.sh
@@ -6,10 +6,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/diff_ret_val/run_wp.sh
+++ b/wp/resources/sample_binaries/diff_ret_val/run_wp.sh
@@ -17,4 +17,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/diff_ret_val/run_wp.sh
+++ b/wp/resources/sample_binaries/diff_ret_val/run_wp.sh
@@ -4,8 +4,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/diff_ret_val/run_wp.sh
+++ b/wp/resources/sample_binaries/diff_ret_val/run_wp.sh
@@ -6,10 +6,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/double_dereference/run_wp.sh
+++ b/wp/resources/sample_binaries/double_dereference/run_wp.sh
@@ -3,8 +3,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/double_dereference/run_wp.sh
+++ b/wp/resources/sample_binaries/double_dereference/run_wp.sh
@@ -17,4 +17,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/double_dereference/run_wp.sh
+++ b/wp/resources/sample_binaries/double_dereference/run_wp.sh
@@ -5,10 +5,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/equiv_argc/run_wp.sh
+++ b/wp/resources/sample_binaries/equiv_argc/run_wp.sh
@@ -17,4 +17,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/equiv_argc/run_wp.sh
+++ b/wp/resources/sample_binaries/equiv_argc/run_wp.sh
@@ -4,8 +4,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/equiv_argc/run_wp.sh
+++ b/wp/resources/sample_binaries/equiv_argc/run_wp.sh
@@ -6,10 +6,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/equiv_argc/run_wp_disallow.sh
+++ b/wp/resources/sample_binaries/equiv_argc/run_wp_disallow.sh
@@ -7,8 +7,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/equiv_argc/run_wp_disallow.sh
+++ b/wp/resources/sample_binaries/equiv_argc/run_wp_disallow.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/equiv_argc/run_wp_disallow.sh
+++ b/wp/resources/sample_binaries/equiv_argc/run_wp_disallow.sh
@@ -21,4 +21,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/equiv_argc/run_wp_force.sh
+++ b/wp/resources/sample_binaries/equiv_argc/run_wp_force.sh
@@ -6,8 +6,6 @@
 
 # Should return SAT.
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/equiv_argc/run_wp_force.sh
+++ b/wp/resources/sample_binaries/equiv_argc/run_wp_force.sh
@@ -8,10 +8,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/equiv_argc/run_wp_force.sh
+++ b/wp/resources/sample_binaries/equiv_argc/run_wp_force.sh
@@ -20,4 +20,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/equiv_null_check/run_wp.sh
+++ b/wp/resources/sample_binaries/equiv_null_check/run_wp.sh
@@ -17,4 +17,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/equiv_null_check/run_wp.sh
+++ b/wp/resources/sample_binaries/equiv_null_check/run_wp.sh
@@ -3,8 +3,6 @@
 
 # Should return SAT.
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/equiv_null_check/run_wp.sh
+++ b/wp/resources/sample_binaries/equiv_null_check/run_wp.sh
@@ -5,10 +5,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/function_call/run_wp_inline_all.sh
+++ b/wp/resources/sample_binaries/function_call/run_wp_inline_all.sh
@@ -5,8 +5,6 @@
 
 # Should return SAT.
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/function_call/run_wp_inline_all.sh
+++ b/wp/resources/sample_binaries/function_call/run_wp_inline_all.sh
@@ -19,4 +19,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/function_call/run_wp_inline_all.sh
+++ b/wp/resources/sample_binaries/function_call/run_wp_inline_all.sh
@@ -7,10 +7,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/function_call/run_wp_inline_foo.sh
+++ b/wp/resources/sample_binaries/function_call/run_wp_inline_foo.sh
@@ -20,4 +20,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/function_call/run_wp_inline_foo.sh
+++ b/wp/resources/sample_binaries/function_call/run_wp_inline_foo.sh
@@ -6,8 +6,6 @@
 
 # Should return SAT.
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/function_call/run_wp_inline_foo.sh
+++ b/wp/resources/sample_binaries/function_call/run_wp_inline_foo.sh
@@ -8,10 +8,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/function_spec/run_wp.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp.sh
@@ -10,10 +10,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
     bap wp \
       --func=main \

--- a/wp/resources/sample_binaries/function_spec/run_wp.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp.sh
@@ -21,4 +21,4 @@ run () {
       -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/function_spec/run_wp.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp.sh
@@ -8,8 +8,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
     bap wp \
       --func=main \

--- a/wp/resources/sample_binaries/function_spec/run_wp_inline_all.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp_inline_all.sh
@@ -20,4 +20,4 @@ run () {
       -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/function_spec/run_wp_inline_all.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp_inline_all.sh
@@ -6,8 +6,6 @@
 
 # Should return UNSAT.
 
-set -x
-
 run () {
     bap wp \
       --func=main \

--- a/wp/resources/sample_binaries/function_spec/run_wp_inline_all.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp_inline_all.sh
@@ -8,10 +8,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
     bap wp \
       --func=main \

--- a/wp/resources/sample_binaries/function_spec/run_wp_inline_foo.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp_inline_foo.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
     bap wp \
       --func=main \

--- a/wp/resources/sample_binaries/function_spec/run_wp_inline_foo.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp_inline_foo.sh
@@ -7,8 +7,6 @@
 
 # Should return UNSAT.
 
-set -x
-
 run () {
     bap wp \
       --func=main \

--- a/wp/resources/sample_binaries/function_spec/run_wp_inline_foo.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp_inline_foo.sh
@@ -21,4 +21,4 @@ run () {
       -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/function_spec/run_wp_inline_garbage.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp_inline_garbage.sh
@@ -20,4 +20,4 @@ run () {
       -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/function_spec/run_wp_inline_garbage.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp_inline_garbage.sh
@@ -6,8 +6,6 @@
 
 # Should return SAT.
 
-set -x
-
 run () {
     bap wp \
       --func=main \

--- a/wp/resources/sample_binaries/function_spec/run_wp_inline_garbage.sh
+++ b/wp/resources/sample_binaries/function_spec/run_wp_inline_garbage.sh
@@ -8,10 +8,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
     bap wp \
       --func=main \

--- a/wp/resources/sample_binaries/goto_string/run_wp.sh
+++ b/wp/resources/sample_binaries/goto_string/run_wp.sh
@@ -22,4 +22,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/goto_string/run_wp.sh
+++ b/wp/resources/sample_binaries/goto_string/run_wp.sh
@@ -11,10 +11,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/goto_string/run_wp.sh
+++ b/wp/resources/sample_binaries/goto_string/run_wp.sh
@@ -9,8 +9,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/goto_string/run_wp_inline.sh
+++ b/wp/resources/sample_binaries/goto_string/run_wp_inline.sh
@@ -11,10 +11,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/goto_string/run_wp_inline.sh
+++ b/wp/resources/sample_binaries/goto_string/run_wp_inline.sh
@@ -23,4 +23,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/goto_string/run_wp_inline.sh
+++ b/wp/resources/sample_binaries/goto_string/run_wp_inline.sh
@@ -9,8 +9,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/hash_function/run_wp.sh
+++ b/wp/resources/sample_binaries/hash_function/run_wp.sh
@@ -3,8 +3,6 @@
 
 # Should return SAT
 
-set -x
-
 run() {
   bap wp \
     --func=perform_hash \

--- a/wp/resources/sample_binaries/hash_function/run_wp.sh
+++ b/wp/resources/sample_binaries/hash_function/run_wp.sh
@@ -5,10 +5,6 @@
 
 set -x
 
-compile() {
-  make
-}
-
 run() {
   bap wp \
     --func=perform_hash \
@@ -17,8 +13,4 @@ run() {
     -- main
 }
 
-clean() {
-  make clean
-}
-
-clean && compile && run
+run

--- a/wp/resources/sample_binaries/indirect_call_no_return/run_wp.sh
+++ b/wp/resources/sample_binaries/indirect_call_no_return/run_wp.sh
@@ -3,8 +3,6 @@
 
 set -x
 
-dummy_dir=../dummy
-
 run () {
   bap wp \
     --func=indirect_call \

--- a/wp/resources/sample_binaries/indirect_call_no_return/run_wp.sh
+++ b/wp/resources/sample_binaries/indirect_call_no_return/run_wp.sh
@@ -17,4 +17,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/indirect_call_no_return/run_wp.sh
+++ b/wp/resources/sample_binaries/indirect_call_no_return/run_wp.sh
@@ -5,10 +5,6 @@ set -x
 
 dummy_dir=../dummy
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=indirect_call \

--- a/wp/resources/sample_binaries/indirect_call_no_return/run_wp.sh
+++ b/wp/resources/sample_binaries/indirect_call_no_return/run_wp.sh
@@ -1,8 +1,6 @@
 # This tests that an indirect call with no return does not have
 # its stack pointer incremented as part of our indirect call spec.
 
-set -x
-
 run () {
   bap wp \
     --func=indirect_call \

--- a/wp/resources/sample_binaries/indirect_call_return/run_wp.sh
+++ b/wp/resources/sample_binaries/indirect_call_return/run_wp.sh
@@ -3,8 +3,6 @@
 
 set -x
 
-dummy_dir=../dummy
-
 run () {
   bap wp \
     --func=indirect_call \

--- a/wp/resources/sample_binaries/indirect_call_return/run_wp.sh
+++ b/wp/resources/sample_binaries/indirect_call_return/run_wp.sh
@@ -17,4 +17,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/indirect_call_return/run_wp.sh
+++ b/wp/resources/sample_binaries/indirect_call_return/run_wp.sh
@@ -5,10 +5,6 @@ set -x
 
 dummy_dir=../dummy
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=indirect_call \

--- a/wp/resources/sample_binaries/indirect_call_return/run_wp.sh
+++ b/wp/resources/sample_binaries/indirect_call_return/run_wp.sh
@@ -1,8 +1,6 @@
 # This tests that an indirect call with a return has its stack pointer incremented
 # as part of our indirect call spec.
 
-set -x
-
 run () {
   bap wp \
     --func=indirect_call \

--- a/wp/resources/sample_binaries/init_var/run_wp.sh
+++ b/wp/resources/sample_binaries/init_var/run_wp.sh
@@ -5,8 +5,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=foo \

--- a/wp/resources/sample_binaries/init_var/run_wp.sh
+++ b/wp/resources/sample_binaries/init_var/run_wp.sh
@@ -7,10 +7,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=foo \

--- a/wp/resources/sample_binaries/init_var/run_wp.sh
+++ b/wp/resources/sample_binaries/init_var/run_wp.sh
@@ -18,4 +18,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/init_var/run_wp_sat.sh
+++ b/wp/resources/sample_binaries/init_var/run_wp_sat.sh
@@ -8,10 +8,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=foo \

--- a/wp/resources/sample_binaries/init_var/run_wp_sat.sh
+++ b/wp/resources/sample_binaries/init_var/run_wp_sat.sh
@@ -6,8 +6,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=foo \

--- a/wp/resources/sample_binaries/init_var/run_wp_sat.sh
+++ b/wp/resources/sample_binaries/init_var/run_wp_sat.sh
@@ -19,4 +19,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/init_var_compare/run_wp.sh
+++ b/wp/resources/sample_binaries/init_var_compare/run_wp.sh
@@ -7,8 +7,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/init_var_compare/run_wp.sh
+++ b/wp/resources/sample_binaries/init_var_compare/run_wp.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/init_var_compare/run_wp.sh
+++ b/wp/resources/sample_binaries/init_var_compare/run_wp.sh
@@ -22,4 +22,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/init_var_compare/run_wp_sat.sh
+++ b/wp/resources/sample_binaries/init_var_compare/run_wp_sat.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/init_var_compare/run_wp_sat.sh
+++ b/wp/resources/sample_binaries/init_var_compare/run_wp_sat.sh
@@ -22,4 +22,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/init_var_compare/run_wp_sat.sh
+++ b/wp/resources/sample_binaries/init_var_compare/run_wp_sat.sh
@@ -7,8 +7,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/linked_list/run_wp.sh
+++ b/wp/resources/sample_binaries/linked_list/run_wp.sh
@@ -6,8 +6,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=create_linked_list \

--- a/wp/resources/sample_binaries/linked_list/run_wp.sh
+++ b/wp/resources/sample_binaries/linked_list/run_wp.sh
@@ -18,4 +18,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/linked_list/run_wp.sh
+++ b/wp/resources/sample_binaries/linked_list/run_wp.sh
@@ -8,10 +8,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=create_linked_list \

--- a/wp/resources/sample_binaries/linked_list/run_wp_null_deref.sh
+++ b/wp/resources/sample_binaries/linked_list/run_wp_null_deref.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=create_linked_list \

--- a/wp/resources/sample_binaries/linked_list/run_wp_null_deref.sh
+++ b/wp/resources/sample_binaries/linked_list/run_wp_null_deref.sh
@@ -20,4 +20,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/linked_list/run_wp_null_deref.sh
+++ b/wp/resources/sample_binaries/linked_list/run_wp_null_deref.sh
@@ -7,8 +7,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=create_linked_list \

--- a/wp/resources/sample_binaries/loop/run_wp.sh
+++ b/wp/resources/sample_binaries/loop/run_wp.sh
@@ -7,8 +7,6 @@
 
 # Should return SAT
 
-set -x
-
 run() {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/loop/run_wp.sh
+++ b/wp/resources/sample_binaries/loop/run_wp.sh
@@ -21,4 +21,4 @@ run() {
     -- main
 }
 
-compile && run
+clean && run

--- a/wp/resources/sample_binaries/loop/run_wp.sh
+++ b/wp/resources/sample_binaries/loop/run_wp.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile() {
-  make
-}
-
 run() {
   bap wp \
     --func=main \
@@ -21,4 +17,4 @@ run() {
     -- main
 }
 
-clean && run
+run

--- a/wp/resources/sample_binaries/memory_samples/arrays/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/arrays/run_wp.sh
@@ -7,8 +7,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=foo_get \

--- a/wp/resources/sample_binaries/memory_samples/arrays/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/arrays/run_wp.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=foo_get \

--- a/wp/resources/sample_binaries/memory_samples/arrays/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/arrays/run_wp.sh
@@ -20,4 +20,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/memory_samples/arrays/run_wp_mem_offset.sh
+++ b/wp/resources/sample_binaries/memory_samples/arrays/run_wp_mem_offset.sh
@@ -8,8 +8,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=foo_get \

--- a/wp/resources/sample_binaries/memory_samples/arrays/run_wp_mem_offset.sh
+++ b/wp/resources/sample_binaries/memory_samples/arrays/run_wp_mem_offset.sh
@@ -22,4 +22,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/memory_samples/arrays/run_wp_mem_offset.sh
+++ b/wp/resources/sample_binaries/memory_samples/arrays/run_wp_mem_offset.sh
@@ -10,10 +10,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=foo_get \

--- a/wp/resources/sample_binaries/memory_samples/arrays/run_wp_pre.sh
+++ b/wp/resources/sample_binaries/memory_samples/arrays/run_wp_pre.sh
@@ -9,8 +9,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=foo_get \

--- a/wp/resources/sample_binaries/memory_samples/arrays/run_wp_pre.sh
+++ b/wp/resources/sample_binaries/memory_samples/arrays/run_wp_pre.sh
@@ -11,10 +11,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=foo_get \

--- a/wp/resources/sample_binaries/memory_samples/arrays/run_wp_pre.sh
+++ b/wp/resources/sample_binaries/memory_samples/arrays/run_wp_pre.sh
@@ -23,4 +23,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/memory_samples/arrays/run_wp_pre_mem_offset.sh
+++ b/wp/resources/sample_binaries/memory_samples/arrays/run_wp_pre_mem_offset.sh
@@ -7,8 +7,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=foo_get \

--- a/wp/resources/sample_binaries/memory_samples/arrays/run_wp_pre_mem_offset.sh
+++ b/wp/resources/sample_binaries/memory_samples/arrays/run_wp_pre_mem_offset.sh
@@ -22,4 +22,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/memory_samples/arrays/run_wp_pre_mem_offset.sh
+++ b/wp/resources/sample_binaries/memory_samples/arrays/run_wp_pre_mem_offset.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=foo_get \

--- a/wp/resources/sample_binaries/memory_samples/data_bss_sections/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/data_bss_sections/run_wp.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/memory_samples/data_bss_sections/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/data_bss_sections/run_wp.sh
@@ -7,8 +7,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/memory_samples/data_bss_sections/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/data_bss_sections/run_wp.sh
@@ -20,4 +20,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/memory_samples/data_bss_sections/run_wp_mem_offset.sh
+++ b/wp/resources/sample_binaries/memory_samples/data_bss_sections/run_wp_mem_offset.sh
@@ -7,8 +7,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/memory_samples/data_bss_sections/run_wp_mem_offset.sh
+++ b/wp/resources/sample_binaries/memory_samples/data_bss_sections/run_wp_mem_offset.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/memory_samples/data_bss_sections/run_wp_mem_offset.sh
+++ b/wp/resources/sample_binaries/memory_samples/data_bss_sections/run_wp_mem_offset.sh
@@ -21,4 +21,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/memory_samples/diff_data/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/diff_data/run_wp.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/memory_samples/diff_data/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/diff_data/run_wp.sh
@@ -21,4 +21,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/memory_samples/diff_data/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/diff_data/run_wp.sh
@@ -7,8 +7,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/memory_samples/diff_data_location/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/diff_data_location/run_wp.sh
@@ -10,10 +10,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/memory_samples/diff_data_location/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/diff_data_location/run_wp.sh
@@ -8,8 +8,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/memory_samples/diff_data_location/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/diff_data_location/run_wp.sh
@@ -22,4 +22,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/memory_samples/diff_data_location/run_wp_mem_offset.sh
+++ b/wp/resources/sample_binaries/memory_samples/diff_data_location/run_wp_mem_offset.sh
@@ -21,4 +21,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/memory_samples/diff_data_location/run_wp_mem_offset.sh
+++ b/wp/resources/sample_binaries/memory_samples/diff_data_location/run_wp_mem_offset.sh
@@ -8,10 +8,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/memory_samples/diff_data_location/run_wp_mem_offset.sh
+++ b/wp/resources/sample_binaries/memory_samples/diff_data_location/run_wp_mem_offset.sh
@@ -6,8 +6,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/memory_samples/diff_stack/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/diff_stack/run_wp.sh
@@ -17,4 +17,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/memory_samples/diff_stack/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/diff_stack/run_wp.sh
@@ -3,8 +3,6 @@
 
 # Should return SAT.
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/memory_samples/diff_stack/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/diff_stack/run_wp.sh
@@ -5,10 +5,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/memory_samples/name_matching/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/name_matching/run_wp.sh
@@ -8,10 +8,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/memory_samples/name_matching/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/name_matching/run_wp.sh
@@ -20,4 +20,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/memory_samples/name_matching/run_wp.sh
+++ b/wp/resources/sample_binaries/memory_samples/name_matching/run_wp.sh
@@ -6,8 +6,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/nested_function_calls/run_wp.sh
+++ b/wp/resources/sample_binaries/nested_function_calls/run_wp.sh
@@ -5,8 +5,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/nested_function_calls/run_wp.sh
+++ b/wp/resources/sample_binaries/nested_function_calls/run_wp.sh
@@ -18,4 +18,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/nested_function_calls/run_wp.sh
+++ b/wp/resources/sample_binaries/nested_function_calls/run_wp.sh
@@ -7,10 +7,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_all.sh
+++ b/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_all.sh
@@ -5,8 +5,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_all.sh
+++ b/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_all.sh
@@ -19,4 +19,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_all.sh
+++ b/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_all.sh
@@ -7,10 +7,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_regex.sh
+++ b/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_regex.sh
@@ -5,8 +5,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_regex.sh
+++ b/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_regex.sh
@@ -19,4 +19,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_regex.sh
+++ b/wp/resources/sample_binaries/nested_function_calls/run_wp_inline_regex.sh
@@ -7,10 +7,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/nested_ifs/run_wp.sh
+++ b/wp/resources/sample_binaries/nested_ifs/run_wp.sh
@@ -9,8 +9,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=nestedIfExample \

--- a/wp/resources/sample_binaries/nested_ifs/run_wp.sh
+++ b/wp/resources/sample_binaries/nested_ifs/run_wp.sh
@@ -22,4 +22,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/nested_ifs/run_wp.sh
+++ b/wp/resources/sample_binaries/nested_ifs/run_wp.sh
@@ -11,10 +11,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=nestedIfExample \

--- a/wp/resources/sample_binaries/nested_ifs/run_wp_goto.sh
+++ b/wp/resources/sample_binaries/nested_ifs/run_wp_goto.sh
@@ -22,4 +22,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/nested_ifs/run_wp_goto.sh
+++ b/wp/resources/sample_binaries/nested_ifs/run_wp_goto.sh
@@ -9,8 +9,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=gotoExample \

--- a/wp/resources/sample_binaries/nested_ifs/run_wp_goto.sh
+++ b/wp/resources/sample_binaries/nested_ifs/run_wp_goto.sh
@@ -11,10 +11,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=gotoExample \

--- a/wp/resources/sample_binaries/nested_ifs/run_wp_inline.sh
+++ b/wp/resources/sample_binaries/nested_ifs/run_wp_inline.sh
@@ -5,8 +5,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/nested_ifs/run_wp_inline.sh
+++ b/wp/resources/sample_binaries/nested_ifs/run_wp_inline.sh
@@ -19,4 +19,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/nested_ifs/run_wp_inline.sh
+++ b/wp/resources/sample_binaries/nested_ifs/run_wp_inline.sh
@@ -7,10 +7,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/no_position_independent/run_wp.sh
+++ b/wp/resources/sample_binaries/no_position_independent/run_wp.sh
@@ -6,10 +6,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=example \

--- a/wp/resources/sample_binaries/no_position_independent/run_wp.sh
+++ b/wp/resources/sample_binaries/no_position_independent/run_wp.sh
@@ -18,4 +18,4 @@ run () {
     -- main_1.so main_2.so
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/no_position_independent/run_wp.sh
+++ b/wp/resources/sample_binaries/no_position_independent/run_wp.sh
@@ -4,8 +4,6 @@
 
 # Should return SAT.
 
-set -x
-
 run () {
   bap wp \
     --func=example \

--- a/wp/resources/sample_binaries/no_stack_protection/run_wp.sh
+++ b/wp/resources/sample_binaries/no_stack_protection/run_wp.sh
@@ -15,4 +15,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/no_stack_protection/run_wp.sh
+++ b/wp/resources/sample_binaries/no_stack_protection/run_wp.sh
@@ -4,10 +4,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/no_stack_protection/run_wp.sh
+++ b/wp/resources/sample_binaries/no_stack_protection/run_wp.sh
@@ -2,8 +2,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/non_null_check/run_wp.sh
+++ b/wp/resources/sample_binaries/non_null_check/run_wp.sh
@@ -7,8 +7,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/non_null_check/run_wp.sh
+++ b/wp/resources/sample_binaries/non_null_check/run_wp.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/non_null_check/run_wp.sh
+++ b/wp/resources/sample_binaries/non_null_check/run_wp.sh
@@ -21,4 +21,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/non_null_check/run_wp_null_deref.sh
+++ b/wp/resources/sample_binaries/non_null_check/run_wp_null_deref.sh
@@ -11,10 +11,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/non_null_check/run_wp_null_deref.sh
+++ b/wp/resources/sample_binaries/non_null_check/run_wp_null_deref.sh
@@ -24,4 +24,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/non_null_check/run_wp_null_deref.sh
+++ b/wp/resources/sample_binaries/non_null_check/run_wp_null_deref.sh
@@ -9,8 +9,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/nqueens/run_wp.sh
+++ b/wp/resources/sample_binaries/nqueens/run_wp.sh
@@ -3,8 +3,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=encode_nqueens \

--- a/wp/resources/sample_binaries/nqueens/run_wp.sh
+++ b/wp/resources/sample_binaries/nqueens/run_wp.sh
@@ -5,10 +5,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=encode_nqueens \
@@ -18,4 +14,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/null_deref/run_wp.sh
+++ b/wp/resources/sample_binaries/null_deref/run_wp.sh
@@ -8,10 +8,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/null_deref/run_wp.sh
+++ b/wp/resources/sample_binaries/null_deref/run_wp.sh
@@ -18,4 +18,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/null_deref/run_wp.sh
+++ b/wp/resources/sample_binaries/null_deref/run_wp.sh
@@ -6,8 +6,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/null_deref/run_wp_null_deref.sh
+++ b/wp/resources/sample_binaries/null_deref/run_wp_null_deref.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/null_deref/run_wp_null_deref.sh
+++ b/wp/resources/sample_binaries/null_deref/run_wp_null_deref.sh
@@ -20,4 +20,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/null_deref/run_wp_null_deref.sh
+++ b/wp/resources/sample_binaries/null_deref/run_wp_null_deref.sh
@@ -7,8 +7,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/pointer_input/run_wp.sh
+++ b/wp/resources/sample_binaries/pointer_input/run_wp.sh
@@ -3,8 +3,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/pointer_input/run_wp.sh
+++ b/wp/resources/sample_binaries/pointer_input/run_wp.sh
@@ -17,4 +17,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/pointer_input/run_wp.sh
+++ b/wp/resources/sample_binaries/pointer_input/run_wp.sh
@@ -5,10 +5,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/position_independent/run_wp.sh
+++ b/wp/resources/sample_binaries/position_independent/run_wp.sh
@@ -18,4 +18,4 @@ run () {
     -- main_1.so main_2.so
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/position_independent/run_wp.sh
+++ b/wp/resources/sample_binaries/position_independent/run_wp.sh
@@ -4,8 +4,6 @@
 
 # Should return SAT.
 
-set -x
-
 run () {
   bap wp \
     --func=example \

--- a/wp/resources/sample_binaries/position_independent/run_wp.sh
+++ b/wp/resources/sample_binaries/position_independent/run_wp.sh
@@ -6,10 +6,6 @@
 
 set -x
 
-compile () {
-  make FLAGS="-fPIC -shared"
-}
-
 run () {
   bap wp \
     --func=example \

--- a/wp/resources/sample_binaries/retrowrite_stub/run_wp.sh
+++ b/wp/resources/sample_binaries/retrowrite_stub/run_wp.sh
@@ -7,8 +7,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/retrowrite_stub/run_wp.sh
+++ b/wp/resources/sample_binaries/retrowrite_stub/run_wp.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/retrowrite_stub/run_wp.sh
+++ b/wp/resources/sample_binaries/retrowrite_stub/run_wp.sh
@@ -21,4 +21,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/retrowrite_stub/run_wp_inline_afl.sh
+++ b/wp/resources/sample_binaries/retrowrite_stub/run_wp_inline_afl.sh
@@ -7,8 +7,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/retrowrite_stub/run_wp_inline_afl.sh
+++ b/wp/resources/sample_binaries/retrowrite_stub/run_wp_inline_afl.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/retrowrite_stub/run_wp_inline_afl.sh
+++ b/wp/resources/sample_binaries/retrowrite_stub/run_wp_inline_afl.sh
@@ -22,4 +22,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/retrowrite_stub/run_wp_inline_all.sh
+++ b/wp/resources/sample_binaries/retrowrite_stub/run_wp_inline_all.sh
@@ -7,8 +7,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/retrowrite_stub/run_wp_inline_all.sh
+++ b/wp/resources/sample_binaries/retrowrite_stub/run_wp_inline_all.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/retrowrite_stub/run_wp_inline_all.sh
+++ b/wp/resources/sample_binaries/retrowrite_stub/run_wp_inline_all.sh
@@ -22,4 +22,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/retrowrite_stub_no_ret/run_wp.sh
+++ b/wp/resources/sample_binaries/retrowrite_stub_no_ret/run_wp.sh
@@ -7,8 +7,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/retrowrite_stub_no_ret/run_wp.sh
+++ b/wp/resources/sample_binaries/retrowrite_stub_no_ret/run_wp.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/retrowrite_stub_no_ret/run_wp.sh
+++ b/wp/resources/sample_binaries/retrowrite_stub_no_ret/run_wp.sh
@@ -21,4 +21,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/return_argc/run_wp.sh
+++ b/wp/resources/sample_binaries/return_argc/run_wp.sh
@@ -5,8 +5,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/return_argc/run_wp.sh
+++ b/wp/resources/sample_binaries/return_argc/run_wp.sh
@@ -18,4 +18,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/return_argc/run_wp.sh
+++ b/wp/resources/sample_binaries/return_argc/run_wp.sh
@@ -7,10 +7,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/rop_example/run_wp.sh
+++ b/wp/resources/sample_binaries/rop_example/run_wp.sh
@@ -17,4 +17,4 @@ run () {
     -- main-original main-rop
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/rop_example/run_wp.sh
+++ b/wp/resources/sample_binaries/rop_example/run_wp.sh
@@ -3,8 +3,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/rop_example/run_wp.sh
+++ b/wp/resources/sample_binaries/rop_example/run_wp.sh
@@ -5,10 +5,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/same_signs/run_wp.sh
+++ b/wp/resources/sample_binaries/same_signs/run_wp.sh
@@ -12,10 +12,6 @@
 set -x
 
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=same_signs \

--- a/wp/resources/sample_binaries/same_signs/run_wp.sh
+++ b/wp/resources/sample_binaries/same_signs/run_wp.sh
@@ -9,9 +9,6 @@
 
 # Should return UNSAT.
 
-set -x
-
-
 run () {
   bap wp \
     --func=same_signs \

--- a/wp/resources/sample_binaries/same_signs/run_wp.sh
+++ b/wp/resources/sample_binaries/same_signs/run_wp.sh
@@ -23,4 +23,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/same_signs/run_wp_postcond.sh
+++ b/wp/resources/sample_binaries/same_signs/run_wp_postcond.sh
@@ -9,8 +9,6 @@
 
 # Should return UNSAT.
 
-set -x
-
 run () {
   bap wp \
     --func=same_signs \

--- a/wp/resources/sample_binaries/same_signs/run_wp_postcond.sh
+++ b/wp/resources/sample_binaries/same_signs/run_wp_postcond.sh
@@ -11,8 +11,6 @@
 
 set -x
 
-dummy_dir=../dummy
-
 run () {
   bap wp \
     --func=same_signs \

--- a/wp/resources/sample_binaries/same_signs/run_wp_postcond.sh
+++ b/wp/resources/sample_binaries/same_signs/run_wp_postcond.sh
@@ -24,4 +24,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/same_signs/run_wp_postcond.sh
+++ b/wp/resources/sample_binaries/same_signs/run_wp_postcond.sh
@@ -13,10 +13,6 @@ set -x
 
 dummy_dir=../dummy
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=same_signs \

--- a/wp/resources/sample_binaries/simple_wp/run_wp.sh
+++ b/wp/resources/sample_binaries/simple_wp/run_wp.sh
@@ -5,8 +5,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/simple_wp/run_wp.sh
+++ b/wp/resources/sample_binaries/simple_wp/run_wp.sh
@@ -18,4 +18,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/simple_wp/run_wp.sh
+++ b/wp/resources/sample_binaries/simple_wp/run_wp.sh
@@ -7,10 +7,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/simple_wp/run_wp_pre.sh
+++ b/wp/resources/sample_binaries/simple_wp/run_wp_pre.sh
@@ -5,8 +5,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/simple_wp/run_wp_pre.sh
+++ b/wp/resources/sample_binaries/simple_wp/run_wp_pre.sh
@@ -18,4 +18,4 @@ run () {
     -- main
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/simple_wp/run_wp_pre.sh
+++ b/wp/resources/sample_binaries/simple_wp/run_wp_pre.sh
@@ -7,10 +7,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/sudoku/run_wp.sh
+++ b/wp/resources/sample_binaries/sudoku/run_wp.sh
@@ -6,8 +6,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=sudoku_solver \

--- a/wp/resources/sample_binaries/sudoku/run_wp.sh
+++ b/wp/resources/sample_binaries/sudoku/run_wp.sh
@@ -8,10 +8,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=sudoku_solver \

--- a/wp/resources/sample_binaries/switch_case_assignments/run_wp.sh
+++ b/wp/resources/sample_binaries/switch_case_assignments/run_wp.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=process_status \

--- a/wp/resources/sample_binaries/switch_case_assignments/run_wp.sh
+++ b/wp/resources/sample_binaries/switch_case_assignments/run_wp.sh
@@ -7,8 +7,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=process_status \

--- a/wp/resources/sample_binaries/switch_case_assignments/run_wp.sh
+++ b/wp/resources/sample_binaries/switch_case_assignments/run_wp.sh
@@ -20,4 +20,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/switch_cases/run_wp.sh
+++ b/wp/resources/sample_binaries/switch_cases/run_wp.sh
@@ -9,10 +9,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=process_message \

--- a/wp/resources/sample_binaries/switch_cases/run_wp.sh
+++ b/wp/resources/sample_binaries/switch_cases/run_wp.sh
@@ -7,8 +7,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=process_message \

--- a/wp/resources/sample_binaries/switch_cases/run_wp.sh
+++ b/wp/resources/sample_binaries/switch_cases/run_wp.sh
@@ -20,4 +20,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/switch_cases_diff_ret/run_wp.sh
+++ b/wp/resources/sample_binaries/switch_cases_diff_ret/run_wp.sh
@@ -9,8 +9,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=process_message \

--- a/wp/resources/sample_binaries/switch_cases_diff_ret/run_wp.sh
+++ b/wp/resources/sample_binaries/switch_cases_diff_ret/run_wp.sh
@@ -13,10 +13,6 @@ set -x
 
 dummy_dir=../dummy
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=process_message \

--- a/wp/resources/sample_binaries/switch_cases_diff_ret/run_wp.sh
+++ b/wp/resources/sample_binaries/switch_cases_diff_ret/run_wp.sh
@@ -11,8 +11,6 @@
 
 set -x
 
-dummy_dir=../dummy
-
 run () {
   bap wp \
     --func=process_message \

--- a/wp/resources/sample_binaries/switch_cases_diff_ret/run_wp.sh
+++ b/wp/resources/sample_binaries/switch_cases_diff_ret/run_wp.sh
@@ -25,4 +25,4 @@ run () {
     -- main_1 main_2
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/verifier_calls/run_wp_assume_sat.sh
+++ b/wp/resources/sample_binaries/verifier_calls/run_wp_assume_sat.sh
@@ -3,8 +3,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/verifier_calls/run_wp_assume_sat.sh
+++ b/wp/resources/sample_binaries/verifier_calls/run_wp_assume_sat.sh
@@ -16,4 +16,4 @@ run () {
     -- verifier_assume_sat
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/verifier_calls/run_wp_assume_sat.sh
+++ b/wp/resources/sample_binaries/verifier_calls/run_wp_assume_sat.sh
@@ -5,10 +5,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/verifier_calls/run_wp_assume_unsat.sh
+++ b/wp/resources/sample_binaries/verifier_calls/run_wp_assume_unsat.sh
@@ -16,4 +16,4 @@ run () {
     -- verifier_assume_unsat
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/verifier_calls/run_wp_assume_unsat.sh
+++ b/wp/resources/sample_binaries/verifier_calls/run_wp_assume_unsat.sh
@@ -3,8 +3,6 @@
 
 # Should return UNSAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/verifier_calls/run_wp_assume_unsat.sh
+++ b/wp/resources/sample_binaries/verifier_calls/run_wp_assume_unsat.sh
@@ -5,10 +5,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/verifier_calls/run_wp_nondet.sh
+++ b/wp/resources/sample_binaries/verifier_calls/run_wp_nondet.sh
@@ -17,4 +17,4 @@ run () {
     -- verifier_nondet
 }
 
-compile && run
+run

--- a/wp/resources/sample_binaries/verifier_calls/run_wp_nondet.sh
+++ b/wp/resources/sample_binaries/verifier_calls/run_wp_nondet.sh
@@ -4,8 +4,6 @@
 
 # Should return SAT
 
-set -x
-
 run () {
   bap wp \
     --func=main \

--- a/wp/resources/sample_binaries/verifier_calls/run_wp_nondet.sh
+++ b/wp/resources/sample_binaries/verifier_calls/run_wp_nondet.sh
@@ -6,10 +6,6 @@
 
 set -x
 
-compile () {
-  make
-}
-
 run () {
   bap wp \
     --func=main \


### PR DESCRIPTION
This PR addresses issue #108 . Notable changes include:
- Correcting nondeterminstic first run. This is done by replacing all occurrences of `compile && run` with `run` in all `run_wp*` scripts. The compilation is instead done in parallel before tests are run.
- `memory_samples` makefiles now include all targets.
- `make clean` can be run multiple times in a row. This is done by adding the `-f` flag everywhere.
- `cd wp && make` still reinstalls everything, even if it is already installed. This is nearly instantaneous. It's not clear to me how to tell, without directly diffing libraries, whether or 
- The PR also reorganizes a bunch of targets. Specifically:
   - clean now also cleans the `resources/sample_binaries/` directory
   - `wp`'s default target is `make install`
   - the ordering of `wp`'s `install` target goes as follows:
     - attempt to uninstall plugin
     - build library (makes use of dune and make cache)
     - reinstall library
     - build plugin (makes use of bapbuild and make cache)
     - reinstall plugin
   - the plugin and library are only rebuilt if there are changes to `src/*.ml` and `src/*.mli` files, and `wp.ml`, respectively.