### PR TITLE
Changes `init-mem` to look at all read-only segments

### DIFF
--- a/wp/lib/bap_wp/src/compare.ml
+++ b/wp/lib/bap_wp/src/compare.ml
@@ -28,6 +28,7 @@ type 'a code =
     prog : 'a term;
     env : Env.t;
     mem : value memmap;
+    code_addrs : Addr.Set.t;
   }
 
 
@@ -313,8 +314,10 @@ let compare_subs_mem_init : comparator * comparator =
     post, original.env, modified.env
   in
   let hyps ~original ~modified ~rename_set:_ =
-    let mem_orig, env1 = Pre.init_mem original.env original.mem in
-    let mem_mod, env2 = Pre.init_mem modified.env modified.mem in
+    let mem_orig, env1 =
+      Pre.init_mem original.env original.mem original.code_addrs in
+    let mem_mod, env2 =
+      Pre.init_mem modified.env modified.mem modified.code_addrs in
     let pre = Constr.mk_clause [] (mem_orig @ mem_mod) in
     pre, env1, env2
   in

--- a/wp/lib/bap_wp/src/compare.mli
+++ b/wp/lib/bap_wp/src/compare.mli
@@ -44,6 +44,7 @@ type 'a code =
     prog : 'a term;
     env : Env.t;
     mem : value memmap;
