### PR TITLE
Add Bil_to_bir.-prefix to call to eliminate function ambiguity with Bap.Std.Bil.Attribute.call

### DIFF
--- a/wp/lib/bap_wp/tests/unit/test_compare.ml
+++ b/wp/lib/bap_wp/tests/unit/test_compare.ml
@@ -513,9 +513,13 @@ let test_fun_outputs_2 (test_ctx : test_ctxt) : unit =
   let sub1 = Sub.with_name sub1 "test_call" in
   let sub2 = Sub.with_name sub2 "test_call" in
   let main_sub1 =
-    Bil.([ rdi := i64 1 ; rsi := i64 2 ; call sub1 reg64_t]) |> bil_to_sub in
+    Bil.([ rdi := i64 1 ;
+           rsi := i64 2 ; 
+           Bil_to_bir.call sub1 reg64_t]) |> bil_to_sub in
   let main_sub2 =
-    Bil.([ rdi := i64 2 ; rsi := i64 3 ; call sub2 reg64_t]) |> bil_to_sub in
+    Bil.([ rdi := i64 2 ;
+           rsi := i64 3 ;
+           Bil_to_bir.call sub2 reg64_t]) |> bil_to_sub in
   let env1 = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [main_sub1; sub1])
       ~specs:[Pre.spec_chaos_caller_saved] in
   let env2 = Pre.mk_env ctx var_gen ~subs:(Seq.of_list [main_sub2; sub2])
@@ -548,13 +552,13 @@ let test_fun_outputs_3 (test_ctx : test_ctxt) : unit =
     Bil.([rdi := i64 1 ;
           rsi := i64 2 ;
           rdx := i64 3 ;
-          call sub1 reg64_t])
+          Bil_to_bir.call sub1 reg64_t])
     |> bil_to_sub in
   let main_sub2 =
     Bil.([rdi := i64 1 ;
           rsi := i64 2 ;
           rdx := i64 4 ;
-          call sub2 reg64_t])
+          Bil_to_bir.call sub2 reg64_t])
     |> bil_to_sub in
   let env1 = Pre.mk_env ctx var_gen ~specs:[Pre.spec_chaos_caller_saved]
       ~subs:(Seq.of_list [main_sub1; sub1]) in
@@ -588,13 +592,13 @@ let test_fun_outputs_4 (test_ctx : test_ctxt) : unit =
     Bil.([rdi := i64 1 ;
           rsi := i64 2 ;
           rdx := i64 3 ;
-          call sub1 reg64_t])
+          Bil_to_bir.call sub1 reg64_t])
     |> bil_to_sub in
   let main_sub2 =
     Bil.([rdi := i64 1 ;
           rsi := i64 2 ;
           rdx := i64 4 ;
-          call sub2 reg64_t])
+          Bil_to_bir.call sub2 reg64_t])
     |> bil_to_sub in
   let env1 = Pre.mk_env ctx var_gen ~specs:[Pre.spec_chaos_caller_saved]
       ~subs:(Seq.of_list [main_sub1; sub1]) ~use_fun_input_regs:false in

--- a/wp/lib/bap_wp/tests/unit/test_precondition.ml
+++ b/wp/lib/bap_wp/tests/unit/test_precondition.ml
@@ -1349,7 +1349,7 @@ let test_get_vars_inline_1 (test_ctx : test_ctxt) : unit =
   let main_sub = Bil.(
       [
         y := i64 2;
-        call sub reg64_t
+        Bil_to_bir.call sub reg64_t
       ]
     ) |> bil_to_sub
   in


### PR DESCRIPTION
The new updates to Bap caused an overload with the function name "call" in `Bap.Std.Bil.Attribute` and `bil_to_bir.ml`. The test resulted in `test_compare.ml` and `test_precondition.ml` not compiling. 

Adding `Bil_to_bir.` to the beginning of of `call` fixed the issue: both test-files compile and the tests pass again. 