### PR TITLE
Add Bir_to_bil.call to handle function-call creations in unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ myocamlbuild.ml
 *.byte
 *.bpj
 oUnit-All*
+*.DS_Store

--- a/wp/lib/bap_wp/src/bil_to_bir.ml
+++ b/wp/lib/bap_wp/src/bil_to_bir.ml
@@ -137,3 +137,6 @@ let bil_to_sub (stmts : Bil.t) : sub term =
   let res_sub = Term.remove blk_t res_sub head_tid in
   let res_sub = Term.prepend blk_t res_sub hd_blk in
   res_sub
+
+let call (call_sub : sub term ) (arch : Bil.typ) : Bil.Types.stmt  =
+  Bil.(jmp (unknown (call_sub |> Term.tid |> Tid.to_string) arch))

--- a/wp/lib/bap_wp/src/bil_to_bir.ml
+++ b/wp/lib/bap_wp/src/bil_to_bir.ml
@@ -138,5 +138,5 @@ let bil_to_sub (stmts : Bil.t) : sub term =
   let res_sub = Term.prepend blk_t res_sub hd_blk in
   res_sub
 
-let call (call_sub : sub term ) (arch : Bil.typ) : Bil.Types.stmt  =
-  Bil.(jmp (unknown (call_sub |> Term.tid |> Tid.to_string) arch))
+let call (call_sub : sub term ) (typ : Bil.typ) : Bil.Types.stmt  =
+  Bil.(jmp (unknown (call_sub |> Term.tid |> Tid.to_string) typ))

--- a/wp/lib/bap_wp/src/bil_to_bir.mli
+++ b/wp/lib/bap_wp/src/bil_to_bir.mli
@@ -14,7 +14,7 @@
 (**
 
    This module provides utilities to translate from a BIL
-   {!Bap.Std.Bil.t} expression to a BIR subroutine, for which we can
+   {!Bil.t} expression to a BIR subroutine, for which we can
    then invoke {!Precondition.visit_sub} to get the weakest
    precondition.
 
@@ -39,18 +39,20 @@
 
 *)
 
+open Bap.Std
+
 (** Create a pair of a subroutine with name [__assert_fail] and an
     expression which represents an invocation of that subroutine.
 
     A subsequent call to {!bil_to_sub} will correctly translate that
     expression to a BIR [call] expression. *)
-val mk_assert_fail : unit -> Bap.Std.Sub.t * Bap.Std.Exp.t
+val mk_assert_fail : unit -> sub term * exp
 
 
 (** Take a BIL program (a list of statements) and turn it into a
     subroutine. *)
-val bil_to_sub : Bap.Std.Bil.t -> Bap.Std.Sub.t
+val bil_to_sub : bil -> sub term
 
-(** Take a sub term and a type for the term to build a BIL
+(** Take a [sub term] and a type for the term to build a BIL
     function-call *)
-val call : Bap.Std.sub Bap.Std.term -> Bap.Std.Bil.typ -> Bap.Std.Bil.Types.stmt
+val call : sub term -> typ -> Bil.Types.stmt

--- a/wp/lib/bap_wp/src/bil_to_bir.mli
+++ b/wp/lib/bap_wp/src/bil_to_bir.mli
@@ -50,3 +50,7 @@ val mk_assert_fail : unit -> Bap.Std.Sub.t * Bap.Std.Exp.t
 (** Take a BIL program (a list of statements) and turn it into a
     subroutine. *)
 val bil_to_sub : Bap.Std.Bil.t -> Bap.Std.Sub.t
+
+(** Take a sub term and a type for the term to build a BIL
+    function-call *)
+val call : Bap.Std.sub Bap.Std.term -> Bap.Std.Bil.typ -> Bap.Std.Bil.Types.stmt


### PR DESCRIPTION
Here, I've abstracted on subroutine-call handling in unit tests to better handle function-calls. This is done by creating the function `call` in `Bil_to_bir.ml`. Namely, `call` creates a function-call based on a BIL term and appropriate type. 

I also edited `.gitignore` to ignore `.DS_Store` files.