### PR TITLE
Ccasin/user func spec modified vars fix

### DIFF
--- a/wp/lib/bap_wp/src/environment.ml
+++ b/wp/lib/bap_wp/src/environment.ml
@@ -368,6 +368,10 @@ let get_sp (env : t) : Var.t =
 let get_mem (env : t) : Var.t =
   Theory.Target.data (get_target env) |> Var.reify
 
+let get_all_target_vars (env : t) : Bap.Std.Var.Set.t =
+  Theory.Target.vars (get_target env) |>
+  Set.map var_comp ~f:Var.reify
+
 let fold_fun_tids (env : t) ~init:(init : 'a)
     ~f:(f : key:string -> data:Tid.t -> 'a -> 'a) : 'a =
   StringMap.fold env.fun_name_tid ~init:init ~f:f

--- a/wp/lib/bap_wp/src/environment.mli
+++ b/wp/lib/bap_wp/src/environment.mli
@@ -264,6 +264,9 @@ val get_sp : t -> Bap.Std.Var.t
 (** Obtains the BAP variable representing a program's memory. *)
 val get_mem : t -> Bap.Std.Var.t
 
+(** Obtain the set of all registers and memories for the target. *)
+val get_all_target_vars : t -> Bap.Std.Var.Set.t
+
 (** Obtains a list of all the {!Constr.z3_expr}s that represents function call
     predicates that were generated during analysis. *)
 val get_call_preds : t -> ExprSet.t

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -1303,7 +1303,7 @@ let user_func_spec
          kind of empty constr. *)
 
       (* Next, collect inputs/outputs of sub.  We do this by constructing a set
-         of all potential inputs/outputs (all the regsiters and mem), then
+         of all potential inputs/outputs (all the registers and mem), then
          filtering out everything not mentioned by the user-provided specs.
 
          Question: is SP + GPRs really all the registers?  *)

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -1304,12 +1304,8 @@ let user_func_spec
 
       (* Next, collect inputs/outputs of sub.  We do this by constructing a set
          of all potential inputs/outputs (all the registers and mem), then
-         filtering out everything not mentioned by the user-provided specs.
-
-         Question: is SP + GPRs really all the registers?  *)
-      let potential_ios : Bap.Std.Var.Set.t =
-        Set.add (Set.add (Env.get_gprs env) (Env.get_sp env)) (Env.get_mem env)
-      in
+         filtering out everything not mentioned by the user-provided specs. *)
+      let potential_ios : Bap.Std.Var.Set.t = Env.get_all_target_vars env in
       let filter_out_unused (used : string list) (adjust : string -> string) =
         Set.filter potential_ios
           ~f:(fun v ->

--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -1289,16 +1289,52 @@ let user_func_spec
   debug "Making user-defined subroutine spec with subroutine-name: %s, pre:
 %s, post: %s \n%!" sub_name sub_pre sub_post;
   if String.equal sub_name (Sub.name sub) then
-    let spec env post tid = (
+    let spec env post _tid = (
       (* turn strings into proper smtlib2 statements; incr stack_ptr *)
-      let sub_pre : Constr.t = Z3_utils.mk_smtlib2_single env sub_pre in
-      let sub_post : Constr.t = Z3_utils.mk_smtlib2_single env sub_post in
+      let (sub_pre, pre_init_vars, pre_vars)
+          : Constr.t  * string list * string list =
+        Z3_utils.mk_smtlib2_single_with_vars ~debug:true env sub_pre in
+      let (sub_post, post_init_vars, post_vars)
+          : Constr.t * string list * string list =
+        Z3_utils.mk_smtlib2_single_with_vars ~debug:true env sub_post in
+      (* TODO: Some sanity checking on sub_pre and sub_post here.  If you
+         just forget the word "assert" you silently get some kind of empty
+         constr. *)
       let sub_post, env = increment_stack_ptr sub_post env in
+
       (* collect (physical) inputs/outputs of sub *)
-      let sub_inputs : Var.t list = vars_from_sub env sub |> Var.Set.to_list in
-      let sub_inputs =
+      let sub_inputs : Var.t list = (vars_from_sub env sub |> Var.Set.to_list) in
+      let _sub_inputs =
         List.filter sub_inputs ~f:(fun v -> Var.is_physical v) in
-      let sub_outputs : Var.t list = sub_inputs in
+      let _sub_outputs : Var.t list = sub_inputs in
+
+      (* collect (physical) inputs/outputs of sub.  We do this by constructing a
+         set of all potential inputs/outputs (all the regsiters and mem), then
+         filtering out everything not mentioned by the user-provided specs.
+
+         Question: is SP + GPRs really all the registers?
+       *)
+      let potential_ios : Bap.Std.Var.Set.t =
+        Set.add (Set.add (Env.get_gprs env) (Env.get_sp env)) (Env.get_mem env)
+      in
+      let filter_out_unused (used : string list) (adjust : string -> string) =
+        Set.filter potential_ios
+          ~f:(fun v ->
+            List.exists used
+              ~f:(fun s -> String.equal (adjust (Var.to_string v)) s))
+      in
+      let (sub_inputs, sub_outputs : Var.t list * Var.t list) =
+        (Set.to_list (filter_out_unused (pre_init_vars @ post_init_vars)
+                        (fun s -> "init_" ^ s)),
+         Set.to_list (filter_out_unused (pre_vars @ post_vars) Fun.id))
+      in
+
+      Format.printf "\n\nINPUTS: ";
+      List.iter sub_inputs ~f:(fun v -> Format.printf "%s;  " (Var.to_string v));
+      Format.printf "\nOUTPUTS: ";
+      List.iter sub_outputs ~f:(fun v -> Format.printf "%s;  " (Var.to_string v));
+      Format.printf "\n\nEND DEBUG\n\n: ";
+
       let vars = Set.add (Env.get_gprs env) (Env.get_mem env)
                  |> Var.Set.to_list in
       let regs = List.map vars ~f:(fun v -> let r,_ = Env.get_var env v in r) in
@@ -1307,7 +1343,8 @@ let user_func_spec
           match r with
           | Some q -> q
           | None -> let q, _ = Env.mk_init_var env v in q) in
-      let tid_name : string = Tid.name tid in
+      let tid_name : string = Tid.create () |> Tid.to_string in
+(*      let tid_name : string = Tid.name tid in *)
       let sub_post, env = subst_fun_outputs ~tid_name:tid_name env sub
           sub_post ~inputs:sub_inputs ~outputs:sub_outputs in
       (* replace init-vars with vars inside sub_post *)

--- a/wp/lib/bap_wp/src/z3_utils.ml
+++ b/wp/lib/bap_wp/src/z3_utils.ml
@@ -132,11 +132,16 @@ let mk_smtlib2_compare ?(name = None) (env1 : Env.t) (env2 : Env.t)
   let ctx = Env.get_context env1 in
   mk_smtlib2 ~name ctx smtlib_str declsym
 
-
-let mk_smtlib2_single_with_vars ?(debug = false) ?(name = None) (env : Env.t) (smt_post : string) : Constr.t * string list * string list =
+let mk_smtlib2_single_with_vars
+      ?(name = None) (env : Env.t) (smt_post : string)
+    : Constr.t * string list * string list =
   let var_map = Env.get_var_map env in
   let init_var_map = Env.get_init_var_map env in
   let tokens = tokenize smt_post in
+
+  (* Here we are replacing variables in the user's provided input with the
+     appropriate z3 variable name.  We also save these variables for user
+     by the caller. *)
   let (tokens,pre_vars,post_vars) =
     List.fold_right tokens ~init:([],[],[]) ~f:(fun t (ts,pre_v,post_v) ->
         match get_z3_name var_map t Var.name with
@@ -149,36 +154,12 @@ let mk_smtlib2_single_with_vars ?(debug = false) ?(name = None) (env : Env.t) (s
             | None -> (t :: ts, pre_v, post_v)
           end)
   in
-  if debug then
-    begin
-(*      Format.printf "\n\nVARS IN mk_smtlib2_single\npre_vars: ";
-      List.iter pre_vars ~f:(fun v -> Format.printf "%s;  " v);
-      Format.printf "\npost_vars: ";
-      List.iter post_vars ~f:(fun v -> Format.printf "%s;  " v);
-      Format.printf "\n\nEND VARS IN mk_...\n\n" *)
-      ()
-    end
-  else ();
-(*  let smt_post =
-    smt_post
-    |> tokenize
-    |> List.map ~f:(fun token ->
-        match get_z3_name var_map token Var.name with
-        | Some n -> n |> Expr.to_string
-        | None ->
-          begin
-            match get_z3_name init_var_map token (fun v -> "init_" ^ Var.name v) with
-            | Some n -> n |> Expr.to_string
-            | None -> token
-          end)
-    |> build_str
-  in *)
+
   let smt_post = build_str tokens in
   info "New smt-lib string : %s\n" smt_post;
   let decl_syms = get_decls_and_symbols env in
   let ctx = Env.get_context env in
   (mk_smtlib2 ~name ctx smt_post decl_syms, pre_vars, post_vars)
-
 
 let mk_smtlib2_single ?(name = None) (env : Env.t) (smt_post : string)
     : Constr.t =

--- a/wp/lib/bap_wp/src/z3_utils.mli
+++ b/wp/lib/bap_wp/src/z3_utils.mli
@@ -46,7 +46,7 @@ val get_decls_and_symbols : Env.t -> ((Z3.FuncDecl.func_decl * Z3.Symbol.symbol)
     and postconditions for single binary analysis *)
 val mk_smtlib2_single : ?name:string option -> Env.t -> string -> Constr.t
 
-(** [mk_smtlib2_single_with-vars name env smtlib_str] takes in a string
+(** [mk_smtlib2_single_with_vars name env smtlib_str] takes in a string
    representing a valid SMT-Lib-2 statement and returns a WP constraint tagged
    with [name], as well as lists the "init" and non-"init" variables that appear
    in the constraint.  The variables in the SMT-Lib statements need to appear in

--- a/wp/lib/bap_wp/src/z3_utils.mli
+++ b/wp/lib/bap_wp/src/z3_utils.mli
@@ -46,6 +46,15 @@ val get_decls_and_symbols : Env.t -> ((Z3.FuncDecl.func_decl * Z3.Symbol.symbol)
     and postconditions for single binary analysis *)
 val mk_smtlib2_single : ?name:string option -> Env.t -> string -> Constr.t
 
+(** [mk_smtlib2_single_with-vars name env smtlib_str] takes in a string
+   representing a valid SMT-Lib-2 statement and returns a WP constraint tagged
+   with [name], as well as lists the "init" and non-"init" variables that appear
+   in the constraint.  The variables in the SMT-Lib statements need to appear in
+   the environment. The intended purpose of this function is generating
+   hypothesis and postconditions for single binary analysis *)
+val mk_smtlib2_single_with_vars : ?debug:bool -> ?name:string option -> Env.t -> string -> (Constr.t * string list * string list)
+
+
 (** [mk_and] is a slightly optimized version of [Bool.mk_and] that does not produce an
     [and] node if the number of operands is less than 2. This may improve sharing,
     but also improves compatibility of smtlib2 expressions with other solvers.  *)

--- a/wp/lib/bap_wp/src/z3_utils.mli
+++ b/wp/lib/bap_wp/src/z3_utils.mli
@@ -52,7 +52,8 @@ val mk_smtlib2_single : ?name:string option -> Env.t -> string -> Constr.t
    in the constraint.  The variables in the SMT-Lib statements need to appear in
    the environment. The intended purpose of this function is generating
    hypothesis and postconditions for single binary analysis *)
-val mk_smtlib2_single_with_vars : ?debug:bool -> ?name:string option -> Env.t -> string -> (Constr.t * string list * string list)
+val mk_smtlib2_single_with_vars : ?name:string option -> Env.t -> string
+  -> (Constr.t * string list * string list)
 
 
 (** [mk_and] is a slightly optimized version of [Bool.mk_and] that does not produce an


### PR DESCRIPTION
Changes how we calculate what system state is modified when using a user function spec.

The old story was that we analyzed the actual implementation of the function to see what state it touched, and treated everything it touched as both an input an an output to the function.  This had a few issues.  Most pressingly, it doesn't work at all for functions where the implementation is unavailable or can't be analyzed.  It also meant we overestimated what state is changed by a function.

The new system is to look at the variables in the user-provided function spec.  Uses of variables corresponding to the initial values of registers/memory mean those are inputs, and uses of variables corresponding to the final values of registers/memory mean those are updated by the function.  This works well enough - the tests pass (I haven't added new tests since it is exercised by all our existing user function spec tests).

