### PR TITLE
Fortunac/err handling

### DIFF
--- a/wp/plugin/lib/analysis.mli
+++ b/wp/plugin/lib/analysis.mli
@@ -22,6 +22,6 @@ open Bap_main
 
 (** [run params files ctxt] is the main entrypoint for WP. Based on the length
     of [files], it will run either a single or comparative analysis. If 0 or
-    more than 2 files are given, no analysis will be run. [params] sets the
+    more than 2 files are given, an error is returned. [params] sets the
     properties WP will check and update default options. *)
-val run : Parameters.t -> string list -> ctxt -> unit
+val run : Parameters.t -> string list -> ctxt -> (unit, error) result

--- a/wp/plugin/lib/parameters.ml
+++ b/wp/plugin/lib/parameters.ml
@@ -12,8 +12,22 @@
 (***************************************************************************)
 
 open !Core_kernel
+open Bap_main
+open Monads.Std
 
-exception Invalid_input
+(* Error for when a user does not specify a function to analyze. *)
+type Extension.Error.t += Missing_function of string
+
+(* Error for passing an unsupported option to a flag that takes in a list of
+   options. *)
+type Extension.Error.t += Unsupported_option of string
+
+(* Error for passing in a comparison flag when there is only one file to
+   analyze and vice versa. *)
+type Extension.Error.t += Incompatible_flag of string
+
+module Err = Monad.Result.Make(Extension.Error)(Monad.Ident)
+open Err.Syntax
 
 type t = {
   func : string;
@@ -36,78 +50,74 @@ type t = {
 }
 
 (* Ensures the user inputted a function for analysis. *)
-let validate_func (func : string) : unit =
-  if String.is_empty func then begin
-    Printf.printf "Function is not provided for analysis. Usage: \
-                   --func=<name>\n%!";
-    raise Invalid_input
-  end else
-    ()
+let validate_func (func : string) : (unit, error) result =
+  let err = Printf.sprintf "Function is not provided for analysis. Usage: \
+                            --func=<name>%!" in
+  Result.ok_if_true (not @@ String.is_empty func)
+    ~error:(Missing_function err)
 
-(* Looks for an invalid option among the options the user inputted. *)
-let find_invalid_option (opts : string list) (valid : string list)
+
+(* Looks for an unsupported option among the options the user inputted. *)
+let find_unsupported_option (opts : string list) (valid : string list)
   : string option =
   List.find opts ~f:(fun opt ->
       not @@ List.mem valid opt ~equal:String.equal)
 
 (* Ensures the user inputted only supported options for the debug flag. *)
-let validate_debug (debug : string list) : unit =
-  let valid = [
+let validate_debug (debug : string list) : (unit, error) result =
+  let supported = [
     "z3-solver-stats";
     "z3-verbose";
     "constraint-stats";
     "eval-constraint-stats"
   ] in
-  match find_invalid_option debug valid with
+  match find_unsupported_option debug supported with
   | Some s ->
-    Printf.printf "'%s' is not a valid option for --debug. Available options \
-                   are: %s\n%!" s (List.to_string valid ~f:String.to_string);
-    raise Invalid_input
-  | None -> ()
+    let err = Printf.sprintf "'%s' is not a supported option for --debug. \
+                              Available options are: %s%!"
+        s (List.to_string supported ~f:String.to_string) in
+    Error (Unsupported_option err)
+  | None -> Ok ()
 
 (* Ensures the user inputted only supported options for the show flag. *)
-let validate_show (show : string list) : unit =
-  let valid = [
+let validate_show (show : string list) : (unit, error) result =
+  let supported = [
     "bir";
     "refuted-goals";
     "paths";
     "precond-internal";
     "precond-smtlib"
   ] in
-  match find_invalid_option show valid with
+  match find_unsupported_option show supported with
   | Some s ->
-    Printf.printf "'%s' is not a valid option for --show. Available options \
-                   are: %s\n%!" s (List.to_string valid ~f:String.to_string);
-    raise Invalid_input
-  | None -> ()
+    let err = Printf.sprintf "'%s' is not a supported option for --show. \
+                              Available options are: %s%!"
+        s (List.to_string supported ~f:String.to_string) in
+    Error (Unsupported_option err)
+  | None -> Ok ()
 
 (* Ensures the user passed in two files to compare function calls. *)
-let validate_compare_func_calls (flag : bool) (files : string list) : unit =
-  if flag && (List.length files <> 2) then begin
-    Printf.printf "--compare-func-calls is only used for a comparative \
-                   analysis. Please specify two files. Number of files \
-                   given: %d\n%!" (List.length files);
-    raise Invalid_input
-  end else
-    ()
+let validate_compare_func_calls (flag : bool) (files : string list)
+  : (unit, error) result =
+  let err = Printf.sprintf "--compare-func-calls is only used for a \
+                            comparative analysis. Please specify two files. \
+                            Number of files given: %d%!" (List.length files) in
+  Result.ok_if_true ((not flag) || (List.length files = 2))
+    ~error:(Incompatible_flag err)
 
 (* Ensures the user passed in two files to compare post register values. *)
 let validate_compare_post_reg_vals (regs : string list) (files : string list)
-  : unit =
-  if (not @@ List.is_empty regs) && (List.length files <> 2) then begin
-    Printf.printf "--compare-post-reg-values is only used for a comparative \
-                   analysis. Please specify two files. Number of files \
-                   given: %d\n%!" (List.length files);
-    raise Invalid_input
-  end else
-    ()
+  : (unit, error) result =
+  let err = Printf.sprintf "--compare-post-reg-values is only used for a \
+                            comparative analysis. Please specify two files. \
+                            Number of files given: %d%!" (List.length files) in
+  Result.ok_if_true ((List.is_empty regs) || (List.length files = 2))
+    ~error:(Incompatible_flag err)
 
-let validate (f : t) (files : string list) : unit =
-  try begin
-    validate_func f.func;
-    validate_compare_func_calls f.compare_func_calls files;
-    validate_compare_post_reg_vals f.compare_post_reg_values files;
-    validate_debug f.debug;
-    validate_show f.show
-  end with Invalid_input ->
-    exit 1
+let validate (f : t) (files : string list) : (unit, error) result =
+  validate_func f.func >>= fun () ->
+  validate_compare_func_calls f.compare_func_calls files >>= fun () ->
+  validate_compare_post_reg_vals f.compare_post_reg_values files >>= fun () ->
+  validate_debug f.debug >>= fun () ->
+  validate_show f.show >>= fun () ->
+  Ok ()

--- a/wp/plugin/lib/parameters.mli
+++ b/wp/plugin/lib/parameters.mli
@@ -19,10 +19,16 @@
 
 *)
 
-(** An exception that is raised when a user inputs an invalid options to a
-    parameter or when the inputted parameters are not compatible to with each
-    other. *)
-exception Invalid_input
+open Bap_main
+open Monads.Std
+
+(** A result monad that includes Extension.Error.t as the error type. This
+    error is returned when a user passes in an invalid parameter. *)
+module Err : Monad.Result.S with
+  type 'a t := 'a Monad.Result.T1(Extension.Error)(Monad.Ident).t and
+  type 'a m := 'a Monad.Result.T1(Extension.Error)(Monad.Ident).m and
+  type 'a e := 'a Monad.Result.T1(Extension.Error)(Monad.Ident).e and
+  type err := Extension.Error.t
 
 (** The available options to be set. Each flag corresponds to a parameter in
     the set with the BAP custom command line. *)
@@ -47,29 +53,30 @@ type t = {
 }
 
 (** [validate flags files] ensures the user inputted the appropriate flags for
-    the inputted [files]. In the case the user has invalid flags, an error
-    message will print and WP will exit. *)
-val validate : t -> string list -> unit
+    the inputted [files]. In the case the user has invalid flags, an error is
+    returned. *)
+val validate : t -> string list -> (unit, error) result
 
 (** [validate_func name] checks the user inputted a [name] for the function to
-    analyze. Raises {!Invalid_input} when [name] is empty. *)
-val validate_func : string -> unit
+    analyze. Returns an error when [name] is empty. *)
+val validate_func : string -> (unit, error) result
 
 (** [validate_debug options] checks the user inputted the supported options for
-    the debug printer flag. Raises {!Invalid_input} when an unsupported option
-    is inputted. *)
-val validate_debug : string list -> unit
+    the debug printer flag. Returns an error when an unsupported option is
+    inputted. *)
+val validate_debug : string list -> (unit, error) result
 
 (** [validate_show options] checks the user inputted the supported options for
-    the show printer flag. Raises {!Invalid_input} when an unsupported option
-    is inputted. *)
-val validate_show : string list -> unit
+    the show printer flag. Returns an error when an unsupported option is
+    inputted. *)
+val validate_show : string list -> (unit, error) result
 
 (** [validate_compare_func_calls flag files] checks that the flag is only set
-    when there are two files to compare. Raises {!Invalid_input} otherwise. *)
-val validate_compare_func_calls : bool -> string list -> unit
+    when there are two files to compare. Returns an error otherwise. *)
+val validate_compare_func_calls : bool -> string list -> (unit, error) result
 
 (** [validate_compare_post_reg_vals regs files] checks that the list of
     registers to compare is only set when there are two files to compare.
-    Raises {!Invalid_input} otherwise. *)
-val validate_compare_post_reg_vals : string list -> string list -> unit
+    Returns an error otherwise. *)
+val validate_compare_post_reg_vals :
+  string list -> string list -> (unit, error) result