+    code_addrs : Addr.Set.t;
   }
 
 (** The type of functions that generate a postcondition or hypothesis for

--- a/wp/lib/bap_wp/src/precondition.mli
+++ b/wp/lib/bap_wp/src/precondition.mli
@@ -102,8 +102,17 @@ val init_mem_range
   -> Constr.z3_expr
   -> Constr.z3_expr
 
-(** Generates a list of constraints: [mem[0xloc] == 0xval] where the [mem] variable is taken from the environment, and the loc/val pairs are taken from the memmap. *)
-val init_mem : Env.t -> Bap.Std.value Bap.Std.memmap -> Constr.t list * Env.t
+(** Generates a list of constraints: [mem[0xloc] == 0xval] where the [mem] variable
+    is taken from the environment, and the loc/val pairs are taken from the memmap.
+
+    A set of known code addresses is provided. The addresses in this set are ignored
+    when generating the constraints.
+*)
+val init_mem
+  :  Env.t
+  -> Bap.Std.value Bap.Std.memmap
+  -> Bap.Std.Addr.Set.t
+  -> Constr.t list * Env.t
 
 (** Create a Z3 expression that denotes a load in memory [mem] at address [addr]
     with a word size of [word_size] bits and endianness [endian]. *)

--- a/wp/lib/bap_wp/src/runner.ml
+++ b/wp/lib/bap_wp/src/runner.ml
@@ -349,6 +349,7 @@ let single
     (var_gen : Env.var_gen)
     (p : params)
     (prog : program term)
+    (code_addrs : Addr.Set.t)
     (mem : value memmap)
     (target : Theory.target)
     (_file : string)
@@ -392,7 +393,7 @@ let single
   let init_mem_hyps, env =
     (* FIXME: check p.init_mem here *)
     if p.init_mem then
-      Pre.init_mem env mem
+      Pre.init_mem env mem code_addrs
     else
       [], env
   in
@@ -411,7 +412,15 @@ let single
   let pre = Constr.mk_clause hyps [pre] in
   if List.mem p.show "bir" ~equal:String.equal then
     Printf.printf "\nSub:\n%s\n%!" (Sub.to_string main_sub);
-  Single { pre = pre; orig = Comp.{ env=env; prog=main_sub; mem = mem} }
+  Single {
+    pre;
+    orig = Comp.{
+        env;
+        prog = main_sub;
+        mem;
+        code_addrs;
+      }
+  }
 
 (* Runs a comparative analysis. *)
 let comparative
@@ -419,10 +428,12 @@ let comparative
     (var_gen : Env.var_gen)
     (p : params)
     (prog1 : program term)
+    (code1 : Addr.Set.t)
     (mem1 : value memmap)
     (target1 : Theory.target)
     (file1 : string)
     (prog2 : program term)
+    (code2 : Addr.Set.t)
     (mem2 : value memmap)
     (target2 : Theory.target)
     (file2 : string)
@@ -480,8 +491,8 @@ let comparative
     (*(Bap.Std.Var.Set.union vars_sub vars_pointer_reg |> Bap.Std.Var.Set.union sp) env1 in*)
     env1, vars_pointer_reg
   in
-  let code1 = Comp.{ prog = main_sub1; env = env1; mem = mem1 } in
-  let code2 = Comp.{ prog = main_sub2; env = env2; mem = mem2 } in
+  let code1 = Comp.{prog = main_sub1; env = env1; mem = mem1; code_addrs = code1} in
+  let code2 = Comp.{prog = main_sub2; env = env2; mem = mem2; code_addrs = code2} in
   let posts, hyps =
     comparators_of_flags ~orig:code1 ~modif:code2 p
       (pointer_vars_1 |> Bap.Std.Var.Set.to_list)
@@ -552,10 +563,10 @@ type Bap_main.Extension.Error.t += Unsupported_file_count of string
 type input =
   {
     program : program term;
+    code_addrs : Addr.Set.t;
     target : Theory.target;
     filename : string;
   }
-
 
 (* Entrypoint for the WP analysis. *)
 let run
@@ -570,19 +581,32 @@ let run
   (* Determine whether to perform a single or comparative analysis. *)
   match files with
   | [input] ->
-    let {program = prog ; target = tgt; filename = file} = input in
-    let mem = Utils.init_mem ~init_mem:p.init_mem file in
-    single z3_ctx var_gen p prog mem tgt file
+    let {program = prog; code_addrs; target = tgt; filename = file} = input in
+    let mem = Utils.init_mem ~ogre:p.ogre ~init_mem:p.init_mem file in
+    single z3_ctx var_gen p prog code_addrs mem tgt file
     |> check_pre p z3_ctx
   | [input1; input2] ->
-    let { program = prog1; target = tgt1; filename = file1} = input1 in
-    let { program = prog2; target = tgt2; filename = file2} = input2 in
-    let mem1 = Utils.init_mem ~init_mem:p.init_mem file1 in
-    let mem2 = Utils.init_mem ~init_mem:p.init_mem file2 in
+    let {
+      program = prog1;
+      code_addrs = code1;
+      target = tgt1;
+      filename = file1
+    } = input1 in
+    let {
+      program = prog2;
+      code_addrs = code2;
+      target = tgt2;
+      filename = file2
+    } = input2 in
+    let ogre1, ogre2 = match p.ogre with
+      | Some _ -> p.ogre, p.ogre
+      | None -> p.ogre_orig, p.ogre_mod in
+    let mem1 = Utils.init_mem ~ogre:ogre1 ~init_mem:p.init_mem file1 in
+    let mem2 = Utils.init_mem ~ogre:ogre2 ~init_mem:p.init_mem file2 in
     comparative
       z3_ctx var_gen p
-      prog1 mem1 tgt1 file1
-      prog2 mem2 tgt2 file2
+      prog1 code1 mem1 tgt1 file1
+      prog2 code2 mem2 tgt2 file2
     |> check_pre p z3_ctx
   | _ ->
     let err =

--- a/wp/lib/bap_wp/src/runner.mli
+++ b/wp/lib/bap_wp/src/runner.mli
@@ -24,9 +24,18 @@ open Bap_core_theory
 
 module Params = Run_parameters
 
+(** The program data.
+
+    - [program] is the program to be checked.
+    - [code_addrs] is a hash set of addresses that are known to point to
+      executable code (excludes inlined data in the code sections).
+    - [target] is the target machine.
+    - [filename] is the filename of the program.
+*)
 type input =
   {
     program : program term;
+    code_addrs : Addr.Set.t;
     target : Theory.target;
     filename : string;
   }

--- a/wp/lib/bap_wp/src/utils.mli
+++ b/wp/lib/bap_wp/src/utils.mli
@@ -55,4 +55,8 @@ val match_inline : string option -> sub term seq -> sub term seq
     (fatal) errors.
     Returns empty memory if [init_mem = false].
  *)
