### PR TITLE
External SMT Model Keyword "Model" Bug fix

### DIFF
--- a/wp/lib/bap_wp/src/z3_utils.ml
+++ b/wp/lib/bap_wp/src/z3_utils.ml
@@ -166,8 +166,9 @@ let asserts_of_model (model_string : string) (sym_names : string list) : Sexp.t 
             model_val
           | Sexp.List _  ->  (* Function model *)
             Sexp.List [Sexp.Atom "lambda" ; args; model_val] (* Sexp.Atom varname *)
-          | Sexp.Atom a -> failwith (sprintf "Unexpected atom %s in external model %s"
-                                     a model_string)
+          | Sexp.Atom a -> failwith (sprintf "model_string: %s\n
+                  function asserts_of_model: Unexpected atom %s in external model\n"
+                                     model_string a)
         in
         Sexp.List [Sexp.Atom "assert" ;
                    Sexp.List [Sexp.Atom "=" ; Sexp.Atom varname ; model_val]]
@@ -176,15 +177,19 @@ let asserts_of_model (model_string : string) (sym_names : string list) : Sexp.t 
           warning "Warning: %s not instantiated in Z3 query\n" varname;
           Sexp.List [Sexp.Atom "assert" ; Sexp.Atom "true"]
         end
-    | _ -> failwith (sprintf "Error: Unexpected form in external smt model: %s\n"
-                     model_string)
+    | bad_sexp -> failwith (sprintf "model_string: %s\n
+                     function asserts_of_model: Unexpected form %s in external smt model\n"
+                     model_string (Sexp.to_string bad_sexp))
   in
   let model_sexp = Sexp.of_string model_string in
   match model_sexp with
   | Sexp.List (Sexp.Atom "model" :: t) | Sexp.List t ->
     List.map ~f:process_decl t
-  | _ -> failwith (sprintf "Error: Unexpected form in external smt model: %s\n"
-                   model_string)
+  | Atom a -> failwith
+        (sprintf
+          "model_string: %s\n
+          function asserts_of_model: Unexpected outer atom %s in external smt model\n"
+          model_string a)
 
 (* We are still missing some funcdecls, particularly function return values *)
 (** [check_external] invokes an external smt solver as a process. It communicates to the

--- a/wp/lib/bap_wp/src/z3_utils.ml
+++ b/wp/lib/bap_wp/src/z3_utils.ml
@@ -166,7 +166,8 @@ let asserts_of_model (model_string : string) (sym_names : string list) : Sexp.t 
             model_val
           | Sexp.List _  ->  (* Function model *)
             Sexp.List [Sexp.Atom "lambda" ; args; model_val] (* Sexp.Atom varname *)
-          | Sexp.Atom _ -> failwith "Unexpected atom"
+          | Sexp.Atom a -> failwith (sprintf "Unexpected atom %s in external model %s"
+                                     a model_string)
         in
         Sexp.List [Sexp.Atom "assert" ;
                    Sexp.List [Sexp.Atom "=" ; Sexp.Atom varname ; model_val]]
@@ -175,13 +176,15 @@ let asserts_of_model (model_string : string) (sym_names : string list) : Sexp.t 
           warning "Warning: %s not instantiated in Z3 query\n" varname;
           Sexp.List [Sexp.Atom "assert" ; Sexp.Atom "true"]
         end
-    | _ -> failwith "Error: Unexpected form in external smt model"
+    | _ -> failwith (sprintf "Error: Unexpected form in external smt model: %s\n"
+                     model_string)
   in
   let model_sexp = Sexp.of_string model_string in
   match model_sexp with
-  | Sexp.List (Sexp.Atom "model" :: t) ->
+  | Sexp.List (Sexp.Atom "model" :: t) | Sexp.List t ->
     List.map ~f:process_decl t
-  | _ -> failwith "Error: Unexpected form in external smt model"
+  | _ -> failwith (sprintf "Error: Unexpected form in external smt model: %s\n"
+                   model_string)
 
 (* We are still missing some funcdecls, particularly function return values *)
 (** [check_external] invokes an external smt solver as a process. It communicates to the


### PR DESCRIPTION
Relaxed condition looking for keyword "model" in external smt model and enhanced error messages for easier later debugging.