### PR TITLE
Fixes building the plugin for latest BAP

### DIFF
--- a/wp/lib/bap_wp/src/dune
+++ b/wp/lib/bap_wp/src/dune
@@ -1,5 +1,5 @@
 (library
    (name bap_wp)
    (public_name bap_wp)
-   (libraries bap bap-x86-cpu bap-arm z3 ounit2 re str)
+   (libraries bap bap-x86-cpu bap-arm z3 ounit2 re str findlib.dynload threads)
    (preprocess (pps ppx_sexp_conv ppx_bin_prot)))

--- a/wp/plugin/Makefile
+++ b/wp/plugin/Makefile
@@ -88,24 +88,19 @@ reinstall: uninstall reinstall
 
 test.build:
 	$(MAKE) -C $(SAMPLE_BIN_DIR)
+	$(MAKE) -C tests build
 
 test.clean:
 	$(MAKE) -C $(SAMPLE_BIN_DIR) clean
+	$(MAKE) -C tests clean
 
 .PHONY: test
 test: test.unit
 
 .PHONY: test.unit
 test.unit: install
-	ocamlbuild -r -use-ocamlfind \
-		-pkgs $(TEST_PKGS) \
-		-tag $(TEST_TAG) -Is $(TEST_Is_UNIT) test.native
-	./test.native
+	$(MAKE) -C tests test.unit
 
 .PHONY: test.integration
 test.integration: install
-	ocamlbuild -r -use-ocamlfind \
-		-pkgs $(TEST_PKGS) \
-		-tag $(TEST_TAG) \
-		-tag $(TEST_TAG) -Is $(TEST_Is_INTEGRATION) test.native
-	./test.native
+	$(MAKE) -C tests test.integration

--- a/wp/plugin/Makefile
+++ b/wp/plugin/Makefile
@@ -2,7 +2,7 @@ PASS_NAME := wp
 SHELL := /bin/bash
 
 SAMPLE_BIN_DIR := ../resources/sample_binaries
-API_PATH := $(shell bap --api-list-paths)
+API_PATH := $(shell bap config sysdatadir)/api
 VERIFIER_LOCAL := api/c/cbat.h
 VERIFIER_INSTALL_PATH := $(API_PATH)/c/cbat.h
 
@@ -76,7 +76,7 @@ uninstall.verifier:
 
 .PHONY: uninstall
 uninstall: uninstall.verifier
-	bapbundle remove $(PASS_NAME).plugin
+	-bapbundle remove $(PASS_NAME).plugin
 
 .PHONY: reinstall
 reinstall: uninstall reinstall

--- a/wp/plugin/tests/Makefile
+++ b/wp/plugin/tests/Makefile
@@ -1,0 +1,36 @@
+#####################################################
+# DEFAULT
+#####################################################
+
+.DEFAULT_GOAL = all
+
+.PHONY: all
+all: build test.unit test.integration
+
+#####################################################
+# BUILD
+#####################################################
+
+.PHONY: build
+build:
+	dune build
+
+#####################################################
+# CLEAN
+#####################################################
+
+.PHONY: clean
+clean:
+	dune clean
+
+#####################################################
+# TEST
+#####################################################
+
+.PHONY: test.unit
+test.unit:
+	dune runtest --force unit
+
+.PHONY: test.integration
+test.integration:
+	dune runtest --force integration

--- a/wp/plugin/tests/dune-project
+++ b/wp/plugin/tests/dune-project
@@ -1,0 +1,24 @@
+(lang dune 3.0)
+(name wp-plugin-tests)
+(license MIT)
+(version 0.1)
+(source (github draperlaboratory/cbat_tools))
+
+(authors "Draper Laboratory")
+
+(maintainers
+ "Chloe Fortuna <cfortuna@draper.com"
+ "Philip Zucker <pzucker@draper.com>"
+ "Benjamin Mourad <bmourad@draper.com>")
+
+(generate_opam_files true)
+
+(package
+ (name wp-plugin-tests)
+ (synopsis "Tests for the weakest-precondition analysis plugin")
+ (depends
+  (bap (>= 2.6.0))
+  (core (>= v0.15))
+  (z3 (>= 4.8.14))
+  (ounit2 (>= 2.2.3))
+  (re (>= 1.9.0))))

--- a/wp/plugin/tests/integration/dune
+++ b/wp/plugin/tests/integration/dune
@@ -1,0 +1,14 @@
+(tests
+ (names test)
+ (libraries
+   bap
+   ounit2
+   z3
+   findlib.dynload
+   threads
+   re
+   str
+   core_unix
+   wp-plugin-tests)
+ (flags -w -5A-48-44-70)
+ (ocamlopt_flags -O3))

--- a/wp/plugin/tests/integration/dune
+++ b/wp/plugin/tests/integration/dune
@@ -10,5 +10,5 @@
    str
    core_unix
    wp-plugin-tests)
- (flags -w -5A-48-44-70)
+ (flags -w -A-48-44-70)
  (ocamlopt_flags -O3))

--- a/wp/plugin/tests/integration/test_wp_integration.ml
+++ b/wp/plugin/tests/integration/test_wp_integration.ml
@@ -1,5 +1,5 @@
 open OUnitTest
-open Test_wp_utils
+open Wp_plugin_tests.Test_wp_utils
 
 let integration_tests = List.append [
 

--- a/wp/plugin/tests/test_libs/dune
+++ b/wp/plugin/tests/test_libs/dune
@@ -1,0 +1,14 @@
+(library
+ (name wp_plugin_tests)
+ (public_name wp-plugin-tests)
+ (flags -w -A-44-70)
+ (libraries
+   bap
+   z3
+   bap_wp
+   ounit2
+   re
+   str
+   core_unix
+   findlib.dynload
+   threads))

--- a/wp/plugin/tests/test_libs/test_wp_utils.ml
+++ b/wp/plugin/tests/test_libs/test_wp_utils.ml
@@ -24,7 +24,7 @@ module IntSet = Set.Make(Int)
 
 (* To run these tests: `make test` or `make test.integration` in wp directory *)
 
-let bin_dir = "../resources/sample_binaries"
+let bin_dir = "../../../../../resources/sample_binaries"
 
 let timeout_msg = "Test times out!"
 

--- a/wp/plugin/tests/unit/dune
+++ b/wp/plugin/tests/unit/dune
@@ -1,0 +1,14 @@
+(tests
+ (names test)
+ (libraries
+   bap
+   ounit2
+   z3
+   findlib.dynload
+   threads
+   re
+   str
+   core_unix
+   wp-plugin-tests)
+ (flags -w -5A-48-44-70)
+ (ocamlopt_flags -O3))

--- a/wp/plugin/tests/unit/dune
+++ b/wp/plugin/tests/unit/dune
@@ -10,5 +10,5 @@
    str
    core_unix
    wp-plugin-tests)
- (flags -w -5A-48-44-70)
+ (flags -w -A-48-44-70)
  (ocamlopt_flags -O3))

--- a/wp/plugin/tests/unit/test_wp_unit.ml
+++ b/wp/plugin/tests/unit/test_wp_unit.ml
@@ -1,5 +1,5 @@
 open OUnitTest
-open Test_wp_utils
+open Wp_plugin_tests.Test_wp_utils
 
 let unit_tests = [
 


### PR DESCRIPTION
1. For the API path, we should use `bap config sysdatadir`
2. `bapbundle remove <plugin>` will return a nonzero error code if the plugin is not installed, which can be annoying when trying to build the project. The error code should be ignored in the Makefile.