### PR TITLE
Run ocp-indent on all .ml and .mli files in cbat_tools

### DIFF
--- a/bildb/bildb.ml
+++ b/bildb/bildb.ml
@@ -13,8 +13,8 @@ module Param = struct
   open Config
 
   let () = manpage [
-    `S "DESCRIPTION";
-    `P "A Primus-based BIL debugger.";
+      `S "DESCRIPTION";
+      `P "A Primus-based BIL debugger.";
     ]
 
   let debug = flag "debug" ~doc:"Run the debugger."

--- a/bildb/lib/bildb_cursor.ml
+++ b/bildb/lib/bildb_cursor.ml
@@ -291,7 +291,7 @@ module Make (Machine : Primus.Machine.S) = struct
           | Some b -> set_blk (Some b)
           | None -> set_blk None 
         end
-      in
+    in
     let* _ = set_tid (Some tid) in
     Machine.return () 
 

--- a/bildb/lib/bildb_init.ml
+++ b/bildb/lib/bildb_init.ml
@@ -42,7 +42,7 @@ module Lexer = struct
   (* For printing all errors at once. *)
   let string_of_errors (errors : token list) : string =
     let pieces = List.map errors ~f:(fun x ->
-      Printf.sprintf "- %s" (string_of_token x)) in
+        Printf.sprintf "- %s" (string_of_token x)) in
     String.concat pieces ~sep:"\n"
 
   (* This function takes a line number [n] and a line from an init file,
@@ -55,22 +55,22 @@ module Lexer = struct
     else
 
       (* It could be a 'Variables:' or 'Locations:' heading. *)
-      if String.is_prefix s ~prefix:"Variables:" then [Variables n]
-      else
-        if String.is_prefix s ~prefix:"Locations:" then [Locations n]
-        else
+    if String.is_prefix s ~prefix:"Variables:" then [Variables n]
+    else
+    if String.is_prefix s ~prefix:"Locations:" then [Locations n]
+    else
 
-          (* Otherwise, we should have a 'key : value' line. *)
-          let pieces = String.split s ~on:':' in
-          if List.length pieces <> 2 then
-            let msg = 
-              Printf.sprintf "Expected 'key : value' but got '%s'" s in
-            [Error (n, msg)]
-          else
-            let pieces' = List.map pieces ~f:String.strip in
-            let key = List.nth_exn pieces' 0 in
-            let value = List.nth_exn pieces' 1 in
-            [Key (n, key); Value (n, value)]
+      (* Otherwise, we should have a 'key : value' line. *)
+      let pieces = String.split s ~on:':' in
+      if List.length pieces <> 2 then
+        let msg = 
+          Printf.sprintf "Expected 'key : value' but got '%s'" s in
+        [Error (n, msg)]
+      else
+        let pieces' = List.map pieces ~f:String.strip in
+        let key = List.nth_exn pieces' 0 in
+        let value = List.nth_exn pieces' 1 in
+        [Key (n, key); Value (n, value)]
 
   (* Recursively tokenize each line of the init file. *)
   let rec next ?n:(n=1) (lines : string list) : t =
@@ -85,8 +85,8 @@ module Lexer = struct
   let tokenize (lines : string list) : (t, string) Stdlib.result =
     let toks = next lines in
     let errors = List.filter toks ~f:(fun x -> match x with
-      | Error _ -> true
-      | _ -> false) in
+        | Error _ -> true
+        | _ -> false) in
     match List.length errors = 0 with
     | false -> Error (string_of_errors errors)
     | true -> Ok toks
@@ -191,9 +191,9 @@ module Parser = struct
       | Lexer.Variables _ -> 
         begin
           let var_tokens, the_rest = List.split_while tail ~f:(fun x ->
-            match x with
-            | Lexer.Locations _ -> false
-            | _ -> true) in
+              match x with
+              | Lexer.Locations _ -> false
+              | _ -> true) in
           let r = vars_from var_tokens in
           match r with
           | Error e -> Error e
@@ -208,9 +208,9 @@ module Parser = struct
       | Lexer.Locations _ ->
         begin
           let loc_tokens, the_rest = List.split_while tail ~f:(fun x ->
-            match x with
-            | Lexer.Variables _ -> false
-            | _ -> true) in
+              match x with
+              | Lexer.Variables _ -> false
+              | _ -> true) in
           let r = locs_from loc_tokens in
           match r with
           | Error e -> Error e

--- a/bildb/lib/bildb_init.mli
+++ b/bildb/lib/bildb_init.mli
@@ -3,11 +3,11 @@
     In particular, this module loads a file that looks like this:
 
     {[
-            Variables:
-              RAX: 0x00000abc
-              RDI: 0xdeadbeaf
-            Locations:
-              0x3ffffff1: 0x00000003
+      Variables:
+        RAX: 0x00000abc
+          RDI: 0xdeadbeaf
+          Locations:
+        0x3ffffff1: 0x00000003
     ]}
 
     It parses that file, and builds a {!Data.State.t} record, to

