### PR TITLE
Save a pruned version of the kb to the cache

### DIFF
--- a/wp/plugin/lib/analysis.ml
+++ b/wp/plugin/lib/analysis.ml
@@ -179,8 +179,8 @@ let comparators_of_flags
 (* Runs a single binary analysis. *)
 let single (bap_ctx : ctxt) (z3_ctx : Z3.context) (var_gen : Env.var_gen)
     (p : Params.t) (file : string) : combined_pre =
-  let prog = Utils.read_program bap_ctx ~loader:Utils.loader ~filepath:file in
-  let arch = Option.value_exn (Cache.Arch.load file) in
+  let prog, arch = Utils.read_program bap_ctx
+      ~loader:Utils.loader ~filepath:file in
   let subs = Term.enum sub_t prog in
   let main_sub = Utils.find_func_err subs p.func in
   let to_inline = Utils.match_inline p.inline subs in
@@ -213,10 +213,10 @@ let single (bap_ctx : ctxt) (z3_ctx : Z3.context) (var_gen : Env.var_gen)
 (* Runs a comparative analysis. *)
 let comparative (bap_ctx : ctxt) (z3_ctx : Z3.context) (var_gen : Env.var_gen)
     (p : Params.t) (file1 : string) (file2 : string) : combined_pre =
-  let prog1 = Utils.read_program bap_ctx ~loader:Utils.loader ~filepath:file1 in
-  let prog2 = Utils.read_program bap_ctx ~loader:Utils.loader ~filepath:file2 in
-  let arch1 = Option.value_exn (Cache.Arch.load file1) in
-  let arch2 = Option.value_exn (Cache.Arch.load file2) in
+  let prog1, arch1 = Utils.read_program bap_ctx
+      ~loader:Utils.loader ~filepath:file1 in
+  let prog2, arch2 = Utils.read_program bap_ctx
+      ~loader:Utils.loader ~filepath:file2 in
   let subs1 = Term.enum sub_t prog1 in
   let subs2 = Term.enum sub_t prog2 in
   let main_sub1 = Utils.find_func_err subs1 p.func in

--- a/wp/plugin/lib/cache.mli
+++ b/wp/plugin/lib/cache.mli
@@ -76,8 +76,8 @@ module Program : sig
       from the knowledge base. *)
   val load : string -> Program.t option
 
-  (** [save filename] saves the program representation of [filename] to the
-      knowledge base. *)
+  (** [save filename program] saves the program representation of [filename] to
+      the knowledge base. *)
   val save : string -> Program.t -> unit
 
 end
@@ -90,4 +90,7 @@ module Arch : sig
       not need to be stored manually. *)
   val load : string -> Arch.t option
 
+  (** [save filename arch] saves [filename]'s architecture to the knowledge
+      base. *)
+  val save : string -> Arch.t -> unit
 end

--- a/wp/plugin/lib/utils.mli
+++ b/wp/plugin/lib/utils.mli
@@ -29,9 +29,10 @@ module Env = Environment
 (** The loader WP uses for lifting a binary, defaulting to LLVM. *)
 val loader : string
 
-(** Obtains the program representation of the binary at the given filepath using
-    the BAP context and loader for lifting the binary. *)
-val read_program : ctxt -> loader:string -> filepath:string -> Program.t
+(** Obtains the program representation and the architecture of the binary at the
+    given filepath using the BAP context and loader for lifting the binary. *)
+val read_program :
+  ctxt -> loader:string -> filepath:string -> Program.t * Arch.t
 
 (** [find_func_err subs name] obtains a function named [name] from a
     sequence of subroutines [subs]. Fails if the function can't be found. *)


### PR DESCRIPTION
Based off of our discussion yesterday, this PR tests saving a pruned version of the kb to the cache. On some functions (tar_dirname), this changed runtime from 33s to 9s, but on others, (parse_branch), this changed runtime from 1m46s to 2m45s. I'm not really sure if this is the approach we want to go for.

This also might fix #247. I wasn't able to reproduce this bug unfortunately, but I had to update some parts of the architecture retrieval API. If you could test this for me, that would be great!