--- a/wp/plugin/tests/test_parameters.ml
+++ b/wp/plugin/tests/test_parameters.ml
@@ -11,9 +11,10 @@
 (*                                                                         *)
 (***************************************************************************)
 
-open !Core_kernel
 open OUnit2
 open OUnitTest
+open !Core_kernel
+open Bap_main
 
 module Params = Parameters
 
@@ -22,41 +23,39 @@ module Params = Parameters
 let test_validate_input
     ?length:(length = Immediate)
     ~valid:(valid : bool)
-    (validator : unit -> 'a)
+    (res : (unit, error) result)
    : test =
-  let test _ =
-    if not valid then
-      assert_raises Params.Invalid_input validator
-    else
-      validator ()
+  let test _ = match res with
+    | Error _ -> assert_bool "Returned an error when params are valid" (not valid)
+    | Ok () -> assert_bool "Should have returned an error for an invalid param" valid
   in
   test_case ~length test
 
 let suite = [
 
   "No function specified" >: test_validate_input ~valid:false
-    (fun () -> Params.validate_func "");
+    (Params.validate_func "");
   "Function specified" >: test_validate_input ~valid:true
-    (fun () -> Params.validate_func "main");
+    (Params.validate_func "main");
 
   "Invalid option for debug" >: test_validate_input ~valid:false
-    (fun () -> Params.validate_debug ["foo"]);
+    (Params.validate_debug ["foo"]);
   "Valid option for debug" >: test_validate_input ~valid:true
-    (fun () -> Params.validate_debug ["z3-solver-stats"]);
+    (Params.validate_debug ["z3-solver-stats"]);
 
   "Invalid option for show" >: test_validate_input ~valid:false
-    (fun () -> Params.validate_show ["foo"]);
+    (Params.validate_show ["foo"]);
   "Valid option for debug" >: test_validate_input ~valid:true
-    (fun () -> Params.validate_show ["bir"]);
+    (Params.validate_show ["bir"]);
 
   "One file for compare_func_calls" >: test_validate_input ~valid:false
-    (fun () -> Params.validate_compare_func_calls true ["exe1"]);
+    (Params.validate_compare_func_calls true ["exe1"]);
   "Two files for compare_func_calls" >: test_validate_input ~valid:true
-    (fun () -> Params.validate_compare_func_calls true ["exe1"; "exe2"]);
+    (Params.validate_compare_func_calls true ["exe1"; "exe2"]);
 
   "One file for compare_post_reg_values" >: test_validate_input ~valid:false
-    (fun () -> Params.validate_compare_post_reg_vals ["x"] ["exe1"]);
+    (Params.validate_compare_post_reg_vals ["x"] ["exe1"]);
   "Two files for compare_post_reg_values" >: test_validate_input ~valid:true
-    (fun () -> Params.validate_compare_post_reg_vals ["x"] ["exe1"; "exe2"]);
+    (Params.validate_compare_post_reg_vals ["x"] ["exe1"; "exe2"]);
 
 ]

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -12,6 +12,7 @@
 (***************************************************************************)
 
 open Bap_main
+open Parameters.Err.Syntax
 
 module Cmd = Extension.Command
 module Typ = Extension.Type
@@ -224,8 +225,8 @@ let callback
       stack_size = stack_size
     })
   in
-  Parameters.validate params files;
-  Analysis.run params files ctxt;
+  Parameters.validate params files >>= fun () ->
+  Analysis.run params files ctxt >>= fun () ->
   Ok ()
 
 let () =


### PR DESCRIPTION
Fixes #234. Checking for invalid parameters will return an `Error` rather than just calling `exit 1`.