--- a/bildb/lib/bildb_startup.ml
+++ b/bildb/lib/bildb_startup.ml
@@ -40,27 +40,27 @@ module Make (Conf : Configuration) (Machine : Primus.Machine.S) = struct
   let initialize_variables (state : Data.t) : unit Machine.t =
     let vars = Data.variables state in
     let output = List.map vars ~f:(fun variable ->
-      let w = Data.word_of_var_value variable in
-      let* var = find_var (Data.string_of_var_key variable) in
-      match var with
-      | None -> Machine.return ()
-      | Some v -> set_variable v w)
-      in
+        let w = Data.word_of_var_value variable in
+        let* var = find_var (Data.string_of_var_key variable) in
+        match var with
+        | None -> Machine.return ()
+        | Some v -> set_variable v w)
+    in
     Machine.sequence output
 
   (* Set the locations specified in [state] to the provided values. *)
   let initialize_locations (state : Data.t) : unit Machine.t =
     let locs = Data.locations state in
     let output = List.map locs ~f:(fun location ->
-      let a = Data.word_of_loc_address location in
-      let w = Data.word_of_loc_value location in
-      let* is_mapped = Mem.is_mapped a in
-      let* _ = if is_mapped
-        then Machine.return ()
-        else Mem.allocate a 1
+        let a = Data.word_of_loc_address location in
+        let w = Data.word_of_loc_value location in
+        let* is_mapped = Mem.is_mapped a in
+        let* _ = if is_mapped
+          then Machine.return ()
+          else Mem.allocate a 1
         in
-      Mem.store a w)
-      in
+        Mem.store a w)
+    in
     Machine.sequence output
 
   (* This function is triggered when {Primus.System.init} fires.

--- a/bildb/lib/bildb_startup.mli
+++ b/bildb/lib/bildb_startup.mli
@@ -21,10 +21,10 @@ end
 (** This is the Primus component mentioned above that runs at startup.
     Note that it must be parameterized by a {!Configuration} module. *)
 module Make 
-    : functor (Conf : Configuration) (Machine : Primus.Machine.S) -> sig
+  : functor (Conf : Configuration) (Machine : Primus.Machine.S) -> sig
 
-  (* This function subscribes to the appropriate Primus events, so it
-     can do its thing when Primus starts up. *)
-  val init : unit -> unit Machine.t
+    (* This function subscribes to the appropriate Primus events, so it
+       can do its thing when Primus starts up. *)
+    val init : unit -> unit Machine.t
 
-end
+  end

--- a/bildb/lib/bildb_tty.ml
+++ b/bildb/lib/bildb_tty.ml
@@ -37,11 +37,11 @@ let end_tag = "\x1b[0m"
 type t = { style : style; color : color; newline : string; text : string }
 
 let mk 
-      ?style:(style=Plain) 
-      ?color:(color=Default) 
-      ?newline:(newline="") 
-      (text : string) 
-    : t = { style; color; newline; text }
+    ?style:(style=Plain) 
+    ?color:(color=Default) 
+    ?newline:(newline="") 
+    (text : string) 
+  : t = { style; color; newline; text }
 
 let for_terminal t : string =
   let start_style = start_of_style t.style in
@@ -50,7 +50,7 @@ let for_terminal t : string =
     match (start_style, start_color) with
     | ("","") -> ""
     | _ -> end_tag
-    in
+  in
   Printf.sprintf "%s%s%s%s%s" start_style start_color t.text fini t.newline
 
 let to_string t : string = t.text

--- a/bildb/lib/bildb_ui.mli
+++ b/bildb/lib/bildb_ui.mli
@@ -106,7 +106,7 @@ end
 
     If a screen includes no prompt or handler, it simply returns 
     a "Finished" event after it is rendered.
-    
+
     The {!Make.render} function is recursive, so if it renders a screen
     with a handler that returns a new screen, it will render that new
     screen too, and the process can repeat until a quit or finish event

--- a/bildb/lib/bildb_utils.ml
+++ b/bildb/lib/bildb_utils.ml
@@ -18,15 +18,15 @@ let pad (s : string) (width : int) : string =
    fill up a screen of the specified [width]. *)
 let tabulate (data : string list) (width : int) : string list =
   let widest = List.fold data ~init:0 ~f:(fun acc s ->
-    let len = String.length s in
-    if Int.(>) len acc then len
-    else acc
+      let len = String.length s in
+      if Int.(>) len acc then len
+      else acc
     ) in
   let item_width = widest + Ui.col_padding in
   let cols = width / item_width in
   let chunks = List.chunks_of data cols in
   List.map chunks ~f:(fun chunk ->
-    String.concat (List.map chunk ~f:(fun s -> pad s item_width)))
+      String.concat (List.map chunk ~f:(fun s -> pad s item_width)))
 
 (* Splits a string on white space characters and trims each word. *)
 let words_of (s : string) : string list =

--- a/vsa/value_set/lib/src/cbat_ai_memmap.ml
+++ b/vsa/value_set/lib/src/cbat_ai_memmap.ml
@@ -36,7 +36,7 @@ module Word_ops = Cbat_word_ops
     (This is largely baked into BAP as well)
     TODO: fix this via a secondary, internal module that
     adapts its interface to deal with this.
- *)
+*)
 let addressable_width = 8
 
 module Key = struct
@@ -334,7 +334,7 @@ end = struct
     let top = Seq.singleton @@ WordSet.top sz in
     let p = replicate_wordset v.data sz in
     if WordSet.bitwidth p mod sz > 0 then Utils.not_implemented ~top
-       (Printf.sprintf "%i-val cast to incompatible size %i" w sz)
+        (Printf.sprintf "%i-val cast to incompatible size %i" w sz)
     else let wordset_seq = segment_wordset p sz in
       match e with
       | BigEndian -> reverse_seq wordset_seq
@@ -419,7 +419,7 @@ let bottom (i : idx) : t =
    variable endianness or width properly. These must be addressed.
    TODO: performance: the add functions all sometimes split existing
    intervals. This might usually work, but could cause pathological blowup
- *)
+*)
 
 (* helper function *)
 let default_value (o : BL.t) (i : Val.idx) : Val.t =

