### PR TITLE
Fixes detection of intrinsic calls in BAP

### DIFF
--- a/wp/lib/bap_wp/src/loader.mli
+++ b/wp/lib/bap_wp/src/loader.mli
@@ -25,7 +25,3 @@ open Bap_core_theory
 (** Slot containing the registers that are referenced in an assembly
     instruction. *)
 val registers : (Theory.Semantics.cls, Var.Set.t) KB.slot
-
-(** Slot that states whether an instruction is lifted as an intrinsic call or
-    not. *)
-val intrinsic : (Theory.Semantics.cls, bool option) KB.slot


### PR DESCRIPTION
Addresses #366.

We no longer rely on a BIL lifter being available, but instead look at
the subroutine in question since the information is there on whether it
is intrinsic or not.

The `Sub.intrinsic` tag doesn't seem to get populated anywhere, so for
now we can check that the subroutine's name is prefixed with
`intrinsic:`.