### PR TITLE
Change body margins to higher percentages

### DIFF
--- a/docs/cbat.css
+++ b/docs/cbat.css
@@ -4,7 +4,7 @@ body {
   line-height: 2rem;
   font-weight: 100;
   color: hsla(228, 0%, 25%, 1.0);
-  margin: 1rem 2rem;
+  margin: 5% 15%;
 }
 
 h1 {


### PR DESCRIPTION
Upped margins on the `body` element, and changed units from `rem` to percentages. 

If you pull this branch, and on your local computer open `docs/index.html` in a browser, you should be able to see it.

This fixes #266 