--- a/vsa/value_set/lib/src/cbat_ai_representation.ml
+++ b/vsa/value_set/lib/src/cbat_ai_representation.ml
@@ -68,8 +68,8 @@ let add_memory (e : t) ~(key : var) ~(data : Mem.t) : t =
      to be safe in the case that the implementation changes.
   *)
   canonize
-  {memories = MemEnv.add e.memories ~key ~data;
-   words = e.words}
+    {memories = MemEnv.add e.memories ~key ~data;
+     words = e.words}
 
 (* adds a variable to the words of the input env *)
 let add_word (e : t) ~(key : var) ~(data : wordset) : t =
@@ -78,8 +78,8 @@ let add_word (e : t) ~(key : var) ~(data : wordset) : t =
      to be safe in the case that the implementation changes.
   *)
   canonize
-  {memories = e.memories;
-   words = WordEnv.add e.words ~key ~data}
+    {memories = e.memories;
+     words = WordEnv.add e.words ~key ~data}
 
 let find_word (i : WordSet.idx) (env : t) (v : var) : wordset = WordEnv.find i env.words v
 let find_memory (i : Mem.idx) (env : t) (v : var) : Mem.t = MemEnv.find i env.memories v
@@ -104,9 +104,9 @@ let join (e1 : t) (e2 : t) : t =
      to be safe in the case that the implementation changes.
   *)
   canonize
-  { memories = MemEnv.join e1.memories e2.memories;
-    words = WordEnv.join e1.words e2.words
-  }
+    { memories = MemEnv.join e1.memories e2.memories;
+      words = WordEnv.join e1.words e2.words
+    }
 
 let widen_join (e1 : t) (e2 : t) : t =
   (* Note: canonization is unnecessary here given the current
@@ -114,18 +114,18 @@ let widen_join (e1 : t) (e2 : t) : t =
      to be safe in the case that the implementation changes.
   *)
   canonize
-  { memories = MemEnv.widen_join e1.memories e2.memories;
-    words = WordEnv.widen_join e1.words e2.words
-  }
+    { memories = MemEnv.widen_join e1.memories e2.memories;
+      words = WordEnv.widen_join e1.words e2.words
+    }
 
 let meet (e1 : t) (e2 : t) : t =
   (* unlike the other operations, canonization is necessary here
      since the meet of two non-bottom elements can be bottom
   *)
   canonize
-  { memories = MemEnv.meet e1.memories e2.memories;
-    words = WordEnv.meet e1.words e2.words
-  }
+    { memories = MemEnv.meet e1.memories e2.memories;
+      words = WordEnv.meet e1.words e2.words
+    }
 
 let precedes (e1 : t) (e2 : t) : bool =
   MemEnv.precedes e1.memories e2.memories &&

--- a/vsa/value_set/lib/src/cbat_clp.ml
+++ b/vsa/value_set/lib/src/cbat_clp.ml
@@ -148,10 +148,10 @@ let canonize (p : t) : t =
     let e = W.add p.base p.step in
     if W.(>=) e p.base then p
     else create e ~step:(W.neg p.step) ~cardn:two
-  (* If p.cardn steps traverse the full domain, we approximate
-     with an infinite CLP. In other words, all cardinalities c
-     such that c*p.step <= 2^szIn are treated equivalently.
-  *)
+    (* If p.cardn steps traverse the full domain, we approximate
+       with an infinite CLP. In other words, all cardinalities c
+       such that c*p.step <= 2^szIn are treated equivalently.
+    *)
   else if is_infinite p then infinite(p.base, p.step)
   else p
 
@@ -192,8 +192,8 @@ let iter (p : t) : word list =
   iter_acc p'.base p'.step p'.cardn []
 
 (*  computes the closest element of p that precedes
-   i, i.e. the first element reached by starting from i and decreasing.
-   Assumes that the inputs have the same bitwidth.
+    i, i.e. the first element reached by starting from i and decreasing.
+    Assumes that the inputs have the same bitwidth.
 *)
 let nearest_pred (i : word) (p : t) : word option =
   assert(bitwidth p = W.bitwidth i);
@@ -499,49 +499,49 @@ let intersection (p1 : t) (p2 : t) : t =
   Option.value ~default:bot begin
     finite_end p1 >>= fun e1 ->
     finite_end p2 >>= fun e2 ->
