### PR TITLE
Add diagnostics to show flag

### DIFF
--- a/wp/lib/bap_wp/src/precondition.ml
+++ b/wp/lib/bap_wp/src/precondition.ml
@@ -1430,13 +1430,14 @@ let mem_read_offsets (env2 : Env.t)
 let check ?(refute = true) ?(print_constr = []) ?(debug = false) ?ext_solver
     ?(fmt = Format.err_formatter) (solver : Solver.solver)
     (ctx : Z3.context) (pre : Constr.t)  : Solver.status =
-  Format.fprintf fmt "Evaluating precondition.\n%!";
-
+  if Utils.print_diagnostics print_constr then
+    Format.fprintf fmt "Evaluating precondition.\n%!";
   if (List.mem print_constr "precond-internal" ~equal:(String.equal)) then (
     let colorful = List.mem print_constr "colorful" ~equal:String.equal in
     Printf.printf "Internal : %s \n %!" (Constr.to_string ~colorful:colorful pre) ) ;
   let pre' = Constr.eval ~debug:debug pre ctx in
-  Format.fprintf fmt "Checking precondition with Z3.\n%!";
+  if Utils.print_diagnostics print_constr then
+    Format.fprintf fmt "Checking precondition with Z3.\n%!";
   let is_correct =
     if refute then
       Bool.mk_implies ctx pre' (Bool.mk_false ctx)

--- a/wp/lib/bap_wp/src/run_parameters.ml
+++ b/wp/lib/bap_wp/src/run_parameters.ml
@@ -113,7 +113,8 @@ let validate_show (show : string list) : (unit, error) result =
     "paths";
     "precond-internal";
     "precond-smtlib";
-    "colorful"
+    "colorful";
+    "diagnostics"
   ] in
   match find_unsupported_option show supported with
   | Some s ->

--- a/wp/lib/bap_wp/src/runner.ml
+++ b/wp/lib/bap_wp/src/runner.ml
@@ -546,13 +546,15 @@ let check_pre (p : params) (ctx : Z3.context) (cp : combined_pre)
   in
   output_to_gdb ~filename:p.gdb_output ~func:p.func solver result env;
   output_to_bildb ~filename:p.bildb_output solver result env;
-  let () = match cp with
-    | Single cp ->
-      Output.print_result solver result cp.pre ~orig:cp.orig
-        ~modif:cp.orig ~show:p.show;
-    | Comparative cp ->
-      Output.print_result solver result cp.pre ~orig:cp.orig
-        ~modif:cp.modif ~show:p.show;
+  let () =
+    if Utils.print_diagnostics p.show then
+      match cp with
+      | Single cp ->
+        Output.print_result solver result cp.pre ~orig:cp.orig
+          ~modif:cp.orig ~show:p.show;
+      | Comparative cp ->
+        Output.print_result solver result cp.pre ~orig:cp.orig
+          ~modif:cp.modif ~show:p.show;
   in
   Ok result
 

--- a/wp/lib/bap_wp/src/utils.ml
+++ b/wp/lib/bap_wp/src/utils.ml
@@ -162,3 +162,6 @@ module Code_addrs = struct
   let contains : t -> addr -> bool = Tree.contains
 
 end
+
+let print_diagnostics (show : string list) : bool =
+  List.mem show "diagnostics" ~equal:String.equal

--- a/wp/lib/bap_wp/src/utils.mli
+++ b/wp/lib/bap_wp/src/utils.mli
@@ -62,10 +62,13 @@ module Code_addrs : sig
 
   (** The empty set. *)
   val empty : t
-  
+
   (** [collect proj] returns the set of known code addresses in [proj]. *)
   val collect : project -> t
 
   (** [containts t addr] returns [true] if [addr] is a code address in [t]. *)
   val contains : t -> addr -> bool
 end
+
+(** [print_diagnostics show] checks if the 'diagnostics' flag is in [show]. *)
+val print_diagnostics : string list -> bool

--- a/wp/plugin/wp.ml
+++ b/wp/plugin/wp.ml
@@ -195,7 +195,10 @@ let show = Cmd.parameter Typ.(list string) "show"
            `colorful': precond-internal can have color to highlight key words,
            making the output easier to read. Warning: Coloring will change
            the syntax, so don't use this flag if you wish to pass the printed
-           output as an input elsewhere.|}
+           output as an input elsewhere.
+
+           `diagnostics': Prints out debugging information about runtime to
+           stderr.|}
 
 let stack_base = Cmd.parameter Typ.(some int) "stack-base"
     ~doc:{|Sets the location of the stack frame for the function under


### PR DESCRIPTION
Adds the flag for printing diagnostics. If the flag is set, the "evaluating constraint" message, the "sending to Z3" message, the output of "SAT/UNSAT/UNKNOWN", and the model is sent to stderr. 