### PR TITLE
Address issue #295 by moving mk_smtlib2_compare from compare.ml into z3_utils.ml and making Z3_utils.mk_smtlib2 unexposed

### DIFF
--- a/wp/lib/bap_wp/src/compare.mli
+++ b/wp/lib/bap_wp/src/compare.mli
@@ -138,7 +138,3 @@ val compare_subs_smtlib
     hypothesis that memory between the two binaries are equal at the
     beginning of the subroutines. *)
 val compare_subs_mem_eq : comparator * comparator
-
-(** [mk_smtlib2_compare] builds a constraint out of an smtlib2 string that can be used
-    as a comparison predicate between an original and modified binary. *)
-val mk_smtlib2_compare : Env.t -> Env.t -> string -> Constr.t

--- a/wp/lib/bap_wp/src/z3_utils.mli
+++ b/wp/lib/bap_wp/src/z3_utils.mli
@@ -46,17 +46,6 @@ val get_decls_and_symbols : Env.t -> ((Z3.FuncDecl.func_decl * Z3.Symbol.symbol)
     and postconditions for single binary analysis *)
 val mk_smtlib2_single : ?name:string option -> Env.t -> string -> Constr.t
 
-(** [mk_smtlib2] parses a smtlib2 string in the context that has a mapping of func_decl
-    to symbols and returns a constraint [Constr.t] corresponding to the smtlib2 string.
-    The [func_decl * symbol] mapping can be constructed from an [Env.t] using the
-    [get_decls_and_symbols] function. *)
-val mk_smtlib2
-  :  ?name:string option
-  -> Z3.context
-  -> string
-  -> ((Z3.FuncDecl.func_decl * Z3.Symbol.symbol) list)
-  -> Constr.t
-
 (** [mk_and] is a slightly optimized version of [Bool.mk_and] that does not produce an
     [and] node if the number of operands is less than 2. This may improve sharing,
     but also improves compatibility of smtlib2 expressions with other solvers.  *)
@@ -73,3 +62,7 @@ val check_external : Z3.Solver.solver
   -> Z3.context
   -> (Z3.FuncDecl.func_decl * Z3.Symbol.symbol) list
   -> Z3.Solver.status
+
+(** [mk_smtlib2_compare] builds a constraint out of an smtlib2 string that can be used
+    as a comparison predicate between an original and modified binary. *)
+val mk_smtlib2_compare : Env.t -> Env.t -> string -> Constr.t

--- a/wp/lib/bap_wp/tests/unit/test_compare.ml
+++ b/wp/lib/bap_wp/tests/unit/test_compare.ml
@@ -777,67 +777,6 @@ let test_memory_model_3 (test_ctx : test_ctxt) : unit =
     compare_prop Z3.Solver.UNSATISFIABLE
 
 