-      let step = W.lcm_exn p1.step p2.step in
-      if W.is_zero step then begin
-        (* If there is no bounded LCM then s1 or s2 are 0. In other words,
-           one of the inputs is a singleton. Thus the intersection is either
-           equal to the singleton or empty.
-        *)
-        if W.is_zero p2.step then
-          Option.some_if (elem p2.base p1) () >>= fun _ ->
-          !!(create p2.base)
-        else
-          Option.some_if (elem p1.base p2) () >>= fun _ ->
-          !! (create p1.base)
-      end else begin
-        bounded_diophantine p1.step p2.step p2.base >>= fun (x,_) ->
-        (* the result is the first point on p1 that is also on the infinite CLP
-           approximation of p2. Due to the translation of the CLPs, this is the
-           least possible value (before translating back) that can inhabit the
-           intersection.
-        *)
-        let base = W.mul x p1.step in
-        (* e1 and e2 are meaningful iff p1 and p2 respectively are non-infinite.
-           We therefore guard their use so that when either argument is
-           infinite, we compute the proper end.
-        *)
-        let minE = if p1_infinite then e2
-          else if p2_infinite then e1
-          else min e1 e2 in
-        (* If the least possible value in resulting set is greater than the
-           maximum possible value, then the set is empty. This does not apply
-           when p1 is infinite since sometimes the base of p2 (and therefore
-           the result) can wrap backwards over 0.
-        *)
-        Option.some_if (W.(<=) base minE) () >>= fun _ ->
-        let cardn = cardn_from_bounds base step minE in
-        !!(create base ~step ~cardn)
-      end
-  (* whatever the result, we translate it by the original p1.base
-     to make up for the translation at the start.
-  *)
+    let step = W.lcm_exn p1.step p2.step in
+    if W.is_zero step then begin
+      (* If there is no bounded LCM then s1 or s2 are 0. In other words,
+         one of the inputs is a singleton. Thus the intersection is either
+         equal to the singleton or empty.
+      *)
+      if W.is_zero p2.step then
+        Option.some_if (elem p2.base p1) () >>= fun _ ->
+        !!(create p2.base)
+      else
+        Option.some_if (elem p1.base p2) () >>= fun _ ->
+        !! (create p1.base)
+    end else begin
+      bounded_diophantine p1.step p2.step p2.base >>= fun (x,_) ->
+      (* the result is the first point on p1 that is also on the infinite CLP
+         approximation of p2. Due to the translation of the CLPs, this is the
+         least possible value (before translating back) that can inhabit the
+         intersection.
+      *)
+      let base = W.mul x p1.step in
+      (* e1 and e2 are meaningful iff p1 and p2 respectively are non-infinite.
+         We therefore guard their use so that when either argument is
+         infinite, we compute the proper end.
+      *)
+      let minE = if p1_infinite then e2
+        else if p2_infinite then e1
+        else min e1 e2 in
+      (* If the least possible value in resulting set is greater than the
+         maximum possible value, then the set is empty. This does not apply
+         when p1 is infinite since sometimes the base of p2 (and therefore
+         the result) can wrap backwards over 0.
+      *)
+      Option.some_if (W.(<=) base minE) () >>= fun _ ->
+      let cardn = cardn_from_bounds base step minE in
+      !!(create base ~step ~cardn)
+    end
+    (* whatever the result, we translate it by the original p1.base
+       to make up for the translation at the start.
+    *)
   end |> (fun p -> translate p translation)
 
 (* Computes whether there exists any element in both CLPs
- *)
+*)
 let overlap (p1 : t) (p2 : t) : bool = not (is_bottom (intersection p1 p2))
 
 
@@ -569,10 +569,10 @@ let add (p1 : t) (p2 : t) : t =
   (* If either CLP is empty, return bottom *)
   Option.value_map ~default:(bottom sz) (finite_end p1) ~f:begin fun e1 ->
     Option.value_map ~default:(bottom sz) (finite_end p2) ~f:begin fun e2 ->
-        (* if either CLP has step 0 it is a singleton and
-           we simply add its value to each element of the other
-           This case is computed exactly.
-        *)
+      (* if either CLP has step 0 it is a singleton and
+         we simply add its value to each element of the other
+         This case is computed exactly.
+      *)
       if W.is_zero p1.step || is_one p1.cardn then translate p2 p1.base
       else if W.is_zero p2.step || is_one p2.cardn then translate p1 p2.base
       else if is_infinite p1 || is_infinite p2 then
@@ -643,14 +643,14 @@ let mul (p1 : t) (p2 : t) : t =
    TODO: describe
    TODO: should be in word_ops.ml???
    TODO: check!!!
- *)
+*)
 let lead_1_bit_run (w : word) ~hi ~lo : int =
   let rec lead_help (hi : int) (lo : int) : int =
     if hi = lo then hi else
-    let mid = (hi + lo) / 2 in
-    let hi_part = W.extract_exn ~hi ~lo:(mid + 1) w in
-    if W.is_zero (W.lnot hi_part) then lead_help mid lo
-    else lead_help hi (mid + 1)
+      let mid = (hi + lo) / 2 in
+      let hi_part = W.extract_exn ~hi ~lo:(mid + 1) w in
+      if W.is_zero (W.lnot hi_part) then lead_help mid lo
+      else lead_help hi (mid + 1)
   in
   assert(lo >= 0);
   assert(hi >= lo);
@@ -696,7 +696,7 @@ let compute_range_sep msb msb1 msb2 b1 b2 : int = if msb1 > msb2
 (* This algorithm closely follows the one in "Circular Linear Progressions
    in SWEET". It converts a CLP into an AP (terminology from the paper)
    by using the least non-wrapping superset.
- *)
+*)
 let logand (p1 : t) (p2 : t) : t =
   let sz = get_and_check_sizes p1 p2 in
   let bot = bottom sz in
@@ -709,7 +709,7 @@ let logand (p1 : t) (p2 : t) : t =
   (* We ensure that the cardinality of the second CLP is at
      least the cardinality of the first to collapse the two cases where
      once CLP has cardinality 1 and the other has cardinality 2.
-   *)
+  *)
   let p1, p2 = if W.(<=) (cardinality cp1) (cardinality cp2)
     then (cp1, cp2) else (cp2, cp1) in
   let open Monads.Std.Monad.Option.Syntax in
@@ -720,7 +720,7 @@ let logand (p1 : t) (p2 : t) : t =
     else if W.is_one p1.cardn && W.(=) p2.cardn cardn_two then
       (* CLPs can represent any two-element set exactly, so
          we compute the two elements of the set and return them.
-       *)
+      *)
       finite_end p2 >>= fun e2 ->
       let base = W.logand p1.base p2.base in
       let newE = W.logand p1.base e2 in
@@ -764,9 +764,9 @@ let logand (p1 : t) (p2 : t) : t =
             min_elem_p1 min_elem_p2
         in
         let mask = if l_s_b >= range_sep then W.zero sz