-val init_mem : ?init_mem:bool -> Image.path -> value memmap
+val init_mem : ?ogre:string option -> ?init_mem:bool -> Image.path -> value memmap
+
+(** [collect_code_addrs state] returns the set of known instruction
+    addresses given the [state] of a [Project.t]. *)
+val collect_code_addrs : Project.state -> Addr.Set.t

--- a/wp/lib/bap_wp/tests/unit/test_compare.ml
+++ b/wp/lib/bap_wp/tests/unit/test_compare.ml
@@ -41,9 +41,19 @@ let assert_z3_compare (test_ctx : test_ctxt) (body1 : string) (body2 : string)
         print_z3_model solver exp real pre ~orig:env1 ~modif:env2)
     expected result
 
-let code_of_blk blk env = Comp.{env = env; prog = blk; mem = Memmap.empty}
+let code_of_blk blk env = Comp.{
+    env;
+    prog = blk;
+    mem = Memmap.empty;
+    code_addrs = Addr.Set.empty;
+  }
 
-let code_of_sub sub env = Comp.{env = env; prog = sub; mem = Memmap.empty}
+let code_of_sub sub env = Comp.{
+    env;
+    prog = sub;
+    mem = Memmap.empty;
+    code_addrs = Addr.Set.empty;
+  }
 
 let test_block_pair_1 (test_ctx : test_ctxt) : unit =
   let ctx = Env.mk_ctx () in

--- a/wp/lib/bap_wp/tests/unit/testing_utilities.ml
+++ b/wp/lib/bap_wp/tests/unit/testing_utilities.ml
@@ -84,10 +84,12 @@ let no_model (s1 : Solver.status) (s2 : Solver.status) : bool =
   | Solver.UNSATISFIABLE, _ -> true
   | _, _ -> false
 
-let env_code env =
-  let empty_sub = mk_sub [] in
-  let empty_mem = Memmap.empty in
-  Compare.{env = env; prog = empty_sub; mem = empty_mem}
+let env_code env = Compare.{
+    env;
+    prog = mk_sub [];
+    mem = Memmap.empty;
+    code_addrs = Addr.Set.empty;
+  }
 
 let print_z3_model
     ~orig:(env1 : Env.t) ~modif:(env2 : Env.t)

--- a/wp/plugin/lib/wp_analysis.ml
+++ b/wp/plugin/lib/wp_analysis.ml
@@ -35,7 +35,7 @@ let run (p : Params.t) (files : string list) (bap_ctx : ctxt)
 
   (* Unbundle the input file into its loaded program *)
   let mk_input (file,loader) =
-    let prog, tgt =
+    let prog, tgt, code_addrs =
       Utils.read_program
         bap_ctx
         ~loader:(Option.value loader ~default:Utils.default_loader)
@@ -43,6 +43,7 @@ let run (p : Params.t) (files : string list) (bap_ctx : ctxt)
     in
     Runner.{
       program = prog;
+      code_addrs;
       target = tgt;
       filename = file;
     }

--- a/wp/plugin/lib/wp_cache.ml
+++ b/wp/plugin/lib/wp_cache.ml
@@ -94,10 +94,12 @@ end
 
 module Program = struct
 
+  type t = Program.t * Theory.Target.t * Addr.Set.t [@@deriving bin_io]
+
   (* Creates a program cache. *)
-  let program_cache () : (Program.t * Theory.Target.t) Data.Cache.t =
+  let program_cache () : t Data.Cache.t =
     let module Prog = struct
-      type t = Program.t * Theory.Target.t [@@deriving bin_io]
+      type nonrec t = t [@@deriving bin_io]
     end in
     let of_bigstring = Binable.of_bigstring (module Prog) in
     let to_bigstring = Binable.to_bigstring (module Prog) in
