### PR TITLE
Fixes not extracting the memory model from lambda terms

### DIFF
--- a/wp/lib/bap_wp/src/constraint.ml
+++ b/wp/lib/bap_wp/src/constraint.ml
@@ -19,6 +19,7 @@ module Bool = Z3.Boolean
 module BV = Z3.BitVector
 module Model = Z3.Model
 module Solver = Z3.Solver
+
 type z3_expr = Expr.expr
 
 type path = bool Jmp.Map.t

--- a/wp/lib/bap_wp/src/output.ml
+++ b/wp/lib/bap_wp/src/output.ml
@@ -14,7 +14,6 @@
 open !Core
 open Bap.Std
 open Bap_core_theory
-open Monads.Std
 
 include Self()
 
@@ -38,9 +37,8 @@ type mem_model = {
 
 let equal_mem_model (m1 : mem_model) (m2 : mem_model) : bool =
   let eqe (k1, v1) (k2, v2) = Expr.equal k1 k2 && Expr.equal v1 v2 in
-  let eqd = Expr.equal m1.default m2.default in
-  let eqm = List.equal eqe m1.model m2.model in
-  eqd && eqm
+  Expr.equal m1.default m2.default &&
+  List.equal eqe m1.model m2.model
 
 let format_mem_model (fmt : Format.formatter) (mem_model : mem_model) : unit =
   mem_model.model |> List.iter ~f:(fun (key, data) ->

--- a/wp/lib/bap_wp/src/output.mli
+++ b/wp/lib/bap_wp/src/output.mli
@@ -11,26 +11,24 @@
 (*                                                                         *)
 (***************************************************************************)
 
-(**
-
-   This module exports types and utilities to process and report results found
-   using the WP plugin.
-
-   The report contains information about the result of the WP analysis, and in
-   the case the result is [SAT], prints out the model that contains the input
-   register and memory values that result in the program refuting a goal, the path
-   taken to the refuted goal, and the register values at each jump in the path.
-
+(** This module exports types and utilities to process and report results
+    found using the WP plugin.
+    
+    The report contains information about the result of the WP analysis, and in
+    the case the result is [SAT], prints out the model that contains the input
+    register and memory values that result in the program refuting a goal, the
+    path taken to the refuted goal, and the register values at each jump in the
+    path.
 *)
 
 module Env = Environment
 
 module Constr = Constraint
 
-(** Prints out the result from check, and if the result is [SAT], generate a model that
-    represents the registers and memory values that lead to a specific program state,
-    a list of goals that have been refuted, and if specified, the paths that lead to
-    the refuted goals. *)
+(** Prints out the result from check, and if the result is [SAT], generate a
+    model that represents the registers and memory values that lead to a
+    specific program state, a list of goals that have been refuted, and if
+    specified, the paths that lead to the refuted goals. *)
 val print_result
   : ?fmt:Format.formatter
   -> Z3.Solver.solver
@@ -41,20 +39,41 @@ val print_result
   -> modif:(Bap.Std.sub Compare.code)
   -> unit
 
-(** Prints to file a gdb script that will fill the appropriate registers with the countermodel *)
+(** Prints to file a gdb script that will fill the appropriate registers with
+    the countermodel *)
 val output_gdb :
-  Z3.Solver.solver -> Z3.Solver.status -> Env.t -> func:string -> filename:string -> unit
+  Z3.Solver.solver ->
+  Z3.Solver.status ->
+  Env.t ->
+  func:string ->
+  filename:string ->
+  unit
 
 (** [output_bildb solver status env file] prints to a YAML file that will fill
     the appropriate registers with the values found in the countermodel in the
-    case the analysis returns SAT. This is used to initialize the BilDB plugin.*)
+    case the analysis returns SAT. This is used to initialize the BilDB
+    plugin. *)
 val output_bildb :
-  Z3.Solver.solver -> Z3.Solver.status -> Env.t -> string -> unit
+  Z3.Solver.solver ->
+  Z3.Solver.status ->
+  Env.t ->
+  string ->
+  unit
 
-(** [mem_model] The default value stores the final else branch of a memory model. The model holds an association list of addresses and
-    values held at those adresses. *)
-type mem_model = {default : Constr.z3_expr ; model : (Constr.z3_expr * Constr.z3_expr) list}
+(** [mem_model] The default value stores the final else branch of a memory
+    model. The model holds an association list of addresses and values held
+    at those adresses. *)
+type mem_model = {
+  default : Constr.z3_expr;
+  model : (Constr.z3_expr * Constr.z3_expr) list
+}
 
-(** [extract_array] takes a z3 expression that is a sequence of stores and converts it into
-    a mem_model, which consists of a key/value association list and a default value *)
+(** [equal_mem_model m1 m2] returns [true] if [m1] and [m2] can be
+    shown to be equivalent. *)
+val equal_mem_model : mem_model -> mem_model -> bool
+
+(** [extract_array] takes a z3 expression that is a sequence of stores
+    and converts it into a mem_model, which consists of a key/value
+    association list and a default value. The list is guaranteed to be
+    sorted in ascending order of keys. *)
 val extract_array : Constr.z3_expr -> mem_model

--- a/wp/lib/bap_wp/src/z3_utils.ml
+++ b/wp/lib/bap_wp/src/z3_utils.ml
@@ -183,6 +183,16 @@ let mk_and (ctx : Z3.context) (xs : Constr.z3_expr list) : Constr.z3_expr =
   | [x] -> x
   | _   -> Bool.mk_and ctx xs
 
+(** [process_lambda varname model_val ks vs] turns a lambda form of representing
+    the memory into a sequence of stores to an array that is initialized with a
+    default value. It expects that the body of the lambda is a chain of [ite]
+    expressions mapping addresses to values.
+
+    [varname] is the single argument to the lambda.
+    [model_val] is the body of the lambda.
+    [ks] is the sort of the keys for the array.
+    [vs] is the sort of the values for the array.
+*)
 let process_lambda
     (varname : string)
     (model_val : Sexp.t)

--- a/wp/lib/bap_wp/src/z3_utils.ml
+++ b/wp/lib/bap_wp/src/z3_utils.ml
@@ -255,12 +255,12 @@ let asserts_of_model (model_string : string) (sym_names : string list) : Sexp.t 
             failwithf "model_string: %s\n\
                        function asserts_of_model: \
                        Unexpected list %s in external model\n"
-              model_string (Sexp.to_string l) ()
+              (add_pound model_string) (Sexp.to_string l) ()
           | Sexp.Atom a ->
             failwithf "model_string: %s\n\
                        function asserts_of_model: \
                        Unexpected atom %s in external model\n"
-              model_string a () in
+              (add_pound model_string) a () in
         Sexp.List [
           Sexp.Atom "assert";
           Sexp.List [
@@ -277,7 +277,7 @@ let asserts_of_model (model_string : string) (sym_names : string list) : Sexp.t 
       failwithf "model_string: %s\n\
                  function asserts_of_model: \
                  Unexpected form %s in external smt model\n"
-        model_string (Sexp.to_string bad_sexp) () in
+        (add_pound model_string) (Sexp.to_string bad_sexp) () in
   let model_sexp = Sexp.of_string model_string in
   match model_sexp with
   | Sexp.List (Sexp.Atom "model" :: t) | Sexp.List t ->
@@ -286,7 +286,7 @@ let asserts_of_model (model_string : string) (sym_names : string list) : Sexp.t 
     failwithf "model_string: %s\n\
                function asserts_of_model: \
                Unexpected outer atom %s in external smt model\n"
-      model_string a ()
+      (add_pound model_string) a ()
 
 (* We are still missing some funcdecls, particularly function return values *)
 (** [check_external] invokes an external smt solver as a process. It communicates to the


### PR DESCRIPTION
With some external solvers (like Boolector), the memory for the countermodels comes back as a big lambda term consisting of a bunch of if-then-else cases for each address.

Obviously, this is very unreadable for the user. Not only that, WP will fail to construct the refuted goals when the memory model is in this form. 

This PR fixes the way we parse the output from the external solver, turning it into a sequence of array stores.