-              else let ones = W.ones (range_sep - l_s_b) in
-                let sized_ones = W.extract_exn ~hi:(sz - 1) ones in
-                Word.lshift sized_ones (W.of_int ~width:sz l_s_b) in
+          else let ones = W.ones (range_sep - l_s_b) in
+            let sized_ones = W.extract_exn ~hi:(sz - 1) ones in
+            Word.lshift sized_ones (W.of_int ~width:sz l_s_b) in
         let safe_lower_bound =
           W.logand min_elem_p1 min_elem_p2 |> W.logand (W.lnot mask) in
         let safe_upper_bound = W.logand max_elem_p1 max_elem_p2 |>
@@ -780,8 +780,8 @@ let logand (p1 : t) (p2 : t) : t =
                       range_sep = l_s_b then
             W.max p1.step twos_step
           else if most_significant_bit_p2 > most_significant_bit_p1 &&
-                      m_s_b = most_significant_bit_p2 &&
-                      range_sep = l_s_b then
+                  m_s_b = most_significant_bit_p2 &&
+                  range_sep = l_s_b then
             W.max p2.step twos_step
           else twos_step in
         let b1_and_b2 = W.logand min_elem_p1 min_elem_p2 in
@@ -882,7 +882,7 @@ let rshift (p1 : t) (p2 : t) : t =
 
    - [if 0 >= c1[n1 - 1]]
 
-   *)
+*)
 let arshift (p1 : t) (p2 : t) : t =
   let sz1 = bitwidth p1 in
   let sz2 = bitwidth p2 in
@@ -905,7 +905,7 @@ let arshift (p1 : t) (p2 : t) : t =
         if W.(>=) (W.signed p1.base) zero
         then W.arshift (W.signed p1.base) e2
         else W.arshift (W.signed p1.base) p2.base
-        in
+      in
 
       let step = rshift_step W.arshift ~p1 ~p2 ~e2 ~sz1 ~sz2 in
 
@@ -913,7 +913,7 @@ let arshift (p1 : t) (p2 : t) : t =
         if W.(>=) (W.signed e1) zero
         then W.arshift (W.signed e1) p2.base
         else W.arshift (W.signed e1) e2
-        in
+      in
       let cardn = cardn_from_bounds base step new_end in
 
       !!(create base ~step ~cardn)
@@ -1064,8 +1064,8 @@ let of_list ~width l : t =
             assert(W.bitwidth diff = W.bitwidth step);
             assert(W.bitwidth diff = W.bitwidth d);
             if W.(>) d diff
-             then i, d, bounded_gcd diff step
-             else idx, diff, bounded_gcd d step) in
+            then i, d, bounded_gcd diff step
+            else idx, diff, bounded_gcd d step) in
     let l = idx
             (* "rotate" the list left by the index of the desired first element *)
             |> List.split_n l
@@ -1101,13 +1101,13 @@ let div (p1 : t) (p2 : t) : t =
       let e = W.div max_e1 min_e2 in
       let step = if W.is_one (cardinality p2) &&
                     W.is_zero (W.modulo p1.step p2.base)
-          then bounded_gcd (W.div p1.step p2.base)
-              (W.sub (W.div p1.base p2.base) base)
-              (* TODO: improve step precision in cases where
-                 every element of the divisor divides every
-                 element of the dividend
-              *)
-          else W.one width in
+        then bounded_gcd (W.div p1.step p2.base)
+            (W.sub (W.div p1.base p2.base) base)
+            (* TODO: improve step precision in cases where
+               every element of the divisor divides every
+               element of the dividend
+            *)
+        else W.one width in
       let cardn = cardn_from_bounds base step e in
       !!{base; step; cardn}
   end
@@ -1163,7 +1163,7 @@ let meet = intersection
 let widen_join (p1 : t) (p2 : t) =
   assert (subset p1 p2);
   if equal p1 p2 then p1 else
-  infinite (p2.base, p2.step)
+    infinite (p2.base, p2.step)
 
 (* Implement the Value interface *)
 

--- a/vsa/value_set/lib/src/cbat_lattice_intf.ml
+++ b/vsa/value_set/lib/src/cbat_lattice_intf.ml
@@ -49,7 +49,7 @@ end
    The lattice structure is maintained over elements with the
    same index. Meet, join, and precedes should be expected to error if
    passed elements with different indices.
- *)
+*)
 module type S_indexed = sig
   type t
   type idx

--- a/vsa/value_set/lib/src/cbat_vsa.ml
+++ b/vsa/value_set/lib/src/cbat_vsa.ml
@@ -75,7 +75,7 @@ type wordset = WordSet.t
 (* Denotations
    =========================================================
    These functions are denotations of terms in BIR
- *)
+*)
 
 
 (* bitwidth is the width of the two inputs *)
