### PR TITLE
Fortunac/model array printing

### DIFF
--- a/wp/lib/bap_wp/src/compare.ml
+++ b/wp/lib/bap_wp/src/compare.ml
@@ -74,10 +74,14 @@ let compare_blocks
      their original names. *)
   let env2 = Env.set_freshen env2 true in
   let post_eq_list, env1, env2 = set_to_eqs env1 env2 post_regs in
-  let smtlib_post = Z3_utils.mk_smtlib2_compare env1 env2 smtlib_post in
+  let smtlib_post =
+    Z3_utils.mk_smtlib2_compare ~name:(Some "Custom postcondition")
+      env1 env2 smtlib_post in
   let output_eq = Constr.mk_clause [] (smtlib_post :: post_eq_list) in
   let pre_eq_list, env1, env2 = set_to_eqs env1 env2 pre_regs in
-  let smtlib_hyp = Z3_utils.mk_smtlib2_compare env1 env2 smtlib_hyp in
+  let smtlib_hyp =
+    Z3_utils.mk_smtlib2_compare ~name:(Some "Custom precondition")
+      env1 env2 smtlib_hyp in
   let pre1, _ = Pre.visit_block env1 output_eq blk1 in
   let pre2, _ = Pre.visit_block env2 pre1 blk2 in
   let goal = Constr.mk_clause (smtlib_hyp :: pre_eq_list) [pre2] in

--- a/wp/lib/bap_wp/src/output.ml
+++ b/wp/lib/bap_wp/src/output.ml
@@ -116,16 +116,20 @@ let print_memory (fmt : Format.formatter) (model : Model.model)
    during the analysis. *)
 let print_call_preds (fmt : Format.formatter) (model : Model.model)
     (preds : Env.ExprSet.t) : unit =
-  let pred_vals =
-    Env.ExprSet.fold preds ~init:[] ~f:(fun pairs c ->
-        if Z3Array.is_array c then
-          pairs
-        else
-          let name = Expr.to_string c in
-          let value = Constr.eval_model_exn model c in
-          (name, value) :: pairs)
-  in
   Format.fprintf fmt "\n%!";
+  let arrays, consts =
+    Env.ExprSet.partition_tf preds ~f:Z3Array.is_array
+  in
+  Env.ExprSet.iter arrays ~f:(fun a ->
+      Format.fprintf fmt "\t%s |-> [\n" (Expr.to_string a);
+      let value = Constr.eval_model_exn model a in
+      format_mem_model fmt (extract_array value));
+  let pred_vals =
+    Env.ExprSet.fold consts ~init:[] ~f:(fun pairs c ->
+        let name = Expr.to_string c in
+        let value = Constr.eval_model_exn model c in
+        (name, value) :: pairs)
+  in
   Constr.format_values fmt pred_vals
 
 let print_fun_decls (fmt : Format.formatter) (model : Model.model) : unit =

--- a/wp/lib/bap_wp/src/runner.ml
+++ b/wp/lib/bap_wp/src/runner.ml
@@ -387,10 +387,12 @@ let single
     if String.is_empty p.postcond then
       true_constr
     else
-      Z3_utils.mk_smtlib2_single env p.postcond
+      Z3_utils.mk_smtlib2_single
+        ~name:(Some "Custom postcondition") env p.postcond
   in
   let pre, env = Pre.visit_sub env post main_sub in
-  let precond_from_flag = Z3_utils.mk_smtlib2_single env p.precond in
+  let precond_from_flag = Z3_utils.mk_smtlib2_single
+      ~name:(Some "Custom precondition") env p.precond in
   let pre = Constr.mk_clause [precond_from_flag;] [pre] in
   let pre = Constr.mk_clause hyps [pre] in
   if List.mem p.show "bir" ~equal:String.equal then

--- a/wp/lib/bap_wp/src/z3_utils.ml
+++ b/wp/lib/bap_wp/src/z3_utils.ml
@@ -102,7 +102,8 @@ let get_z3_name (map : Constr.z3_expr Var.Map.t) (name : string) (fmt : Var.t ->
 
 (** [mk_smtlib2_compare] builds a constraint out of an smtlib2 string that can be used
     as a comparison predicate between an original and modified binary. *)
-let mk_smtlib2_compare (env1 : Env.t) (env2 : Env.t) (smtlib_str : string) : Constr.t =
+let mk_smtlib2_compare ?(name = None) (env1 : Env.t) (env2 : Env.t)
+    (smtlib_str : string) : Constr.t =
   let var_map1 = Env.get_var_map env1 in
   let var_map2 = Env.get_var_map env2 in
   let init_var_map1 = Env.get_init_var_map env1 in
@@ -129,8 +130,8 @@ let mk_smtlib2_compare (env1 : Env.t) (env2 : Env.t) (smtlib_str : string) : Con
   let declsym2 = get_decls_and_symbols env2 in
   let declsym = declsym1 @ declsym2 in
   let ctx = Env.get_context env1 in
-  mk_smtlib2 ctx smtlib_str declsym
-  
+  mk_smtlib2 ~name ctx smtlib_str declsym
+
 let mk_smtlib2_single ?(name = None) (env : Env.t) (smt_post : string) : Constr.t =
   let var_map = Env.get_var_map env in
   let init_var_map = Env.get_init_var_map env in

--- a/wp/lib/bap_wp/src/z3_utils.mli
+++ b/wp/lib/bap_wp/src/z3_utils.mli
@@ -65,4 +65,4 @@ val check_external : Z3.Solver.solver
 
 (** [mk_smtlib2_compare] builds a constraint out of an smtlib2 string that can be used
     as a comparison predicate between an original and modified binary. *)
-val mk_smtlib2_compare : Env.t -> Env.t -> string -> Constr.t
+val mk_smtlib2_compare : ?name:string option -> Env.t -> Env.t -> string -> Constr.t


### PR DESCRIPTION
Some simple changes for printing the output:
- The tags of preconditions and postconditions specified by the user from the command line used to be their string representations. They now have the tag `Custom pre/postcondition`.
- We did not print z3 expressions that were arrays in the model. These will now get printed. ex:
```
loop_mem028 |-> [
		else |-> 0x00]
```
```
(g_%00000975_ret_mem RAX0 RSP0 mem0) |-> [
		else |-> 0x00]
```