### PR TITLE
Create a program cache

### DIFF
--- a/wp/plugin/lib/cache.mli
+++ b/wp/plugin/lib/cache.mli
@@ -40,6 +40,9 @@ module Digests : sig
   (** Creates a digest for the project state cache. *)
   val project : (namespace:string -> digest) -> digest
 
+  (** Creates a digest for the program cache. *)
+  val program : (namespace:string -> digest) -> digest
+
 end
 
 (** A cache containing persistent information stored in the Knowledge Base. *)
@@ -65,32 +68,14 @@ module Project : sig
 
 end
 
-(** This module contains functions for interacting with a binary's {!Program.t},
-    which is BAP's representation of the program in BIR after disassembly. This
-    program is stored in the knowledge base cache, and will persist through
-    different runs of WP on the same unchanged binary given the same flags are
-    used for disassembly. *)
+(** A cache containing a binary's {!Program.t}, which is BAP's representation of
+    the program in BIR after disassembly, and the architecture of the binary. *)
 module Program : sig
 
-  (** [load filename] obtains the program representation of [filename] (if any)
-      from the knowledge base. *)
-  val load : string -> Program.t option
+  (** Loads a program and its architecture (if any) from the cache. *)
+  val load : digest -> (Program.t * Arch.t) option
 
-  (** [save filename program] saves the program representation of [filename] to
-      the knowledge base. *)
-  val save : string -> Program.t -> unit
+  (** Saves a program and its architecture in the cache. *)
+  val save : digest -> Program.t -> Arch.t -> unit
 
-end
-
-(** This module is used for interacting with the architecture for a binary. *)
-module Arch : sig
-
-  (** [load filename] obtains [filename]'s architecture from the knowledge base.
-      This information is populated when BAP disassembles a binary, and does
-      not need to be stored manually. *)
-  val load : string -> Arch.t option
-
-  (** [save filename arch] saves [filename]'s architecture to the knowledge
-      base. *)
-  val save : string -> Arch.t -> unit
 end

--- a/wp/plugin/lib/utils.ml
+++ b/wp/plugin/lib/utils.ml
@@ -58,24 +58,20 @@ end
 let read_program (ctxt : ctxt) ~(loader : string) ~(filepath : string)
     : Program.t * Arch.t =
   let mk_digest = Cache.Digests.get_generator ctxt ~filepath ~loader in
-  let knowledge_digest = Cache.Digests.knowledge mk_digest in
-  let () = Cache.Knowledge.load knowledge_digest in
-  match Cache.Program.load filepath with
+  let program_digest = Cache.Digests.program mk_digest in
+  match Cache.Program.load program_digest with
   | Some prog ->
     info "Program %s (%a) found in cache.%!"
-      filepath Data.Cache.Digest.pp knowledge_digest;
-    prog, Option.value_exn (Cache.Arch.load filepath)
+      filepath Data.Cache.Digest.pp program_digest;
+    prog
   | None ->
     (* The program_t is not in the cache. Disassemble the binary. *)
     info "Saving program %s (%a) to cache.%!"
-      filepath Data.Cache.Digest.pp knowledge_digest;
+      filepath Data.Cache.Digest.pp program_digest;
     let project = create_proj None loader filepath in
     let prog = project |> Project.program |> clear_mapper#run in
     let arch = Project.arch project in
-    let () = Toplevel.reset () in
-    let () = Cache.Program.save filepath prog in
-    let () = Cache.Arch.save filepath arch in
-    let () = Cache.Knowledge.save knowledge_digest in
+    let () = Cache.Program.save program_digest prog arch in
     prog, arch
 
 (* Finds a function in the binary. *)


### PR DESCRIPTION
Based off the discussion from #248.

That PR broke the inner consistency of the knowledge base, something we should avoid. There were multiple solutions such as creating a custom loader to read our custom Project.t representation, saving one subroutine per file, or creating a cache for the Program.t

While having one subroutine per file sounds like a good idea to minimize the BAP startup overhead and the weakest precondition is only being calculated on one subroutine at a time, WP still looks at the other functions to create function summaries. We also want to avoid serializing our project to keep our CLI cleaner. Creating a program cache also required the least amount of changes to WP.

The speed of this is similar to the previous PR (e.g. `tar_dirname`: 8.645s and `parse_branch`: 2m46.430s.)