@@ -235,14 +235,14 @@ let rec denote_exp (e : exp) (env : AI.t) : val_t or_type_error =
   let return_mem (v : Mem.t) = return @@ `Mem v in
   match e with
   | Bil.Var v -> begin match Var.typ v with
-    | Type.Imm bitwidth -> return_imm @@ AI.find_word bitwidth env v
-    | Type.Mem (addr_i, addressable_size) ->
-      let addr_width : int = Size.in_bits addr_i in
-      let addressable_width : int = Size.in_bits addressable_size in
-      let k = {Mem.addr_width = addr_width;
-               Mem.addressable_width = addressable_width} in
-      return_mem @@ AI.find_memory k env v
-    | Type.Unk -> failwith "Error in denote_exp: var type is not representable by Type.t"
+      | Type.Imm bitwidth -> return_imm @@ AI.find_word bitwidth env v
+      | Type.Mem (addr_i, addressable_size) ->
+        let addr_width : int = Size.in_bits addr_i in
+        let addressable_width : int = Size.in_bits addressable_size in
+        let k = {Mem.addr_width = addr_width;
+                 Mem.addressable_width = addressable_width} in
+        return_mem @@ AI.find_memory k env v
+      | Type.Unk -> failwith "Error in denote_exp: var type is not representable by Type.t"
     end
   | Bil.Int bv -> return_imm @@ WordSet.singleton bv
   | Bil.BinOp (op, e1, e2) ->
@@ -363,15 +363,15 @@ let denote_jump (denote_call : sub:tid -> AI.t -> target:tid -> AI.t)
     let inspect_call c =
       Format.printf "//Assuming a well-formed call-return control flow@.";
       match Call.return c with
-        | None -> AI.bottom
-        | Some (Direct tid) when not (target = tid) -> AI.bottom
-        | Some (Indirect _)
-        | Some (Direct _) ->
-          (* In this case, the call might return to target *)
-          begin match Call.target c with
-            | Indirect _ -> AI.top
-            | Direct sub -> denote_call ~sub env ~target
-          end in
+      | None -> AI.bottom
+      | Some (Direct tid) when not (target = tid) -> AI.bottom
+      | Some (Indirect _)
+      | Some (Direct _) ->
+        (* In this case, the call might return to target *)
+        begin match Call.target c with
+          | Indirect _ -> AI.top
+          | Direct sub -> denote_call ~sub env ~target
+        end in
     begin match Jmp.kind jmp with
       | Int _ -> not_implemented ~top:AI.top "interrupt denotation"
       | Call c -> inspect_call c
@@ -379,7 +379,7 @@ let denote_jump (denote_call : sub:tid -> AI.t -> target:tid -> AI.t)
       | Ret (Direct tid) ->  if target = tid then env else AI.bottom
       | Goto (Indirect _)
       | Ret (Indirect _) -> env
-      end
+    end
   end
   |> Seq.fold ~init:AI.bottom ~f:AI.join
 
@@ -388,11 +388,11 @@ let denote_jump (denote_call : sub:tid -> AI.t -> target:tid -> AI.t)
 *)
 let denote_block (denote_call : sub:tid -> AI.t -> target:tid -> AI.t)
     (ctx : program term) ~(source : tid) (env : AI.t) : target:tid -> AI.t =
- match (Program.lookup blk_t ctx source) with
-   | Some b ->
-     let postcond = denote_defs b env in
-     denote_jump denote_call b postcond
-   | None -> invalid_arg "source tid does not represent block"
+  match (Program.lookup blk_t ctx source) with
+  | Some b ->
+    let postcond = denote_defs b env in
+    denote_jump denote_call b postcond
+  | None -> invalid_arg "source tid does not represent block"
 
 
 type vsa_sol = (tid, AI.t) Solution.t
@@ -412,7 +412,7 @@ let default_entry () : AI.t =
 
 (* Set up the initial solution for a general VSA pass over a subroutine.
    Assumes that the inputs can be any valid values for their types.
- *)
+*)
 let init_sol ?entry (sub : sub term) =
   let empty_map = Tid.Map.empty in
   let msb = Term.first blk_t sub in

--- a/vsa/value_set/lib/src/cbat_vsa_utils.ml
+++ b/vsa/value_set/lib/src/cbat_vsa_utils.ml
@@ -13,20 +13,20 @@
 
 (* Utility functions specific to this project but not associated with
    any particular piece of functionality.
- *)
+*)
 
 exception NotImplemented of string
 
 (* When true, the analysis fails whenever it encounters a denotation
    that isn't implemented yet. When false, the analysis proceeds with
    a (very) conservative approximation.
- *)
+*)
 let fail_on_not_implemented = ref true
 
 (* call as a placeholder where a piece of code has not been written yet.
    An optional argument, top, is for a conservative approximation of
    the desired result, where appropriate.
- *)
+*)
 let not_implemented ?(top : 'a option) component : 'a = match top with
   | None -> raise (NotImplemented component)
   | Some tp -> if !fail_on_not_implemented

--- a/vsa/value_set/lib/src/cbat_word_ops.ml
+++ b/vsa/value_set/lib/src/cbat_word_ops.ml
@@ -57,7 +57,7 @@ let bounded_gcd (w1 : word) (w2 : word) : word =
 
 (* Performs an unsigned division that rounds updwards instead of downwards. *)
 let cdiv a b : word = if W.is_zero (W.modulo a b)
-    then W.div a b else W.succ (W.div a b)
+  then W.div a b else W.succ (W.div a b)
 
 let is_one (w : word) : bool = W.is_zero (W.pred w)
 
@@ -124,10 +124,10 @@ let lead_1_bit (w : word) : int option =
     let open Monads.Std.Monad.Option.Syntax in
     Option.some_if (hi >= lo) () >>= fun _ ->
     if hi = lo then !!hi else
-    let mid = (hi + lo) / 2 in
-    let hi_part = W.extract_exn ~hi ~lo:(mid + 1) w in
-    if W.is_zero hi_part then lead_help mid lo
-    else lead_help hi (mid + 1)
+      let mid = (hi + lo) / 2 in
+      let hi_part = W.extract_exn ~hi ~lo:(mid + 1) w in
+      if W.is_zero hi_part then lead_help mid lo
+      else lead_help hi (mid + 1)
   in
   if W.is_zero w then None else lead_help ((W.bitwidth w) - 1) 0
 

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -683,16 +683,16 @@ let indirect_spec_default : Env.indirect_spec =
    * when we can use it to determine the destination of the
    * indirect call. *)
   fun env post _exp has_return ->
-  if has_return then increment_stack_ptr post env
-  else post, env
+    if has_return then increment_stack_ptr post env
+    else post, env
 
 let jmp_spec_default : Env.jmp_spec =
   fun _ _ _ _ -> None
 
 let int_spec_default : Env.int_spec =
   fun env post _ ->
-  error "Currently we do not handle system calls%!";
-  post, env
+    error "Currently we do not handle system calls%!";
+    post, env
 
 let num_unroll : int ref = ref 5
 
@@ -1204,13 +1204,13 @@ let init_vars (vars : Var.Set.t) (env : Env.t) : Constr.t list * Env.t =
 let mem_read_offsets (env2 : Env.t) (offset : Constr.z3_expr -> Constr.z3_expr)
   : Env.exp_cond =
   fun env1 exp ->
-  let ctx = Env.get_context env1 in
-  let conds = collect_mem_read_expr env1 env2 exp offset in
-  let name = "Assume memory equivalence at offset" in
-  if List.is_empty conds then
-    None
-  else
-    Some (Assume (AfterExec (Constr.mk_goal name (Bool.mk_and ctx conds))))
+    let ctx = Env.get_context env1 in
+    let conds = collect_mem_read_expr env1 env2 exp offset in
+    let name = "Assume memory equivalence at offset" in
+    if List.is_empty conds then
+      None
+    else
+      Some (Assume (AfterExec (Constr.mk_goal name (Bool.mk_and ctx conds))))
 
 let check ?refute:(refute = true) ?(print_constr = []) ?(debug = false)
     (solver : Solver.solver) (ctx : Z3.context) (pre : Constr.t)  : Solver.status =

--- a/wp/lib/bap_wp/src/symbol.ml
+++ b/wp/lib/bap_wp/src/symbol.ml
@@ -36,7 +36,7 @@ let exec_err (cmd : string) (e : exn) : string =
 
 let cmd_err (cmd : string) (code : int) (out : string) (err : string) : string =
   Format.sprintf "Command exited with non-zero exit code.\nCMD: '%s'\n \
-                 EXIT CODE: '%d'\nSTDOUT: %s\nSTDERR: %s%!" cmd code out err
+                  EXIT CODE: '%d'\nSTDOUT: %s\nSTDERR: %s%!" cmd code out err
 
 let run_command (cmd : string) : string =
   let code, out, err = try

--- a/wp/plugin/lib/wp_analysis.ml
+++ b/wp/plugin/lib/wp_analysis.ml
@@ -75,7 +75,7 @@ let mk_func_name_map (subs_orig : Sub.t Seq.t) (subs_mod : Sub.t Seq.t)
             let not_in_mod = not @@ Seq.exists subs_mod ~f:(fun s ->
                 String.equal (Sub.name s) name_mod) in
             begin if not_in_mod then
-              warning "%s is not found in the modified binary." name_mod
+                warning "%s is not found in the modified binary." name_mod
             end;
             String.Map.set m ~key:name_orig ~data:name_mod
           else m))

--- a/wp/plugin/lib/wp_parameters.ml
+++ b/wp/plugin/lib/wp_parameters.ml
@@ -114,7 +114,7 @@ let validate_compare_func_calls (flag : bool) (files : string list)
 
 (* Ensures the uer passed in two files to check for invalid dereferences. *)
 let validate_check_invalid_derefs (flag : bool) (files : string list)
-    : (unit, error) result =
+  : (unit, error) result =
   validate_two_files flag "check-invalid-derefs" files
 
 (* Ensures the user passed in two files to compare post register values. *)

--- a/wp/plugin/lib/wp_parameters.mli
+++ b/wp/plugin/lib/wp_parameters.mli
@@ -26,9 +26,9 @@ open Monads.Std
     error is returned when a user passes in an invalid parameter. *)
 module Err : Monad.Result.S with
   type 'a t := 'a Monad.Result.T1(Extension.Error)(Monad.Ident).t and
-  type 'a m := 'a Monad.Result.T1(Extension.Error)(Monad.Ident).m and
-  type 'a e := 'a Monad.Result.T1(Extension.Error)(Monad.Ident).e and
-  type err := Extension.Error.t
+type 'a m := 'a Monad.Result.T1(Extension.Error)(Monad.Ident).m and
+type 'a e := 'a Monad.Result.T1(Extension.Error)(Monad.Ident).e and
+type err := Extension.Error.t
 
 (** The available options to be set. Each flag corresponds to a parameter in
     the set with the BAP custom command line. *)

--- a/wp/plugin/lib/wp_utils.ml
+++ b/wp/plugin/lib/wp_utils.ml
@@ -57,7 +57,7 @@ end
 
 (* Reads in the program_t and its architecture from a file. *)
 let read_program (ctxt : ctxt) ~(loader : string) ~(filepath : string)
-    : Program.t * Arch.t =
+  : Program.t * Arch.t =
   let mk_digest = Cache.Digests.get_generator ctxt ~filepath ~loader in
   let program_digest = Cache.Digests.program mk_digest in
   match Cache.Program.load program_digest with
@@ -141,6 +141,6 @@ let output_to_gdb ~(filename : string option) ~(func : string)
 (* Checks the user's input for outputting a bildb script. *)
 let output_to_bildb ~(filename : string option) (solver : Z3.Solver.solver)
     (status : Z3.Solver.status) (env : Env.t) : unit =
- match filename with
+  match filename with
   | None -> ()
   | Some name -> Output.output_bildb solver status env name

--- a/wp/plugin/lib/wp_utils.mli
+++ b/wp/plugin/lib/wp_utils.mli
@@ -55,7 +55,7 @@ val update_stack : base:int option -> size:int option -> Env.mem_range
 (** Checks if the user provided a filename to output a gdb script to, and if
     provided, outputs the script. *)
 val output_to_gdb :
-     filename:string option
+  filename:string option
   -> func:string
   -> Z3.Solver.solver
   -> Z3.Solver.status
@@ -65,7 +65,7 @@ val output_to_gdb :
 (** Checks if the user provided a filename to input a bildb init file to, and if
     provided, outputs the script. *)
 val output_to_bildb :
-     filename:string option
+  filename:string option
   -> Z3.Solver.solver
   -> Z3.Solver.status
   -> Env.t

--- a/wp/plugin/tests/test_libs/test_wp_utils.ml
+++ b/wp/plugin/tests/test_libs/test_wp_utils.ml
@@ -118,33 +118,33 @@ let check_result (stream : char Stream.t) (expected_result : string)
 let check_list (expected_reg_models : ((string * string) list) list )
   : (string StringMap.t -> string option) =
   fun observed_mapping ->
-  List.foldi expected_reg_models ~init:(Some "") ~f:(fun i seen_match model ->
-      match seen_match with
-      | Some err ->
-        let result = List.fold model ~init:(None) ~f:(fun acc (reg, value) ->
-            let err =
-              begin match StringMap.find observed_mapping reg with
-                (* if register not observed, then fail *)
-                | None ->
-                  Some (Printf.sprintf
-                    "\n\tRegister %s not found in returned model.\n" reg)
-                | Some observed_value ->
-                  if String.equal observed_value value then None
-                  else
+    List.foldi expected_reg_models ~init:(Some "") ~f:(fun i seen_match model ->
+        match seen_match with
+        | Some err ->
+          let result = List.fold model ~init:(None) ~f:(fun acc (reg, value) ->
+              let err =
+                begin match StringMap.find observed_mapping reg with
+                  (* if register not observed, then fail *)
+                  | None ->
                     Some (Printf.sprintf
-                      "\tRegister mismatch: %s expected to be %s but was %s\n"
-                      reg value observed_value)
-              end in
-            Option.merge ~f:(^) acc err
-          ) in
-        begin match result with
-          | None -> None
-          | Some cur_err ->
-            let model_msg = (Printf.sprintf "\nModel %d:\n" i) in
-            Some (err ^ model_msg ^ cur_err)
-        end
-      | None -> seen_match
-    )
+                            "\n\tRegister %s not found in returned model.\n" reg)
+                  | Some observed_value ->
+                    if String.equal observed_value value then None
+                    else
+                      Some (Printf.sprintf
+                              "\tRegister mismatch: %s expected to be %s but was %s\n"
+                              reg value observed_value)
+                end in
+              Option.merge ~f:(^) acc err
+            ) in
+          begin match result with
+            | None -> None
+            | Some cur_err ->
+              let model_msg = (Printf.sprintf "\nModel %d:\n" i) in
+              Some (err ^ model_msg ^ cur_err)
+          end
+        | None -> seen_match
+      )
 
 (* given a list of registers, [register_names], and a mapping, [mapping],
    from registers to bitvector values, returns a list of bitvectors
@@ -226,16 +226,16 @@ let get_register_args (n : int) (arch : Arch.t): string list =
 (* returns a function that checks a [n] by [n] nqueens board. *)
 let check_n_queens (n: int) (arch : Arch.t) : (string StringMap.t -> string option) =
   fun var_mapping ->
-  let width = 64 in
-  let board_args = get_register_args 6 arch in
-  let num_bits = n * n in
-  let num_registers = num_bits / width in
-  (* n <= 3 has no solutions *)
-  if n <= 3 then assert_failure "Nqueens example run on too small of an n";
-  let filtered_board_args = board_args |> List.filteri ~f:(fun i _ -> i <= num_registers)
-  in
-  let board_pieces = gather_register_values filtered_board_args var_mapping in
-  check_n_queen_diag_col_row n board_pieces
+    let width = 64 in
+    let board_args = get_register_args 6 arch in
+    let num_bits = n * n in
+    let num_registers = num_bits / width in
+    (* n <= 3 has no solutions *)
+    if n <= 3 then assert_failure "Nqueens example run on too small of an n";
+    let filtered_board_args = board_args |> List.filteri ~f:(fun i _ -> i <= num_registers)
+    in
+    let board_pieces = gather_register_values filtered_board_args var_mapping in
+    check_n_queen_diag_col_row n board_pieces
 
 (* given a sudoku board and list of indices,
    check that indices preserve sudoku invariants *)
@@ -284,7 +284,7 @@ let check_bad_hash_function (registers : string list) : ((string StringMap.t) ->
       None
     else
       Some (Printf.sprintf "\n Expected the hash %s but got hash %s"
-        (Bitvector.to_string result) (Bitvector.to_string result_index))
+              (Bitvector.to_string result) (Bitvector.to_string result_index))
 
 (* The length of a test_case is in seconds.
    OUnit has predefined test lengths of:

--- a/wp/plugin/tests/unit/test_parameters.ml
+++ b/wp/plugin/tests/unit/test_parameters.ml
@@ -24,7 +24,7 @@ let test_validate_input
     ?length:(length = Immediate)
     ~valid:(valid : bool)
     (res : (unit, error) result)
-   : test =
+  : test =
   let test _ = match res with
     | Error _ -> assert_bool "Returned an error when params are valid" (not valid)
     | Ok () -> assert_bool "Should have returned an error for an invalid param" valid


### PR DESCRIPTION
Adresses issue #286. I ran `ocp-indent -i` on all `.ml` and `.mli` files I could manually find, including those outside of `wp`. This will allow our code to be more compliant with standard OCaml style. 