@@ -106,13 +108,14 @@ module Program = struct
     Data.Cache.Service.request reader writer
 
   (* Loads a program and its architecture (if any) from the cache. *)
-  let load (digest : digest) : (Program.t * Theory.Target.t) option =
+  let load (digest : digest) : t option =
     let cache = program_cache () in
     Data.Cache.load cache digest
 
   (* Saves a program and its architecture in the cache. *)
-  let save (digest : digest) (program : Program.t) (tgt : Theory.Target.t) : unit =
+  let save (digest : digest) (program : Program.t) (tgt : Theory.Target.t)
+      (code_addrs : Addr.Set.t) : unit =
     let cache = program_cache () in
-    Data.Cache.save cache digest (program, tgt)
+    Data.Cache.save cache digest (program, tgt, code_addrs)
 
 end

--- a/wp/plugin/lib/wp_cache.mli
+++ b/wp/plugin/lib/wp_cache.mli
@@ -73,10 +73,12 @@ end
     the program in BIR after disassembly, and the architecture of the binary. *)
 module Program : sig
 
+  type t = Program.t * Theory.target * Addr.Set.t
+
   (** Loads a program and its architecture (if any) from the cache. *)
-  val load : digest -> (Program.t * Theory.target) option
+  val load : digest -> t option
 
   (** Saves a program and its architecture in the cache. *)
-  val save : digest -> Program.t -> Theory.target -> unit
+  val save : digest -> Program.t -> Theory.target -> Addr.Set.t -> unit
 
 end

--- a/wp/plugin/lib/wp_utils.ml
+++ b/wp/plugin/lib/wp_utils.ml
@@ -67,7 +67,7 @@ end
 
 (* Reads in the program_t and its architecture from a file. *)
 let read_program (ctxt : ctxt) ~(loader : string) ~(filepath : string)
-  : Program.t * Theory.target =
+  : Program.t * Theory.target * Addr.Set.t =
   let mk_digest = Cache.Digests.get_generator ctxt ~filepath ~loader in
   let program_digest = Cache.Digests.program mk_digest in
   match Cache.Program.load program_digest with
@@ -80,7 +80,9 @@ let read_program (ctxt : ctxt) ~(loader : string) ~(filepath : string)
     info "Saving program %s (%a) to cache.%!"
       filepath Data.Cache.Digest.pp program_digest;
     let project = create_proj None loader filepath in
+    let code_addrs =
+      project |> Project.state |> Bap_wp.Utils.collect_code_addrs in
     let prog = project |> Project.program |> clear_mapper#run in
     let tgt = Project.target project in
-    let () = Cache.Program.save program_digest prog tgt in
-    prog, tgt
+    let () = Cache.Program.save program_digest prog tgt code_addrs in
+    prog, tgt, code_addrs

--- a/wp/plugin/lib/wp_utils.mli
+++ b/wp/plugin/lib/wp_utils.mli
@@ -29,5 +29,8 @@ val default_loader : string
 
 (** Obtains the program representation and the architecture of the binary at the
     given filepath using the BAP context and loader for lifting the binary. *)
-val read_program :
-  ctxt -> loader:string -> filepath:string -> Program.t * Theory.target
+val read_program
+  :  ctxt
+  -> loader:string
+  -> filepath:string
+  -> Program.t * Theory.target * Addr.Set.t


### PR DESCRIPTION
The `--init-mem` option currently tells WP to initialize everything in the `.rodata` section for both the original and modified binaries. In some binaries, we might be interested in code that gets inlined into the `.text` section (e.g. constant pools on ARM/Thumb).

This PR changes the behavior to look at any segment without write permissions. Since this will include the executable segments, it can potentially cause a blowup in memory usage. To fix this, we cache the set of known code addresses by calling `Disasm.Driver.explore` on entry to the library/plugin.

On a side note, if an OGRE file was provided, then `Utils.init_mem` should use that as the loader instead of the default loader (currently LLVM). This can save a lot on memory usage and running time.