### PR TITLE
makefile clean and rebuild plugin upon lib change

### DIFF
--- a/wp/plugin/Makefile
+++ b/wp/plugin/Makefile
@@ -17,6 +17,10 @@ TEST_Is := 'lib,tests'
 BUILD := $(PASS_NAME).plugin
 SRC_FILES := $(wildcard **/*.ml) $(wildcard **/*.mli)
 
+LIB_SRC_FILES := $(wildcard ../lib/bap_wp/src/*.ml) $(wildcard ../lib/bap_wp/src/*.mli)
+
+TRACK_LIB:= _build/TRACK_LIB
+
 #####################################################
 # DEFAULT
 #####################################################
@@ -33,13 +37,23 @@ all: install
 clean: uninstall test.clean
 	bapbuild -clean
 
+
+####################################################
+# REBUILD ON LIB CHANGE
+####################################################
+
+$(TRACK_LIB): $(LIB_SRC_FILES)
+	bapbuild -clean
+	mkdir _build
+	touch $(TRACK_LIB)
+
 #####################################################
 # BUILD
 #####################################################
 
 build: $(BUILD)
 
-$(BUILD): $(SRC_FILES)
+$(BUILD): $(SRC_FILES) $(TRACK_LIB)
 	bapbuild -use-ocamlfind -pkgs $(PKGS) -tag $(TAG) -I $(Is) $(PASS_NAME).plugin
 
 #####################################################


### PR DESCRIPTION
Addresses #252. The change allows us to get around a bug in `ocamlbuild` that does not relink against a rebuild library when using a cache. Instead, this introduces a change in the plugin file that cleans the plugin directory upon a change to the library. Now, we can run `make` instead of `make clean && make` when we've made changes to the library and want the plugin and library to be rebuilt.