-let test_mk_smtlib2_compare_1 (test_ctx : test_ctxt) : unit =
-  let ctx = Env.mk_ctx () in
-  let var_gen = Env.mk_var_gen () in
-  let env1 = Pre.mk_env ~target:test_tgt ctx var_gen in
-  let env2 = Pre.mk_env ~target:test_tgt ctx var_gen in
-  let env2 = Env.set_freshen env2 true in
-  let x = Var.create "x" reg32_t in
-  let y = Var.create "y" reg32_t in
-  let x1, env1 = Env.get_var env1 x in
-  let _, env2 = Env.get_var env2 x in
-  let _, env1 = Env.get_var env1 y in
-  let y2, env2 = Env.get_var env2 y in
-  let init_x1, env1 = Env.mk_init_var env1 x in
-  let _, env2 = Env.mk_init_var env2 x in
-  let _, env1 = Env.mk_init_var env1 y in
-  let init_y2, env2 = Env.mk_init_var env2 y in
-  let cond = "(assert (and (= x_orig init_x_orig) (= y_mod init_y_mod)))" in
-  let expected =
-    let constr =
-      Bool.mk_and ctx [Bool.mk_eq ctx x1 init_x1; Bool.mk_eq ctx y2 init_y2]
-      |> Constr.mk_goal "(and (= x0 init_x0) (= y02 init_y02))"
-      |> Constr.mk_constr
-    in
-    Constr.mk_clause [] [constr]
-  in
-  let result = Compare.mk_smtlib2_compare env1 env2 cond in
-  assert_equal ~ctxt:test_ctx
-    ~printer:Constr.to_string
-    expected result
-
-
-let test_mk_smtlib2_compare_2 (test_ctx : test_ctxt) : unit =
-  let ctx = Env.mk_ctx () in
-  let var_gen = Env.mk_var_gen () in
-  let env1 = Pre.mk_env ~target:test_tgt ctx var_gen in
-  let env2 = Pre.mk_env ~target:test_tgt ctx var_gen in
-  let env2 = Env.set_freshen env2 true in
-  let x = Var.create "x" reg32_t in
-  let x1, env1 = Env.get_var env1 x in
-  let x2, env2 = Env.get_var env2 x in
-  let _, env1 = Env.mk_init_var env1 x in
-  let init_x2, env2 = Env.mk_init_var env2 x in
-  let x_orig123 = BV.mk_const_s ctx "x_orig123" 32 in
-  let cond =
-    "(declare-const x_orig123 (_ BitVec 32)) \n\
-     (assert (and (= x_orig x_orig123) (= x_mod init_x_mod)))"
-  in
-  let expected =
-    let constr =
-      Bool.mk_and ctx [Bool.mk_eq ctx x1 x_orig123; Bool.mk_eq ctx x2 init_x2]
-      |> Constr.mk_goal "(and (= x0 x_orig123) (= x01 init_x01))"
-      |> Constr.mk_constr
-    in
-    Constr.mk_clause [] [constr]
-  in
-  let result = Compare.mk_smtlib2_compare env1 env2 cond in
-  assert_equal ~ctxt:test_ctx
-    ~printer:Constr.to_string
-    expected result
-
-
 let suite = [
   "z = x+y; and x = x+1; y = y-1; z = x+y;"  >:: test_block_pair_1;
   "z = x; and y = x; z = y;"                 >:: test_block_pair_2;
@@ -865,7 +804,4 @@ let suite = [
   "Diff data location: UNSAT"                >:: test_memory_model_1;
   "Diff data location: SAT"                  >:: test_memory_model_2;
   "Diff data location, substitution: UNSAT"  >:: test_memory_model_3;
-
-  "Parsing smtlib compare expression"        >:: test_mk_smtlib2_compare_1;
-  "Should not overwrite x_orig123"           >:: test_mk_smtlib2_compare_2;
 ]

--- a/wp/lib/bap_wp/tests/unit/test_z3_utils.ml
+++ b/wp/lib/bap_wp/tests/unit/test_z3_utils.ml
@@ -26,6 +26,65 @@ module BV = Z3.BitVector
 
 let test_tgt = Testing_utilities.test_tgt
 
+let test_mk_smtlib2_compare_1 (test_ctx : test_ctxt) : unit =
+  let ctx = Env.mk_ctx () in
+  let var_gen = Env.mk_var_gen () in
+  let env1 = Pre.mk_env ctx var_gen in
+  let env2 = Pre.mk_env ctx var_gen in
+  let env2 = Env.set_freshen env2 true in
+  let x = Var.create "x" reg32_t in
+  let y = Var.create "y" reg32_t in
+  let x1, env1 = Env.get_var env1 x in
+  let _, env2 = Env.get_var env2 x in
+  let _, env1 = Env.get_var env1 y in
+  let y2, env2 = Env.get_var env2 y in
+  let init_x1, env1 = Env.mk_init_var env1 x in
+  let _, env2 = Env.mk_init_var env2 x in
+  let _, env1 = Env.mk_init_var env1 y in
+  let init_y2, env2 = Env.mk_init_var env2 y in
+  let cond = "(assert (and (= x_orig init_x_orig) (= y_mod init_y_mod)))" in
+  let expected =
+    let constr =
+      Bool.mk_and ctx [Bool.mk_eq ctx x1 init_x1; Bool.mk_eq ctx y2 init_y2]
+      |> Constr.mk_goal "(and (= x0 init_x0) (= y02 init_y02))"
+      |> Constr.mk_constr
+    in
+    Constr.mk_clause [] [constr]
+  in
+  let result = Z3_utils.mk_smtlib2_compare env1 env2 cond in
+  assert_equal ~ctxt:test_ctx
+    ~printer:Constr.to_string
+    expected result
+
+let test_mk_smtlib2_compare_2 (test_ctx : test_ctxt) : unit =
+  let ctx = Env.mk_ctx () in
+  let var_gen = Env.mk_var_gen () in
+  let env1 = Pre.mk_env ctx var_gen in
+  let env2 = Pre.mk_env ctx var_gen in
+  let env2 = Env.set_freshen env2 true in
+  let x = Var.create "x" reg32_t in
+  let x1, env1 = Env.get_var env1 x in
+  let x2, env2 = Env.get_var env2 x in
+  let _, env1 = Env.mk_init_var env1 x in
+  let init_x2, env2 = Env.mk_init_var env2 x in
+  let x_orig123 = BV.mk_const_s ctx "x_orig123" 32 in
+  let cond =
+    "(declare-const x_orig123 (_ BitVec 32)) \n\
+     (assert (and (= x_orig x_orig123) (= x_mod init_x_mod)))"
+  in
+  let expected =
+    let constr =
+      Bool.mk_and ctx [Bool.mk_eq ctx x1 x_orig123; Bool.mk_eq ctx x2 init_x2]
+      |> Constr.mk_goal "(and (= x0 x_orig123) (= x01 init_x01))"
+      |> Constr.mk_constr
+    in
+    Constr.mk_clause [] [constr]
+  in
+  let result = Z3_utils.mk_smtlib2_compare env1 env2 cond in
+  assert_equal ~ctxt:test_ctx
+    ~printer:Constr.to_string
+    expected result
+       
 let test_mk_smtlib2_single_1 (test_ctx : test_ctxt) : unit =
   let ctx = Env.mk_ctx () in
   let var_gen = Env.mk_var_gen () in
@@ -49,7 +108,7 @@ let test_mk_smtlib2_single_1 (test_ctx : test_ctxt) : unit =
   assert_equal ~ctxt:test_ctx
     ~printer:Constr.to_string
     expected result
-
+  
 let test_mk_smtlib2_single_2 (test_ctx : test_ctxt) : unit =
   let ctx = Env.mk_ctx () in
   let var_gen = Env.mk_var_gen () in
@@ -76,6 +135,8 @@ let test_mk_smtlib2_single_2 (test_ctx : test_ctxt) : unit =
     expected result
 
 let suite = [
+  "Parsing smtlib compare expression" >:: test_mk_smtlib2_compare_1;
+  "Should not overwrite x_orig123"    >:: test_mk_smtlib2_compare_2;
   "Parsing smtlib single expression" >:: test_mk_smtlib2_single_1;
   "Should not overwrite x123"        >:: test_mk_smtlib2_single_2;
 ]

--- a/wp/lib/bap_wp/tests/unit/test_z3_utils.ml
+++ b/wp/lib/bap_wp/tests/unit/test_z3_utils.ml
@@ -29,8 +29,8 @@ let test_tgt = Testing_utilities.test_tgt
 let test_mk_smtlib2_compare_1 (test_ctx : test_ctxt) : unit =
   let ctx = Env.mk_ctx () in
   let var_gen = Env.mk_var_gen () in
-  let env1 = Pre.mk_env ctx var_gen in
-  let env2 = Pre.mk_env ctx var_gen in
+  let env1 = Pre.mk_env ~target:test_tgt ctx var_gen in
+  let env2 = Pre.mk_env ~target:test_tgt ctx var_gen in
   let env2 = Env.set_freshen env2 true in
   let x = Var.create "x" reg32_t in
   let y = Var.create "y" reg32_t in
@@ -56,11 +56,12 @@ let test_mk_smtlib2_compare_1 (test_ctx : test_ctxt) : unit =
     ~printer:Constr.to_string
     expected result
 
+
 let test_mk_smtlib2_compare_2 (test_ctx : test_ctxt) : unit =
   let ctx = Env.mk_ctx () in
   let var_gen = Env.mk_var_gen () in
-  let env1 = Pre.mk_env ctx var_gen in
-  let env2 = Pre.mk_env ctx var_gen in
+  let env1 = Pre.mk_env ~target:test_tgt ctx var_gen in
+  let env2 = Pre.mk_env ~target:test_tgt ctx var_gen in
   let env2 = Env.set_freshen env2 true in
   let x = Var.create "x" reg32_t in
   let x1, env1 = Env.get_var env1 x in

--- a/wp/lib/bap_wp/tests/unit/test_z3_utils.ml
+++ b/wp/lib/bap_wp/tests/unit/test_z3_utils.ml
@@ -108,7 +108,7 @@ let test_mk_smtlib2_single_1 (test_ctx : test_ctxt) : unit =
   assert_equal ~ctxt:test_ctx
     ~printer:Constr.to_string
     expected result
-  
+
 let test_mk_smtlib2_single_2 (test_ctx : test_ctxt) : unit =
   let ctx = Env.mk_ctx () in
   let var_gen = Env.mk_var_gen () in


### PR DESCRIPTION
The function `mk_smtlib2_compare`, which existed inside `compare.ml`, is the natural comparative counterpart to `Z3_utils.mk_smtlib2_single`. 

For style and consistency, I took `mk_smtlib2_compare` from `compare.ml` and put it in `z3_utils.ml`, and edited the test files and `.mli`-files.  

I left `mk_smtlib2` the same, except I removed it from `z3_utils.mli` since it was only ever being called/used in `mk_smtlib2_compare`.