### PR TITLE
Update value-set analysis for BAP 2.x

### DIFF
--- a/vsa/value_set/lib/cbat_value_set.opam
+++ b/vsa/value_set/lib/cbat_value_set.opam
@@ -14,7 +14,7 @@ homepage: "https://github.com/draperlaboratory/cbat_tools"
 bug-reports: "https://github.com/draperlaboratory/cbat_tools"
 dev-repo: "git+https://github.com/draperlaboratory/cbat_tools"
 depends: [
-  "bap" {>= "master"}
+  "bap" {>= "2.1.0"}
   "core" {>= "0.12.4"}
   "ppx_deriving"
   "ppx_bin_prot"

--- a/vsa/value_set/lib/src/cbat_lattice_intf.ml
+++ b/vsa/value_set/lib/src/cbat_lattice_intf.ml
@@ -139,7 +139,7 @@ end = struct
   let meet a b = a && b
   let join a b = a || b
   let widen_join = join
-  let equal a b = a = b
+  let equal = Bool.(=)
   let precedes a b = (not a) || b (* definition of classical implication *)
 
   let pp ppf (b : t) = Format.fprintf ppf (if b then "top" else "bottom")

--- a/vsa/value_set/lib/src/cbat_vsa.ml
+++ b/vsa/value_set/lib/src/cbat_vsa.ml
@@ -262,7 +262,7 @@ let rec denote_exp (e : exp) (env : AI.t) : val_t or_type_error =
     let sz = Size.in_bits s in
     let exp = Type.imm sz in
     let u_type_error = Type.Error.bad_type ~exp ~got:u_typ in
-    monadic_assert (exp = u_typ) u_type_error >>= fun () ->
+    monadic_assert Type.(exp = u_typ) u_type_error >>= fun () ->
     denote_exp a env >>= val_as_imm >>= fun addr ->
     denote_exp m env >>= val_as_mem >>= fun mv ->
     denote_exp u env >>= val_as_imm >>= fun v ->
@@ -364,7 +364,7 @@ let denote_jump (denote_call : sub:tid -> AI.t -> target:tid -> AI.t)
       Format.printf "//Assuming a well-formed call-return control flow@.";
       match Call.return c with
         | None -> AI.bottom
-        | Some (Direct tid) when not (target = tid) -> AI.bottom
+        | Some (Direct tid) when compare_tid target tid <> 0 -> AI.bottom
         | Some (Indirect _)
         | Some (Direct _) ->
           (* In this case, the call might return to target *)
@@ -376,7 +376,7 @@ let denote_jump (denote_call : sub:tid -> AI.t -> target:tid -> AI.t)
       | Int _ -> not_implemented ~top:AI.top "interrupt denotation"
       | Call c -> inspect_call c
       | Goto (Direct tid)
-      | Ret (Direct tid) ->  if target = tid then env else AI.bottom
+      | Ret (Direct tid) ->  if compare_tid target tid = 0 then env else AI.bottom
       | Goto (Indirect _)
       | Ret (Indirect _) -> env
       end

--- a/vsa/value_set/plugin/value_set.ml
+++ b/vsa/value_set/plugin/value_set.ml
@@ -30,11 +30,12 @@ let main (sub : string option) (fail_not_impl : bool) (unsound_stack : bool) (sh
   Utils.unsound_stack := unsound_stack;
   let prog = Project.program proj in
   let prog = match sub with
-  | Some sname -> Term.filter sub_t prog ~f:(fun s -> sname = Sub.name s)
+  | Some sname -> Term.filter sub_t prog ~f:(fun s -> String.(sname = Sub.name s))
   | None -> prog in
   let process_sub s =
     let sname = Sub.name s in
-    if Option.value ~default:sname sub = sname then begin
+    let vname = Option.value ~default:sname sub in
+    if String.(sname = vname) then begin
       if show_vsa then Format.printf "Analyzing routine %s@." sname;
       let vsa = Vsa.static_graph_vsa [] prog s (Vsa.init_sol s) in
       Term.concat_map blk_t s ~f:begin fun b ->


### PR DESCRIPTION
I updated the VSA plugin for BAP 2.x (a somewhat workaround, though).

* Both `vsa/value_set` and `vsa/explicit_edge` now can be built
* All Unit tests in `value_set` passed
* Tested with `bap 2.2.0` and `OCaml 4.08.1`